### PR TITLE
Override default max width for the blog pages

### DIFF
--- a/_sass/_components.blog.scss
+++ b/_sass/_components.blog.scss
@@ -147,3 +147,7 @@
     margin-top: 2rem;
     margin-bottom: 2rem;
 }
+
+.blog p {
+    max-width: none;
+}


### PR DESCRIPTION
The paragraphs elsewhere on the dev site benefit from this rule, so
they don’t become too long. But for the articles on the blog it makes
the images and lists all wonky, so let’s override this.