### PR TITLE
Fix fallback images for the hero image

### DIFF
--- a/_sass/_components.welcome.scss
+++ b/_sass/_components.welcome.scss
@@ -5,6 +5,10 @@
 *   Site intro and top boxes on the front page
 ------------------------------------------------------- */
 
+picture img {
+    width: 100%;
+}
+
 .welcome {
     background-color: $background-grey;
     padding: $spacing;

--- a/_sass/_components.welcome.scss
+++ b/_sass/_components.welcome.scss
@@ -5,7 +5,7 @@
 *   Site intro and top boxes on the front page
 ------------------------------------------------------- */
 
-picture img {
+picture.megaheader img {
     width: 100%;
 }
 

--- a/index.html
+++ b/index.html
@@ -3,9 +3,10 @@ layout: redesign
 ---
 
 
-    <picture class="">
+    <picture class="megaheader">
       <source srcset="{{ site.baseurl }}/img/megaheader/picture-a.jpg" media="(min-width: 1000px)">
-      <img src="{{ site.baseurl }}/img/megaheader/picture-b.jpg" alt="">
+      <source srcset="{{ site.baseurl }}/img/megaheader/picture-b.jpg" media="(max-width: 1000px)">
+      <img src="{{ site.baseurl }}/img/megaheader/picture-b.jpg" srcset="{{ site.baseurl }}/img/megaheader/picture-b.jpg 1000w, {{ site.baseurl }}/img/megaheader/picture-a.jpg 2000w" alt="">
     </picture>
     <div class="welcome">
 


### PR DESCRIPTION
This is an imperfect fix for browsers that don't support `<picture>`. On Safari, it will fall back to `srcset`, which will pick the best image to use depending on the resolution of the browser when the page loads. On IE, it will always show `picture-b`, but it will scale it to 100% width. On Chrome and Firefox it should work as before.

Screenshot of the original layout glitch:

![skjermbilde 2015-12-08 kl 13 58 31](https://cloud.githubusercontent.com/assets/678101/11658495/420464b2-9dc3-11e5-815f-951347827903.png)
