### PR TITLE
Add commit hash to build

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -21,6 +21,7 @@ desc 'Build the _site directory'
 task :build => [:clean, :install_dependencies] do
   puts '= build using jekyll'
   system('JEKYLL_ENV=production bundle exec jekyll build --trace')
+  system('git rev-parse HEAD >> _site/.gitcommit')
 end
 
 desc 'Run locally using jekyll'


### PR DESCRIPTION
We're doing this in order to be able to discover exactly which commit the build was created from. This makes it much easier to add safety-features to deployment:

- We can check that the build we are deploying contains the commit that was deployed the last time (and require a rollback-flag to permit the deploy if it doesn't)
- We can remind the user to build in the event that they have forgotten (their _site is an old build, and they don't realise)