### PR TITLE
Change contact point to whitelist an ip

### DIFF
--- a/api/pickup-point/api.raml
+++ b/api/pickup-point/api.raml
@@ -29,7 +29,7 @@ documentation:
 
       #### High-volume users
 
-      If you're a high-volume user of the Pickup Point API, please [contact Customer Service](http://developer.bring.com/support/) to discuss your options.
+      If you're a high-volume user of the Pickup Point API, please [contact us](mailto:developer@bring.com) to discuss your options.
 
       When contacting Bring support include a description of how you are using the Pickup Point API, also an estimate of current request volumes.
 


### PR DESCRIPTION
Today, page says to contact customer service to remove rate-limit, which is adding another layer in communication. Hence it is changed to mail to developer's inbox so that IT team can get the request straightway and discuss the change with the concern salesperson, if required.