### PR TITLE
Document PIP demo customer number

### DIFF
--- a/api/order/to-mailbox/api.raml
+++ b/api/order/to-mailbox/api.raml
@@ -728,6 +728,12 @@ documentation:
       
       In cases where the criterias are not met, i.e. bad weather (risk of damage) or where Posten consider for security reason the risk too high by using Bag on door, the parcel will still be delivered to the recipient's pickup point for delivery.
 
+- title: Testing
+  content: |
+    If you need to execute Pakke i postkassen test bookings via the Mailbox Packet API, please use this customer number: PARCELS_NORWAY-00000000002. 
+    
+    When using this demo customer number, testindicator is automatically set to "true", and the labels will be covered with TEST.
+    
 - title: Authentication
   content: |
     The API requires authentication for all its endpoints. See the [getting started guide on authentication](/api/#authentication) if you're not sure what this means.


### PR DESCRIPTION
Added two sentences to document that we now have a demo customer number in place for testing PIP in Mailbox Packet API.