### PR TITLE
Add Revision History for optional measurements in booking api

### DIFF
--- a/api/revision-history/index.html
+++ b/api/revision-history/index.html
@@ -16,6 +16,9 @@ layout: redesign
         </section>
 
         <section class="api__section">
+          <h4>July 23, 2020 - Booking API</h4>
+          <p>Added support for booking parcel services without measurements</p>
+
           <h4>July 07, 2020 - Event Cast API</h4>
           <p>Added support for new request parameter <code class="highlighter-rouge">limit</code>. This can be used to limit the number of latest webhooks returned</p>
 


### PR DESCRIPTION
<img width="592" alt="Screenshot 2020-08-04 at 6 52 18 AM" src="https://user-images.githubusercontent.com/20452385/89254276-156cbf00-d61f-11ea-8943-2f71e04fc821.png">
