### PR TITLE
Update documentation about SG version 10 being discontinued.

### DIFF
--- a/api/shipping-guide/api.raml
+++ b/api/shipping-guide/api.raml
@@ -12,7 +12,7 @@ documentation:
         We are excited to introduce Shipping Guide API 2.0 - a new and improved version of our Shipping Guide API🎊🎉. The latest version is packed with powerful capabilities and a simplified, structured request and response model, making it easier to provide both you and your end customers with different shipping alternatives.
         Please refer to <a href="/api/shipping-guide_2/">Shipping Guide API 2.0</a> for more information.
         <br><br>
-        <strong>NOTE:</strong> The latest version will gradually replace <a href="/api/shipping-guide/#soap">existing versions</a> of the Shipping Guide API, and versions <strong>3</strong>, <strong>4</strong>, <strong>5</strong> and <strong>6</strong> have already been phased out. We are of course giving all users enough time to make the switch before phasing out old versions.
+        <strong>NOTE:</strong> The latest version will gradually replace <a href="/api/shipping-guide/#soap">existing versions</a> of the Shipping Guide API, and versions <strong>3</strong>, <strong>4</strong>, <strong>5</strong>, <strong>6</strong> and <strong>10</strong> have already been phased out. We are of course giving all users enough time to make the switch before phasing out old versions.
       </div>
 
       The Shipping Guide (Fraktguiden) is a free service from Bring that provides
@@ -766,7 +766,7 @@ documentation:
 
       ### WSDL
 
-      WSDL / schema versions: [1](https://api.bring.com/shippingguide/api/ws/fraktguide-v1.wsdl), [2](https://api.bring.com/shippingguide/api/ws/fraktguide-v2.wsdl), [7](https://api.bring.com/shippingguide/api/ws/fraktguide-v7.wsdl), [8](https://api.bring.com/shippingguide/api/ws/fraktguide-v8.wsdl), [9](https://api.bring.com/shippingguide/api/ws/fraktguide-v9.wsdl), [10](https://api.bring.com/shippingguide/api/ws/fraktguide-v10.wsdl), [11](https://api.bring.com/shippingguide/api/ws/fraktguide-v11.wsdl). The current version is 11.
+      WSDL / schema versions: [1](https://api.bring.com/shippingguide/api/ws/fraktguide-v1.wsdl), [2](https://api.bring.com/shippingguide/api/ws/fraktguide-v2.wsdl), [7](https://api.bring.com/shippingguide/api/ws/fraktguide-v7.wsdl), [8](https://api.bring.com/shippingguide/api/ws/fraktguide-v8.wsdl), [9](https://api.bring.com/shippingguide/api/ws/fraktguide-v9.wsdl), [11](https://api.bring.com/shippingguide/api/ws/fraktguide-v11.wsdl). The current version is 11.
 
       [Fraktguide XML Schema documentation](https://api.bring.com/shippingguide/api/ws/schema-latest.xsd)
 

--- a/index.html
+++ b/index.html
@@ -47,7 +47,7 @@ layout: redesign
         We are excited to introduce Shipping Guide API 2.0 - a new and improved version of our Shipping Guide API🎊🎉. The latest version is packed with powerful capabilities and a simplified, structured request and response model, making it easier to provide both you and your end customers with different shipping alternatives.
         Please refer to <a href="/api/shipping-guide_2/">Shipping Guide API 2.0</a> for more information.
         <br><br>
-        <strong>NOTE:</strong>  The latest version will gradually replace <a href="/api/shipping-guide/#soap">existing versions</a> of the Shipping Guide API, and versions <strong>3</strong>, <strong>4</strong>, <strong>5</strong> and <strong>6</strong> have already been phased out. We are of course giving all users enough time to make the switch before phasing out old versions.
+        <strong>NOTE:</strong> The latest version will gradually replace <a href="/api/shipping-guide/#soap">existing versions</a> of the Shipping Guide API, and versions <strong>3</strong>, <strong>4</strong>, <strong>5</strong>, <strong>6</strong> and <strong>10</strong> have already been phased out. We are of course giving all users enough time to make the switch before phasing out old versions.
       </div>
     {% include apiflock.html %}
     </div>


### PR DESCRIPTION
Continuing the attempt to actively decommission unused Shipping guide 1.0 versions. Version 10 is now being decommissioned.