### PR TITLE
Add email to footer for better API support ✉️

### DIFF
--- a/_layouts/redesign.html
+++ b/_layouts/redesign.html
@@ -39,7 +39,7 @@
       <ul class="list-inline sitefooter-links sitefooter-nav delta">
         <li><a href="{{ site.baseurl }}/" title="Bring Developer Blog">Bring Developer</a></li>
         <li><a href="https://github.com/bring/developer-site" title="The source code for this site">GitHub</a></li>
-        <li><a href="https://twitter.com/bringdeveloper" title="Our Twitter account">@bringdeveloper</a></li>
+        <li><a href="mailto:developer@bring.com">developer@bring.com</a></li>
         <li><a href="{{ site.baseurl }}/blog/" title="Bring Developer Blog">Blog</a></li>
         <li><a href="{{ site.baseurl }}/jobs/">Jobs</a></li>
         <li><a href="https://api.bring.com/shippingguide/user/terms.pdf">Terms & Conditions</a></li>


### PR DESCRIPTION
Twitter doesn’t seem to be the best way for us to provide API support
so let’s try using email as contact info for the dev site.