### PR TITLE
Remove site for Code Gathering

### DIFF
--- a/code-gathering/index.html
+++ b/code-gathering/index.html
@@ -3,60 +3,9 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>Code Gathering</title>
-  <style>
-      body {
-        background-color: #000;
-        font-family: monaco, monospace;
-        color: white;
-      }
-
-      h1 {
-        color: green;
-        font-size: 4rem;
-        margin-bottom: 0;
-      }
-
-    .wrapper {
-        margin-top: 1.5rem;
-        max-width: 42rem;
-        margin-left: auto;
-        margin-right: auto;
-      }
-
-    .info {
-        font-size: 1.5rem;
-        list-style-type: none;
-        padding-left: 0;
-        margin-bottom: 1.5rem;
-        border-bottom: 2px dashed #ccc;
-        padding-bottom: 1.5rem;
-      }
-
-    .info span { color: #777; }
-
-  </style>
+  <title>405</title>
 </head>
 <body>
-
-  <div class="wrapper">
-    <h1>Code Gathering</h1>
-
-    <ul class="info">
-      <li>📅 <span>When:</span> Tuesday 27th February, 09.00 – 15.00 </li>
-      <li>📍 <span>Where:</span> Auditorium, Posthuset in Oslo </li>
-      <li>👾 <span>Who:</span> developers at Posten and Bring</li>
-    </ul>
-
-    <p> You are invited to a day of talks for and by developers working in different departments at Posten and Bring. Both employees and consultants are very welcome. The only prerequisite is an interest in hearing other developers talk about code.</p>
-
-    <p> Save the date &amp; stay tuned for more info.</p>
-
-    <p>Looking forward to seeing you there!</p>
-
-    <p>– The org committee </p>
-
-  </div>
-
+  <p>Due to ongoing activities we unfortunately have to postpone the event.</p>
 </body>
 </html>


### PR DESCRIPTION
This change was made cause higher-ups pulled the brakes on the event.