### PR TITLE
Provide frontpage entrance to e-commerce section

### DIFF
--- a/_includes/sitemenu.html
+++ b/_includes/sitemenu.html
@@ -1,6 +1,9 @@
 
       <nav class="sitemenu" data-sticky="true">
         <ul class="list-bare sitemenu__list">
+          <li class="{% if page.url == '/api/introduction/' %} active{% endif %}">
+            <h3 class="sitemenu__apititle epsilon u-mb0"><a href="{{ site.baseurl }}/api/introduction/">Why use our APIs?</a></h3>
+          </li>
           <li class="{% if page.url == '/api/' %} active{% endif %}">
             <h3 class="sitemenu__apititle epsilon u-mb0"><a href="{{ site.baseurl }}/api/">Getting Started</a></h3>
             {% if page.url == '/api/' %}

--- a/index.html
+++ b/index.html
@@ -16,17 +16,10 @@ layout: redesign
           <h2 class="welcome__tagline">Tools to help you integrate services from Bring with your&nbsp;systems.</h2>
           <ul class="layout welcome__list">
             <li class="layout__item palm-one-whole lap-and-up-one-third welcome__item">
-              <a href="{{ site.baseurl }}/api/introduction/" class="welcome__link">
-                <img src="{{ site.baseurl }}/img/illustration01.svg" alt="">
-                <h2>What is this…?!</h2>
-                <p class="u-mb0">Are you running an eCommerce site? Or&nbsp;software dealing with shipments from Nordic countries? Then you may want to use Bring APIs.</p>
-              </a>
-            </li><!--
-            --><li class="layout__item palm-one-whole lap-and-up-one-third welcome__item">
               <a href="{{ site.baseurl }}/api/" class="welcome__link">
                 <img src="{{ site.baseurl }}/img/illustration02.svg" alt="">
                 <h2>Getting started with&nbsp;our&nbsp;APIs</h2>
-                <p class="u-mb0">Most of our APIs are open. Some require (or give extra features with) authentication. And do you want JSON, XML or&nbsp;SOAP?</p>
+                <p class="u-mb0">Developing an e-commerce site? Or&nbsp;software dealing with shipments from Nordic countries? Then you may want to use Bring APIs.</p>
               </a>
             </li><!--
           --><li class="layout__item palm-one-whole lap-and-up-one-third welcome__item">
@@ -34,6 +27,13 @@ layout: redesign
                 <img src="{{ site.baseurl }}/img/illustration03.svg" alt="">
                 <h2>EDI documentation</h2>
                 <p class="u-mb0">If you're an EDI vendor, this is where you will find our implementation guides. (Sorry, only in Norwegian at the moment.)</p>
+              </a>
+            </li><!--
+          --><li class="layout__item palm-one-whole lap-and-up-one-third welcome__item">
+              <a href="{{ site.baseurl }}/ecommerce/" class="welcome__link">
+                <img src="{{ site.baseurl }}/img/illustration01.svg" alt="">
+                <h2>E-commerce</h2>
+                <p class="u-mb0">Useful features like shipping method, pickup point, booking details and plenty more — together with suggested web store implementation.</p>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
This change will reprioritize the three entrances with illustration and headline. Moving e-commerce up to get more focus, and bumping the initial sort intoduction page about Why use our APIs? to a list item in the sitemenu.