### PR TITLE
Header level alignment, documentation section

### DIFF
--- a/api/booking/api.raml
+++ b/api/booking/api.raml
@@ -15,13 +15,9 @@ documentation:
 
       This API has similarities with the Shipment API, but there are differences. Read more about the [differences between the Booking API and the Shipment API](/api/booking-shipment/).
 
-- title: Versioning strategy
+- title: Versioning
   content: |
       Each request has a `schemaVersion` element indicating which release of the schema is being used in the request and expected schema format in the response. Important: All clients must accept new (unknown) elements in the response. E.g. unknown elements should be ignored. The client framework used by client must thus not crash when unknown elements are encountered. Note that this requirement excludes the (old, but still widely used) Apache Axis 1.x Web Service client framework.
-
-- title: Encoding
-  content: |
-    Booking endpoints will assume all requests are UTF-8 encoded
 
 - title: Authentication
   content: |
@@ -34,6 +30,10 @@ documentation:
     ![Authorized for booking](booking_authorization.png)
 
     To perform a booking, you must specify which customer number to use. For your convenience, there is an [API for getting the customer numbers](#list-customer-numbers) associated with your API user. The Customer Number API also links customer numbers with the services the customer number is valid for.
+
+- title: Encoding
+  content: |
+    Booking endpoints will assume all requests are UTF-8 encoded
 
 - title: Making labels
   content: |
@@ -77,9 +77,6 @@ documentation:
     
 - title: Mailbox Parcel (Pakke i Postkassen)
   content: |
-
-    #### About Mailbox parcel
-    
     - Booking Mailbox Parcel in Booking API is a single-step process with one label per booking (multi-kolli is not supported). Each parcel is invoiced separately. A link to the label is returned in the response. 
     - When booking Mailbox Parcel in Booking API, the new API customer number is used. This is identical to your company's main customer number (without prefix PARCELS_NORWAY and without padded zeros if any).
     - When booking Mailbox Parcel in Booking API, the service is defined by setting 3584 or 3570 in the product id. 
@@ -89,16 +86,13 @@ documentation:
     ### 3570 (tracking with RFID)
     Mailbox Parcel shipments can optionally be ordered with tracking using RFID.
 
-    #### How does tracking with RFID work?
-    Normally, we create PDF labels that can be printed on any printer.
-
-    If you opt for tracking, we create ZPL labels instead. ZPL stands for [Zebra Programming Language (ZPL)](https://en.wikipedia.org/wiki/Zebra_(programming_language)).
+    Normally, we create PDF labels that can be printed on any printer. If you opt for tracking, we create ZPL labels instead. ZPL stands for [Zebra Programming Language (ZPL)](https://en.wikipedia.org/wiki/Zebra_(programming_language)).
 
     The labels will be ZPL code containing instructions for programming the passive RFID antenna in the printer's labels with package numbers.
 
     In addition to the RFID programming instructions, the ZPL code contains instructions for rendering the rest of the label (addresses, icons, barcode, etc.).
 
-    ##### Special hardware required
+    #### Special hardware required
     RFID-tagged labels require special printer hardware. Currently we support the following printers:
 
     - Zebra R410
@@ -107,7 +101,7 @@ documentation:
     ### 3584 (no tracking)
     If you don't have a supported printer, you cannot order shipments with tracking. In this case, we will create normal PDF labels that can be printed using any printer.
 
-    ### Additional Service : Bag on door (Pose på døren)
+    ### Additional Service: Bag on door (Pose på døren)
     A delivery alternative for Mailbox Parcels that cannot be delivered to the mailbox. 
 
     Mailbox Parcel (Pakke i postkassen) is a parcel that will be delivered in the recipient’s mailbox. If the parcel for various reasons does not fit in the mailbox, the sender may, against a surcharge of NOK 15 per shipment, choose to leave the parcel on the door handle (in a special bag) to avoid it being sent to the pickup point (surcharge of NOK 23 per shipment). This delivery option will have to be confirmed by the receiver upon booking in the sender's webshop. When the parcel is delivered as a bag on the door, the bar code is scanned and the recipient will receive an SMS/email. Note that if the parcel is delivered in the mailbox the additional fee will not occur.
@@ -150,7 +144,7 @@ documentation:
 
     Please refer to the _Request params_ section below for more details about the elements. Customs tariff codes (tolltariffnummer) can be found [here](http://tolltariffen.toll.no/).
 
-    #### Example
+    ### Example
 
     In this example, you are sending a parcel/shipment with 2 shampoos, 5 cotton t-shirts and 1 wool jacket. The number of pieces is 8 (2 shampoos + 5 cotton
     t-shirts + 1 wool jacket), and the number of articles is 3 (shampoo, cotton t-shirt, wool jacket). The whole shipment is referred to as an item.

--- a/api/event-cast/api.raml
+++ b/api/event-cast/api.raml
@@ -109,17 +109,18 @@ documentation:
 
     The Event Cast API makes you subscribe to such events using Webhooks.
 
-    #### Webohook Definition
+    ### Webohook Definition
     > A Webhook in web development is a method of augmenting or altering the behaviour of a web page, or web application, with custom callbacks.
     > These callbacks may be maintained, modified, and managed by third-party users and developers who may not necessarily be affiliated with the originating website or application.
 
-    #### Webhooks in Bring
+    ### Webhooks in Bring
     In the context of Bring, this means that whenever an event is registered in Bring for a subscribed parcel and/or shipment,
     we'll send a HTTP POST to your callback URL that were defined during the Webhook registration.
 
     Using Webhooks is quite simple, and allows for immediate feedback based on the event that occured for the subscribed entity.
     Additionally, it allows integrations of customers to become simpler, as no scheduled mechanism is required to be implemented.
     You basically just define an endpoint that accepts HTTP POST, and the event details will be sent there - quite amazing 🙌
+
 - title: Authentication
   content: |
     In order to use the API, you will need to register with Mybring and create an API key. Whenever issuing a request, the following headers is required to be present.
@@ -131,6 +132,7 @@ documentation:
     | `X-Bring-Client-URL` | `https://example.com/` | A URL that sort of identifies you | |
 
     **Note:** See the [getting started guide on authentication](/api/#authentication) if you want to know more about how to get started with authentication for APIs in Mybring.
+
 - title: API limitations
   content: |
     There is some known/deliberate limitations for the API:
@@ -140,6 +142,7 @@ documentation:
     | All requests | The Webhook API allows a maximum of **50 concurrent requests** per user |
     | Batch creation | Whilst creating requests for Webhooks is a feature we encurage to use, its maximum amount of parcels and/or shipments is limited to **100 per request**. If you have more than 100 at the time, split to mulitple requests using the batch-API |
     | Webhook testing | The `/api/v1/Webhooks/{WebhookId}/test`-api allows a maximum of **10 concurrent requests** per user |
+
 - title: Events
   content: |
     When registering for a Webhook you can choose between a range of different event groups that you can subscribe for.
@@ -149,13 +152,13 @@ documentation:
     Each of the event groups corresponds to a certain set of actions that can happen to the package/shipment you subscribe for. For instance, if you subscribe to `DELIVERED`, all internal Bring-events
     will trigger a request to your defined callback URL.
 
-    #### Event groups
+    ### Event groups
 
     Default set of subscribeable event groups. Notice that this list is subject for change.
 
     | Event | Description |
     |:-------|:--------|
-    | `ARRIVED_DELIVERY` | Arrived Delivery point - This is when a container arrives at recipients address, and can start unloading.  |
+    | `ARRIVED_DELIVERY` | Arrived Delivery point - This is when a container arrives at recipients address, and can start unloading. |
     | `ARRIVED_COLLECTION` | Arrived for collection at pickup point |
     | `ATTEMPTED_DELIVERY` | The package has been attempted delivered at the door. Depending on the service it will be tried again or sent to closest pickup point. |
     | `CUSTOMS` | Package is in customs clearance. |
@@ -167,12 +170,12 @@ documentation:
     | `DELIVERY_ORDERED` | Home delivery has been ordered |
     | `DEVIATION` | Deviation in production. Something wrong has happened and there is a probability for delay. |
     | `HANDED_IN` | Package has been handed in to Bring. |
-    | `INTERNATIONAL` | Package has been sent from origin country or arrived at destination country.  |
+    | `INTERNATIONAL` | Package has been sent from origin country or arrived at destination country. |
     | `IN_TRANSIT` | Package is in transit. |
     | `NOTIFICATION_SENT` | Notification for this package has been sent by sms, push and/or mail. This can be informational notifications and action notification like pickup notice. |
     | `PRE_NOTIFIED` | EDI message for the package has been received by Bring. |
     | `READY_FOR_PICKUP` | Package has arrived at pickup point. |
-    | `RETURN` | The package has been returned to sender.  |
+    | `RETURN` | The package has been returned to sender. |
     | `TRANSPORT_TO_RECIPIENT` | Package has been loaded for delivery to the recipient. |
     | `TERMINAL` | The package is now registered/arrived at inbound/outbound storage terminal |
 
@@ -212,7 +215,7 @@ documentation:
 - title: Payload
   content: |
 
-    #### Payload delivery headers
+    ### Payload delivery headers
 
     `HTTP POST` payloads that are delivered to your Webhook's configured URL endpoint contains several Bring specific headers:
 
@@ -223,7 +226,7 @@ documentation:
     | `X-bring-Version` | Indicates the version of application |
     | `<your headers>` | Any headers that were specified in the Webhook configuration will also be appended |
 
-    #### Example
+    ### Example
 
     Requests issued from Bring to your endpoint will look similar to this:
 
@@ -250,32 +253,32 @@ documentation:
 - title: Q & A
   content: |
 
-    #### Can I have multiple Webhooks for the same parcel?
+    **Can I have multiple Webhooks for the same parcel?**<br>
     You can register for multiple Webhooks on the same parcel/shipment, as long as the event groups are different for each registration.
 
-    #### How many active Webhooks can I have simultaneously?
+    **How many active Webhooks can I have simultaneously?**<br>
     Currently there is no limitation.
 
-    #### Is the expiration duration configurable?
+    **Is the expiration duration configurable?**<br>
     No.
 
-    #### Can I get a history of events that were sent for a subscription?
+    **Can I get a history of events that were sent for a subscription?**<br>
     Not in this version. It may be available in the future. Please note that you may use the [Tracking API](/api/tracking) if you'd like the entire list of events that has happened for a lifecycle related to a shipment.
 
-    #### Will I be able to see my previous/expired Webhooks (active and inactive)?
+    **Will I be able to see my previous/expired Webhooks (active and inactive)?**<br>
     No.
 
-    #### What happens if our endpoint is down and a callback is being sent?
+    **What happens if our endpoint is down and a callback is being sent?**<br>
     We'll try issuing a request to your defined endpoint up to three - 3 - times with a delay on 30 minutes for the two first, then wait an hour for the last retry.
     After this, callbacks will not be retried.
 
-    #### Do you support wildcard events/event groups (e.g `*` or `ALL`)?
+    **Do you support wildcard events/event groups (e.g `*` or `ALL`)?**<br>
     No.
 
-    #### Do you support modifying existing active webhooks?
+    **Do you support modifying existing active webhooks?**<br>
     No.
 
-    #### My shipment is not yet registered with Bring, will registering for Webhook work related to that tracking number?
+    **My shipment is not yet registered with Bring, will registering for Webhook work related to that tracking number?**<br>
     Yes.
 
     When you subscribe for a parcel that does not yet exist in Bring' systems, a retry mechanism will try for up to two - 2 - days to ensure that the Webhook will be registered when the parcel is found internally.

--- a/api/invoice/api.raml
+++ b/api/invoice/api.raml
@@ -64,9 +64,9 @@ documentation:
   content: |
       The invoice API is used to list invoices and download the invoice pdfs same as in Mybring.
 
-      ### Before you start
+- title: Authentication
+  content: |
       Before you can begin using the new API you'll have to do the following:
-
       * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
       * [Generate an API key](/api/#authentication) for your user
 

--- a/api/order-management/api.raml
+++ b/api/order-management/api.raml
@@ -17,14 +17,6 @@ documentation:
 
     Please note that this API currently doesn't support json on all of its methods yet. Look in the example section to see which are supported.
 
-    ## Error handling
-
-    When using the Order Management, errors or service unavailability can occur, although we do our utmost to prevent any downtime. Thus it is important to use timeouts and other error handling techniques when making requests to the service.
-
-    How you handle errors depends on the nature of your application, but one strategy for handling such situations is by providing a failover if the shipping guide responds with an error or does not respond at all (timeout).
-
-    See [the list of error codes](#list-error-codes) for hints on how to implement error handling.
-
 - title: Authentication
   content: |
     The Order Management API requires authentication for all its endpoints. See the [getting started guide on authentication](/api/#authentication) if you're not sure what this means.
@@ -36,6 +28,14 @@ documentation:
     | `X-Bring-Client-URL` | `https://example.com/ ` | A URL that sort of identifies where you're using the APIs. |
 
     Those headers must be set for all endpoints documented below.
+
+- title: Error handling
+  content: |
+    When using the Order Management, errors or service unavailability can occur, although we do our utmost to prevent any downtime. Thus it is important to use timeouts and other error handling techniques when making requests to the service.
+
+    How you handle errors depends on the nature of your application, but one strategy for handling such situations is by providing a failover if the shipping guide responds with an error or does not respond at all (timeout).
+
+    See [the list of error codes](#list-error-codes) for hints on how to implement error handling.
 
 /purchaseorderCustomer/{customerId}:
   displayName: Check if customer is valid for order management

--- a/api/pickup-point/api.raml
+++ b/api/pickup-point/api.raml
@@ -71,19 +71,19 @@ documentation:
         - Type Noutopiste : Finland Pickup Point
         - Type LOCKER     : Finland Locker Pickup Point
 
-- title: Steps for Authentication
+- title: Authentication
   content: |
 
       Before you can begin using the pickuppoint API you'll have to do the following:
-         * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
-         * [Generate an API key](/api/#authentication) for your user
+      * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
+      * [Generate an API key](/api/#authentication) for your user
 
-      ### 1. Get your API key from Mybring
+      ### Get your API key from Mybring
       To make API requests you will need an API key. Click the link below, which sends you to your "Settings and API" page in Mybring profile administration. Scroll down to the "API key" section. Your generated API key which you will use to authenticate your requests can be found here.
 
       <a href="https://www.mybring.com/useradmin/account/settings/api">Get API key</a>
 
-      ### 2. Add authentication headers
+      ### Add authentication headers
       A description of the headers can be found in [Getting Started / Authentication](/api/#authentication).
 
 

--- a/api/postal-code/api.raml
+++ b/api/postal-code/api.raml
@@ -20,6 +20,22 @@ documentation:
 
       It is NOT possible to get data in batch or get list of valid postal codes for a given country at a regular interval.
 
+- title: Authentication
+  content: |
+
+      Before you can begin using the postal code API you'll have to do the following:
+      * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
+      * [Generate an API key](/api/#authentication) for your user
+
+      ### Get your API key from Mybring
+      To make API requests you will need an API key. Click the link below, which sends you to your "Settings and API" page in Mybring profile administration. Scroll down to the "API key" section. Your generated API key which you will use to authenticate your requests can be found here.
+
+      <a href="https://www.mybring.com/useradmin/account/settings/api">Get API key</a>
+
+      ### Add authentication headers
+      A description of the headers can be found in [Getting Started / Authentication](/api/#authentication).
+
+
 - title: Supported Countries
   content: |
       The following countries are supported:
@@ -52,21 +68,6 @@ documentation:
       | SPECIALCUSTOMER | Special, e.g special return postal codes for selected customers. |
       | SPECIALNOSTREET | Special, e.g special postal codes for customers with old "serviceboks". |
       | UNKNOWN | Unknown postal code type. Used for e.g. international postal codes. |
-
-- title: Steps for Authentication
-  content: |
-
-      Before you can begin using the postal code API you'll have to do the following:
-         * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
-         * [Generate an API key](/api/#authentication) for your user
-
-      ### 1. Get your API key from Mybring
-      To make API requests you will need an API key. Click the link below, which sends you to your "Settings and API" page in Mybring profile administration. Scroll down to the "API key" section. Your generated API key which you will use to authenticate your requests can be found here.
-
-      <a href="https://www.mybring.com/useradmin/account/settings/api">Get API key</a>
-
-      ### 2. Add authentication headers
-      A description of the headers can be found in [Getting Started / Authentication](/api/#authentication).
 
 - title: Support CORS
   content: |

--- a/api/reports/api.raml
+++ b/api/reports/api.raml
@@ -84,40 +84,10 @@ documentation:
 
     All these APIs are available in json and xml formats.
 
-- title: How to use
-  content: |
-    The Reports API is a logged-in service and you need to get an API-key and authenticate before being able to use the API.
-
-    The two first steps in the process is only necessary to find customer numbers and report types for the user. You can save these IDs, and perform the generation-step without verifying the IDs. The response may get added information, so implementation should ignore new elements added to the response.
-
-    1. Get customer IDs
-    2. Get list of available reports
-    3. Generate report
-    4. Check status of report
-    5. Download report
-    6. Get list of invoice numbers for given customer or group
-
-- title:
-  content: |
-    #### List of available invoice sources
-    For specified invoice report 4 different types of report can be returned depending on the invoice source. Those are
-
-    Cargo Domestic and Sea :
-      - AMPHORA_DOMESTIC
-      - AMPHORA_SEA
-
-    Cargo International and Sysped :
-      - AMPHORA_BCI
-      - SYSPED
-
-    Parcels :
-      - PARCEL_DOMESTIC
-
 - title: Authentication
   content: |
     The Reports API requires authentication for all its endpoints.
 
-    ### Before you start
     Before you can begin using the new API you'll have to do the following:
 
     * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
@@ -137,7 +107,34 @@ documentation:
     | `X-MyBring-API-Key` | `1234abc-abcd-1234-5678-abcd1234abcd ` | Mybring login's API key |
     | `X-Bring-Client-URL` | `https://example.com/ ` | A URL that sort of identifies where you're using the APIs. | 
 
-    Those headers must be set for all endpoints documented below.
+    Those headers must be set for all endpoints.
+
+- title: How to use
+  content: |
+    The Reports API is a logged-in service and you need to get an API-key and authenticate before being able to use the API.
+
+    The two first steps in the process is only necessary to find customer numbers and report types for the user. You can save these IDs, and perform the generation-step without verifying the IDs. The response may get added information, so implementation should ignore new elements added to the response.
+
+    1. Get customer IDs
+    2. Get list of available reports
+    3. Generate report
+    4. Check status of report
+    5. Download report
+    6. Get list of invoice numbers for given customer or group
+
+    ### Available invoice sources
+    For specified invoice report 4 different types of report can be returned depending on the invoice source. Those are
+
+    Cargo Domestic and Sea :
+      - AMPHORA_DOMESTIC
+      - AMPHORA_SEA
+
+    Cargo International and Sysped :
+      - AMPHORA_BCI
+      - SYSPED
+
+    Parcels :
+      - PARCEL_DOMESTIC
 
 /generate{mediaTypeExtension}:
   displayName: List available customers

--- a/api/shipping-guide_2/api.raml
+++ b/api/shipping-guide_2/api.raml
@@ -16,8 +16,10 @@ documentation:
 
       The Shipping Guide API 2.0 has both a REST and a SOAP interface. The REST interface only supports single consignments, while the SOAP interface can be used for multiple consignments.
 
-      ##### NOTE: Any new users created post launch date 28-may-2020 attempting to request agreement prices by using old versions of Shipping Guide API, will be provided with an error message referring to the latest version.
+      **NOTE: Any new users created post launch date 28-may-2020 attempting to request agreement prices by using old versions of Shipping Guide API, will be provided with an error message referring to the latest version.**
 
+- title: Versioning
+  content: |
       ### Upgrade from previous version
 
       Shipping Guide API 2.0 is a replacement for the original API that is now deprecated. If needed, can you you still read the [documentation for the old version of the Shipping Guid API](/api/shipping-guide/).
@@ -31,33 +33,40 @@ documentation:
       * [Ability to fetch agreement prices specific to a service on REST](/api/shipping-guide_2/#get-shipment-prices-and-estimated-delivery): Now you can specify multiple services and along with multiple customer number in a single REST request. [How?](/api/shipping-guide_2/#get-shipment-prices-and-estimated-delivery)
       *  Some improvements to our service offering are planned for 2018-19. More info about upcoming changes will follow to all our partners. Future services will be supported by this new API-version in addition to other improvements. Note that our old versions of API’s will not support future changes in our service offering.
 
-- title: Getting started
-  content: |
-      This guide will walk you through getting shipment alternatives for your first consignment using Shipping Guide API. In this example we will be calling the SOAP interface with a HTTP client and query for the service `SERVICEPAKKE` and `PA_DOREN` for two packages.
+      ### Versioning strategy
+      The Shipping Guide makes an effort to always be backwards compatible regarding data format for requests and responses. To achieve this, namespace schema versioning is used in the request for webservices, indicating which version the client is on and what data-format the client expects in the result. For REST, versioning is defined as part of endpoint itself.
 
-      ### Before you start
+      **Important**: All clients must accept **new (unknown) elements** in the response. E.g. unknown elements should be ignored. Also, **new error codes and warning codes** could be added as well. The client framework used by client must not crash when **unknown elements or new code values** are are encountered.
+
+      When incompatible changes in the schema are made (other than addition of new elements), the namespace versioning will be updated accordingly. The new schema is used at the *same endpoint URL* as before for webservices. Old schema versions will be shut down some time in the future, so its recommended always updating to the latest version.
+
+- title: Authentication
+  content: |
       Before you can begin using the new API you'll have to do the following:
 
       * [Sign up for a Mybring account](https://www.mybring.com/signup/register/user) if you do not already have one. If you're already registered in Mybring, head to the [settings and API](https://www.mybring.com/useradmin/account/settings/api) page to get your API key.
       * [Generate an API key](/api/#authentication) for your user
 
-
-      ### 1. Get your API key from Mybring
+      ### Get your API key from Mybring
       To make API requests you will need an API key. Click the link below, which sends you to your "Settings and API" page in Mybring profile administration. Scroll down to the "API key" section. Your generated API key which you will use to authenticate your requests can be found here.
 
       <a href="https://www.mybring.com/useradmin/account/settings/api">Get API key</a>
 
-      ### 2. Add authentication headers
+      ### Add authentication headers
       A description of the headers can be found in [Getting Started / Authentication](/api/#authentication).
 
-      ### 3. Add additional headers
+- title: Example walkthrough
+  content: |
+      This guide will walk you through getting shipment alternatives for your first consignment using Shipping Guide API. In this example we will be calling the SOAP interface with a HTTP client and query for the service `SERVICEPAKKE` and `PA_DOREN` for two packages.    
+
+      ### 1. Add additional headers
       Since we're using the SOAP (1.1) interface we'll have to add the following header:
 
       - `Content-type: text/xml`
 
       Most SOAP libraries will do this for you.
 
-      ### 4. Add the body to the request
+      ### 2. Add the body to the request
       In this request we will query prices and expected delivery time for the service `SERVICEPAKKE` for a single package being sent from the postal code 0015 to 5518 in Norway.
 
       ```
@@ -128,7 +137,7 @@ documentation:
       </soapenv:Envelope>
       ```
 
-      ### 5. Submit the request
+      ### 3. Submit the request
 
       Post your request to
 
@@ -237,12 +246,7 @@ documentation:
 
       If you want to know more about the fields you can have a look at the XSD linked from the section [Request and response structure](/api/shipping-guide_2/#request-and-response-structure)
 
-
-- title: Shipping Guide topics
-  content: |
-      If you want to know more about corner cases/topics/etc, then [Let's talk about Shipping Guide](/api/shipping-guide_2/topics)
-
-- title: Handle API errors
+- title: Error handling
   content: |
       When using the Shipping Guide it is important to handle errors gracefully. Your users should still be able to order even if the Shipping Guide API returns an error or if there is an error establishing a connection to the API.
 
@@ -277,14 +281,6 @@ documentation:
 
         When we are not able to process one of the service requested, we will respond with a error on service level. Details of possible error codes are documented in [XSD](https://api.bring.com/shippingguide/api/ws/shipping-guide-20.xsd) and [WDSL](https://api.bring.com/shippingguide/api/ws/shippingguide-20.wsdl) itself, making it easier for clients to parse it.
 
-- title: Versioning
-  content: |
-       The Shipping Guide makes an effort to always be backwards compatible regarding data format for requests and responses. To achieve this, namespace schema versioning is used in the request for webservices, indicating which version the client is on and what data-format the client expects in the result. For REST, versioning is defined as part of endpoint itself.
-
-       **Important**: All clients must accept **new (unknown) elements** in the response. E.g. unknown elements should be ignored. Also, **new error codes and warning codes** could be added as well. The client framework used by client must not crash when **unknown elements or new code values** are are encountered.
-
-       When incompatible changes in the schema are made (other than addition of new elements), the namespace versioning will be updated accordingly. The new schema is used at the *same endpoint URL* as before for webservices. Old schema versions will be shut down some time in the future, so its recommended always updating to the latest version.
-
 - title: Improve performance
   content: |
       To have better performance of the api
@@ -309,13 +305,13 @@ documentation:
       
       There are two ways of using the functionality for estimated arrival time for pickup points in our Shipping Guide API - with or without the Pickup Point API: 
       
-      #### Estimated arrival time for specified pickup points (w/ Pickup Point API)
+      ### Estimated arrival time for specified pickup points (w/ Pickup Point API)
       You specify which pickup points you want us to return estimated arrival time for by including the relevant pickup point IDs in the Shipping guide request. Based on that, we return the start and end time of the expected arrival time window for each pickup point ID you have specified in the request. For a best possible customer experience, we strongly recommend that you use the functionality in combination with the Pickup Point API.
 
-      #### Estimated arrival time for the end users default pickup point (w/o Pickup Point API)
+      ### Estimated arrival time for the end users default pickup point (w/o Pickup Point API)
       In the absence of specified pickup point IDs, we take care of looking up the recipient` s default pickup point, based on it` s postal code. Based on that, we return the start and end time of the expected arrival time window for the recipient`s default pickup point. 
       
-      ### How to present the time window data in your checkout?
+      ### How to present the time window data in your checkout
       We recommend to insert the start (X) and end (Y) time values into the following sentence:
       
       **Pakken ankommer vanligvis mellom kl. X og Y / The parcel usually arrives between X and Y.**
@@ -325,6 +321,10 @@ documentation:
       **Forventet levert XX.XX.20XX. Pakken ankommer vanligvis mellom kl. X og Y / Expected delivered XX.XX.20XX. The parcel usually arrives between X and Y.**
       
       Note that Bring cannot guarantee the arrival time for a specific parcel. The estimated arrival time indicates when, based on historical scanning data, the parcel normally will become available for pickup at a specific pickup point on that specific date. Also note that CustomerNumber is mandatory to set in order to get estimated delivery time.
+
+- title: Shipping Guide topics
+  content: |
+      If you want to know more about corner cases/topics/etc, then [Let's talk about Shipping Guide](/api/shipping-guide_2/topics)
 
 /v2/products:
   displayName: Get shipment prices and estimated delivery

--- a/api/tracking/api.raml
+++ b/api/tracking/api.raml
@@ -267,12 +267,6 @@ documentation:
       It is an easy way to display details and the status of shipments.
       The information available in this API is the same that is publically available from the [Tracking web site](http://tracking.bring.com/).
 
-- title: Formats
-  content: |
-    The Tracking API generates the following formats:
-    - ```XML```
-    - ```JSON```
-    - ```JSONP```
 - title: Versioning
   content: |
     Latest Tracking API version: `v2`
@@ -326,9 +320,15 @@ documentation:
     | `X-MyBring-API-Key` | `1234abc-abcd-1234-5678-abcd1234abcd ` | Mybring login's API key |
     | `X-Bring-Client-URL` | `https://example.com/` | A URL that sort of identifies where you're using the APIs. |
 
-    The above headers must be present whilst using our logged-in variant of the tracking api. Also, you will have to use the endpoint:
+    The above headers must be present whilst using our logged-in variant of the tracking api. Also, you will have to use the endpoint: [https://api.bring.com/tracking/api/](https://api.bring.com/tracking/api/)
 
-        https://api.bring.com/tracking/api/
+- title: Formats
+  content: |
+    The Tracking API generates the following formats:
+    - ```XML```
+    - ```JSON```
+    - ```JSONP```
+
 - title: JSON API
   content: |
       We follow the [JSON API](http://jsonapi.org/) specification with one
@@ -382,7 +382,7 @@ documentation:
 
           | Event | Description |
           |:-------|:--------|
-          | `ARRIVED_DELIVERY` | Arrived Delivery point - This is when a container arrives at recipients address, and can start unloading.  |
+          | `ARRIVED_DELIVERY` | Arrived Delivery point - This is when a container arrives at recipients address, and can start unloading. |
           | `ARRIVED_COLLECTION` | Arrived for collection at pickup point |
           | `ATTEMPTED_DELIVERY` | The package has been attempted delivered at the door. Depending on the service it will be tried again or sent to closest pickup point. |
           | `CUSTOMS` | Package is in customs clearance. |
@@ -394,12 +394,12 @@ documentation:
           | `DELIVERY_ORDERED` | Home delivery has been ordered |
           | `DEVIATION` | Deviation in production. Something wrong has happened and there is a probability for delay. |
           | `HANDED_IN` | Package has been handed in to Bring. |
-          | `INTERNATIONAL` | Package has been sent from origin country or arrived at destination country.  |
+          | `INTERNATIONAL` | Package has been sent from origin country or arrived at destination country. |
           | `IN_TRANSIT` | Package is in transit. |
           | `NOTIFICATION_SENT` | Notification for this package has been sent by sms, push and/or mail. This can be informational notifications and action notification like pickup notice. |
           | `PRE_NOTIFIED` | EDI message for the package has been received by Bring. |
           | `READY_FOR_PICKUP` | Package has arrived at pickup point. |
-          | `RETURN` | The package has been returned to sender.  |
+          | `RETURN` | The package has been returned to sender. |
           | `TRANSPORT_TO_RECIPIENT` | Package has been loaded for delivery to the recipient. |
           | `TERMINAL` | The package is now registered/arrived at inbound/outbound storage terminal |
           | `UNKNOWN` | Represents unknown / undefined events |

--- a/api/warehousing/api.raml
+++ b/api/warehousing/api.raml
@@ -12,29 +12,13 @@ documentation:
 
     Please note that this API currently doesn't support json on all of its methods yet. Look in the example section to see which are supported.
 
-    ## SOAP
-
-    ### Versioning
-
+- title: Versioning
+  content: |
     Warehousing API makes an effort to always be backwards compatible regarding data format for requests and responses of the Web Service. To achieve this, a SchemaVersion element is used in the request, indicating which version the client is on and what data-format the client expects in the result.
 
     We make an effort not to return new elements in the response when an old schema version is specified. When changes in the schema are made, the SchemaVersion is incremented by one. The new schema is used at the same endpoint URL as before and uses the same namespace for its XML elements. A TraceMessage element (info message) in the response is added to inform the client that its schema should be updated. Old schema versions might in the future be unsupported.
 
     Regarding the XML API (not Web Services), an XML Schema is not used at all. Therefore, clients of the XML API are expected to handle new elements that appear. Nevertheless, the response will be backwards compatible in the sense that elements are not renamed or deleted.
-
-    ### WSDL
-
-    [https://api.bring.com/po/api/ws/purchaseorder-v1.wsdl](https://api.bring.com/po/api/ws/purchaseorder-v1.wsdl)
-
-    [https://api.bring.com/po/api/ws/om-order-v1.wsdl](https://api.bring.com/po/api/ws/om-order-v1.wsdl)
-
-    ## Error handling
-
-    When using the Warehousing API, errors or service unavailability can occur, although we do our utmost to prevent any downtime. Thus it is important to use timeouts and other error handling techniques when making requests to the service.
-
-    How you handle errors depends on the nature of your application, but one strategy for handling such situations is by providing a failover if the shipping guide responds with an error or does not respond at all (timeout).
-
-    See [the list of error codes](#list-error-codes) for hints on how to implement error handling.
 
 - title: Authentication
   content: |
@@ -47,6 +31,22 @@ documentation:
     | `X-Bring-Client-URL` | `https://example.com/ ` | A URL that sort of identifies where you're using the APIs. |
 
     Those headers must be set for all endpoints documented below.
+
+- title: SOAP
+  content: |
+    ### WSDL
+
+    [https://api.bring.com/po/api/ws/purchaseorder-v1.wsdl](https://api.bring.com/po/api/ws/purchaseorder-v1.wsdl)
+
+    [https://api.bring.com/po/api/ws/om-order-v1.wsdl](https://api.bring.com/po/api/ws/om-order-v1.wsdl)
+
+- title: Error handling
+  content: |
+    When using the Warehousing API, errors or service unavailability can occur, although we do our utmost to prevent any downtime. Thus it is important to use timeouts and other error handling techniques when making requests to the service.
+
+    How you handle errors depends on the nature of your application, but one strategy for handling such situations is by providing a failover if the shipping guide responds with an error or does not respond at all (timeout).
+
+    See [the list of error codes](#list-error-codes) for hints on how to implement error handling.
 
 /omorder:
   displayName: Send an order


### PR DESCRIPTION
This is a walkthrough of the headers on the documentation sections to make a more common structure across the different API docs. 
The structure is now h2-h3-h4
There is no h4 without a preceeding h3 and no h3 without a h2 and so on. 
h5 has been demoted to bold or upgraded to h4

A couple of headers have been deleted where they didn’t add anything. Some of the content has been moved around and some has been split, but otherwise left unedited. There will be a separate PR to consolidate some of the common content. 

The endpoint headers will be done separately.
