### PR TITLE
Remove email address from footer

### DIFF
--- a/_layouts/redesign.html
+++ b/_layouts/redesign.html
@@ -39,7 +39,6 @@
       <ul class="list-inline sitefooter-links sitefooter-nav delta">
         <li><a href="{{ site.baseurl }}/" title="Bring Developer Blog">Bring Developer</a></li>
         <li><a href="https://github.com/bring/developer-site" title="The source code for this site">GitHub</a></li>
-        <li><a href="mailto:developer@bring.com">developer@bring.com</a></li>
         <li><a href="{{ site.baseurl }}/blog/" title="Bring Developer Blog">Blog</a></li>
         <li><a href="{{ site.baseurl }}/jobs/">Jobs</a></li>
         <li><a href="{{ site.baseurl }}/files/General_Terms_and_Conditions_for_Self_Service_Solutions.pdf">Terms & Conditions</a></li>


### PR DESCRIPTION
This change was made to encourage questions being posted in the
comments section on each API page, instead of being sent on email.