### PR TITLE
Don’t translate the name Endre to Change

### DIFF
--- a/jobs/index.html
+++ b/jobs/index.html
@@ -34,7 +34,7 @@ Teamene har ansvar for hele stacken fra brukerflatene ned til databasen. Du får
 <p>
   Søknader behandles fortløpende. <strong><a href="mailto:arne.moen@bring.com?cc=endre.midtgard.meckelborg@bring.com" class="linkish">Send CV på e-post</a></strong> til Arne og Endre.<br>
   Avdelingsleder Arne Moen, telefon 902&nbsp;02&nbsp;239<br>
-  Fagsjef Endre Midtgård Meckelborg, telefon 930&nbsp;14&nbsp;504</p>
+  Fagsjef <span translate="no">Endre</span> Midtgård Meckelborg, telefon 930&nbsp;14&nbsp;504</p>
 
 {% include_relative tech-stack.svg %}
 

--- a/jobs/index.html
+++ b/jobs/index.html
@@ -34,7 +34,7 @@ Teamene har ansvar for hele stacken fra brukerflatene ned til databasen. Du får
 <p>
   Søknader behandles fortløpende. <strong><a href="mailto:arne.moen@bring.com?cc=endre.midtgard.meckelborg@bring.com" class="linkish">Send CV på e-post</a></strong> til Arne og Endre.<br>
   Avdelingsleder Arne Moen, telefon 902&nbsp;02&nbsp;239<br>
-  Fagsjef <span translate="no">Endre</span> Midtgård Meckelborg, telefon 930&nbsp;14&nbsp;504</p>
+  Fagsjef <span translate="no">Endre Midtgård Meckelborg</span>, telefon 930&nbsp;14&nbsp;504</p>
 
 {% include_relative tech-stack.svg %}
 


### PR DESCRIPTION
While “Head of Division Change” sounds like a rad title, it makes more
sense to protect this element from translation in translation tools and
we can do that with the `translate` attribute. \o/