### PR TITLE
using unix milliseconds since epoch format for shipping date in booking json req

### DIFF
--- a/api/booking/api.raml
+++ b/api/booking/api.raml
@@ -152,7 +152,7 @@ documentation:
         shippingDateTime:
             description: The date and time when an order is ready to be transported. The label generated against a booking will be valid for 52 weeks when Bring receives the request for an order.
             type: dateTime
-            example: 2016-07-26T06:24:09
+            example: 2016-07-26T06:24:09 or 1469494449000 (for json req)
             required: true
         customerNumber:
             description: Specify API customer number. This parameter can be maximum 35 character long.
@@ -386,9 +386,9 @@ documentation:
         displayName: Select Pickup Point in Sweden
         description: |
           You can specify pickup point Id in request for `PICKUP_PARCEL_BULK` products for delivery of parcels within Sweden and to Sweden from other countries. Use [Pickup Point API](/api/pickup-point/) to get list of nearest pickup points.
-          
+
           The parcel will be delivered to the pickup point specified in the request with SMS/Email notification. Pickup point delivery requires that the *recipient has email and/or phone number set*, so that he can receive notification when the package arrives at the pickup point.
-          
+
           Pickup point id and country code has to be specified under `pickupPoint` in `parties` as shown below.
         body:
           application/json:
@@ -399,11 +399,11 @@ documentation:
         displayName: Select Pickup Point in Denmark
         description: |
           The products `PICKUP_PARCEL` and `PICKUP_PARCEL_BULK` support the `deliveryOption=PICKUP_POINT` for shipments within Denmark and to Denmark, respectively. The parcel will be delivered to the pickup point closest to the recipient address and the recipient will receive a notification when the parcel arrives. If you do not specify a delivery option for these products in Denmark, the package will be delivered to the door.
-          
+
           You can also specify a pickup point id to get the package delivered at a specific pickup point. Use [Pickup Point API](/api/pickup-point/) to get list of nearest pickup points. Pickup point id and country code has to be specified under `pickupPoint` within `parties` as shown below.
-          
+
           `pickupPoint` is optional but both `id` and `countryCode` inside it are mandatory. This element has precedence over `deliveryOption=PICKUP_POINT` i.e. if this element is present then pickup point specified in it will be selected irrespective of value set in `deliveryOption`.
-          
+
           Pickup point delivery requires that the *recipient has email and/or phone number set*, so that he can receive notification when the package arrives at the pickup point.
         body:
           application/json:
@@ -414,9 +414,9 @@ documentation:
         displayName: Select Pickup Point in Finland
         description: |
           You can specify pickup point Id in request for `PICKUP_PARCEL_BULK` products for delivery of parcels to Finland from other countries. Use [Pickup Point API](/api/pickup-point/) to get list of nearest pickup points.
-          
+
           The parcel will be delivered to the pickup point specified in the request with SMS/Email notification. Pickup point delivery requires that the *recipient has email and/or phone number set*, so that he can receive notification when the package arrives at the pickup point.
-          
+
           Pickup point id and country code has to be specified under `pickupPoint` within `parties` as shown below.
         body:
           application/json:
@@ -427,9 +427,9 @@ documentation:
         displayName: Express
         description: |
           ### Express service for Oil Express
-          
+
           You can use Express service if you want to send your goods urgently (this service is *applicable only for Oil Express* product). In case of express delivery, goods are picked up as soon as possible and delivered to its destination.
-          
+
           For using Express service send `true` value in `express` as shown in below example.
         body:
           application/json:

--- a/api/booking/examples/basicRequest.json
+++ b/api/booking/examples/basicRequest.json
@@ -3,7 +3,7 @@
   "schemaVersion": 1,
   "consignments": [
     {
-      "shippingDateTime": "2015-12-04T13:37:00",
+      "shippingDateTime": 1449216420000,
       "parties": {
         "sender": {
           "name": "Ola Nordmann",

--- a/api/booking/examples/bciDangerousGoods.json
+++ b/api/booking/examples/bciDangerousGoods.json
@@ -6,7 +6,7 @@
     "consignments": {
       "consignment": {
         "-correlationId": "INTERNAL-123456",
-        "shippingDateTime": "2016-08-05T22:05:39.454+01:00",
+        "shippingDateTime": 1470414939000,
         "parties": {
           "sender": {
             "name": "Ola Nordmann",

--- a/api/booking/examples/cargoDangerousGoods.json
+++ b/api/booking/examples/cargoDangerousGoods.json
@@ -6,7 +6,7 @@
     "consignments": {
       "consignment": {
         "-correlationId": "123456",
-        "shippingDateTime": "2016-08-05T06:24:09",
+        "shippingDateTime": 1470358449000,
         "parties": {
           "sender": {
             "name": "Ola Danske",

--- a/api/booking/examples/incotermRule.json
+++ b/api/booking/examples/incotermRule.json
@@ -6,7 +6,7 @@
     "consignments": {
       "consignment": {
         "-correlationId": "INTERNAL-123456",
-        "shippingDateTime": "2016-08-10T22:05:39.454+01:00",
+        "shippingDateTime": 1470846939000,
         "parties": {
           "sender": {
             "name": "Ola Nordmann",


### PR DESCRIPTION
normal timestamp in yyy-mm-ddTHH:mm:ss works for xml request but for json request it is not parsed correctly resulting in some issues