### PR TITLE
Changed text for PP API / pickupPointType

### DIFF
--- a/api/pickup-point/api.raml
+++ b/api/pickup-point/api.raml
@@ -60,7 +60,7 @@ documentation:
         type: string
       pickupPointType:
         displayName: Pickup-point type
-        description: Currently available for Swedish pickup point request only.
+        description: Currently available for Swedish, Finnish and Danish pickup point request only.
         enum: [ manned, locker ]
       numberOfResponses:
         description: Return the specified number of pickup points instead of the default.
@@ -175,7 +175,7 @@ documentation:
         type: string
       pickupPointType:
         displayName: Pickup-point type
-        description: Currently available for Swedish pickup point request only.
+        description: Currently available for Swedish, Finnish and Danish pickup point request only.
         enum: [ manned, locker ]
       numberOfResponses:
         description: Return the specified number of pickup points instead of the default.


### PR DESCRIPTION
A change has been made that enables the user to filter on pickup point type in Denmark and Finland. Therefore the API text that describes this is updated.