### PR TITLE
Table details

### DIFF
--- a/content/api/event-cast/api.raml
+++ b/content/api/event-cast/api.raml
@@ -109,7 +109,6 @@ documentation:
 
     The Event Cast API makes you subscribe to such events using Webhooks.
 
-    #### Webhook Definition
     > A Webhook in web development is a method of augmenting or altering the behaviour of a web page, or web application, with custom callbacks.
     > These callbacks may be maintained, modified, and managed by third-party users and developers who may not necessarily be affiliated with the originating website or application.
 

--- a/content/api/shipment/api.raml
+++ b/content/api/shipment/api.raml
@@ -1649,10 +1649,10 @@ documentation:
 
   uriParameters:
     createShipmentId:
-      displayName: If "true" the API will assign a shipment ID for you and return it in the response.
+      description: If "true" the API will assign a shipment ID for you and return it in the response.
       type: boolean
     createPackageId:
-      displayName: If "true" the API will assign all package IDs for you and return them in the response.
+      description: If "true" the API will assign all package IDs for you and return them in the response.
       type: boolean
 
   post:
@@ -1733,10 +1733,10 @@ documentation:
 
   uriParameters:
     createShipmentId:
-      displayName: If "true" the API will assign a shipment ID for you and return it in the response.
+      description: If "true" the API will assign a shipment ID for you and return it in the response.
       type: boolean
     createPackageId:
-      displayName: If "true" the API will assign all package IDs for you and return them in the response.
+      description: If "true" the API will assign all package IDs for you and return them in the response.
       type: boolean
 
   post:

--- a/css/base.css
+++ b/css/base.css
@@ -18,6 +18,7 @@ h2 {
   font-weight: 400;
 }
 
+blockquote + h2,
 table + h2,
 ol + h2,
 ul + h2,
@@ -35,6 +36,7 @@ h3 {
   font-weight: 600;
 }
 
+blockquote + h3,
 table + h3,
 ol + h3,
 ul + h3,
@@ -72,9 +74,12 @@ pre {
 
 blockquote {
   border-left: 2px solid hsl(0, 0%, 86%);
-  color: hsl(0, 0%, 53.5%);
-  padding: 0 1.5ch;
+  color: hsl(0, 0%, 40%);
+  padding: 0 1ch;
   font-style: italic;
+  margin: 0.5em 0 1em;
+  max-width: 54ch;
+
 }
 
 img {

--- a/css/code.css
+++ b/css/code.css
@@ -15,8 +15,12 @@ code,
   font-size: 0.82rem;
 }
 
+td code,
 p code {
   white-space: normal;
+}
+
+p code {
   background-color: hsl(0, 0%, 93.5%);
   padding: 0.1em 0.2em;
   border-radius: 2px;

--- a/css/table.css
+++ b/css/table.css
@@ -43,6 +43,19 @@ td > ul {
   margin-bottom: 0;
 }
 
+.dev-param {
+  background-color: hsl(0, 0%, 95%);
+  padding: 0.1em 0.25em;
+  color:hsl(0, 0%, 26.5%);
+  font-size: 0.9em;
+  border-radius: 2px;
+}
+
+.dev-param--req {
+  background-color: hsl(3, 27.5%, 95%);
+  color: hsl(3, 23%, 35%);
+}
+
 .tr {
   text-align: right;
 }

--- a/css/table.css
+++ b/css/table.css
@@ -7,6 +7,12 @@ table {
   line-height: 1.4;
 }
 
+@media screen and (max-width: 62.5em) {
+  table {
+    font-size: 0.9rem;
+  }
+}
+
 caption {
   text-align: left;
   font-size: 1.17rem;

--- a/css/table.css
+++ b/css/table.css
@@ -4,17 +4,12 @@ table {
   display: block;
   overflow-x: auto;
   margin-bottom: 2rem;
+  line-height: 1.4;
 }
 
-table caption {
+caption {
   text-align: left;
-  font-weight: 600;
-}
-
-thead {
-  font-size: 0.9rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
+  font-size: 1.17rem;
 }
 
 tr {
@@ -24,17 +19,23 @@ tr {
 
 thead tr {
   vertical-align: bottom;
-  border-bottom: 2px solid hsl(0, 0%, 90%);
+  border-bottom: 2px solid hsl(0, 0%, 86%);
+  padding: 0.7em 1.4em 0.3em 0.4em;
 }
 
 th,
 td {
-  padding: 0.5em 1.4em 0.4em 0.4em;
+  padding: 0.7em 1.4em 0.6em 0.4em;
 }
 
 td:last-of-type,
 thead th:last-of-type {
   padding-right: 0.4em;
+}
+
+thead th {
+  padding: 0.7em 1.4em 0.3em 0.4em;
+  font-weight: 600;
 }
 
 td > p,

--- a/layouts/partials/api/namedparams.html
+++ b/layouts/partials/api/namedparams.html
@@ -10,13 +10,12 @@
       <td><code>{{ delimit .type " " }}</code></td>
       <td>
         {{- $desc := slice -}}
-
         {{- if (eq .hideRequired true) -}}
           {{- $desc = $desc | append "" -}}
           {{- else if (eq .required true) -}}
-          {{- $desc = $desc | append "<small>_Required._</small> " -}}
+          {{- $desc = $desc | append "<span class='dev-param dev-param--req'>Required</span> " -}}
           {{- else -}}
-          {{- $desc = $desc | append "<small>_Optional._</small> " -}}
+          {{- $desc = $desc | append "<span class='dev-param'>Optional</span> " -}}
         {{- end -}}
 
         {{- if (ne .name .displayName) -}}

--- a/layouts/partials/api/namedparams.html
+++ b/layouts/partials/api/namedparams.html
@@ -1,4 +1,4 @@
-<table class="api__params">
+<table>
   <thead>
     <th>{{ .title }}</th>
     <th>Type</th>

--- a/layouts/partials/api/namedparams.html
+++ b/layouts/partials/api/namedparams.html
@@ -31,6 +31,7 @@
         {{- end -}}
 
         {{- with .enum -}}
+          <br>
           Possible values:
           <ul>
             {{- range . -}}
@@ -40,17 +41,17 @@
         {{- end -}}
 
         {{- with .default -}}
-          <br />
+          <br>
           Default value: <code>{{ . }}</code>
         {{- end -}}
 
         {{- with .pattern -}}
-          <br />
+          <br>
           Pattern: <code>{{ . }}</code>
         {{- end -}}
 
         {{- with .example -}}
-          <br />
+          <br>
           Example: <code>{{ . }}</code>
         {{- end -}}
       </td>

--- a/layouts/partials/api/ramltype.html
+++ b/layouts/partials/api/ramltype.html
@@ -61,7 +61,7 @@
               {{- end -}}
 
               {{- if (eq $propTypes.displayName $propTypes.name) -}}
-                {{- $desc = $desc | append $propTypes.displayName | append ". " -}}
+                {{- $desc = $desc | append (print $propTypes.displayName ". ") -}}
               {{- end -}}
 
               {{- with $propTypes.description -}}

--- a/layouts/partials/api/ramltype.html
+++ b/layouts/partials/api/ramltype.html
@@ -74,7 +74,7 @@
               {{- end -}}
 
               {{- with $propTypes.enum -}}
-                <br />
+                <br>
                 Possible values:
                 <ul>
                   {{- range . -}}
@@ -86,27 +86,27 @@
               }
 
               {{- with $propTypes.default -}}
-                <br />
+                <br>
                 Default value: <code>{{ . }}</code>
               {{- end -}}
 
               {{- with $propTypes.pattern -}}
-                <br />
+                <br>
                 Pattern: <code>{{ . }}</code>
               {{- end -}}
 
               {{- with $propTypes.minItems -}}
-                <br />
+                <br>
                 Minimum number of items: <code>{{ . }}</code>
               {{- end -}}
 
               {{- with $propTypes.maxItems -}}
-                <br />
+                <br>
                 Maximum number of items: <code>{{ . }}</code>
               {{- end -}}
 
               {{- with $propTypes.example -}}
-                <br />
+                <br>
                 Example: <code>{{ . }}</code>
               {{- end -}}
             {{- end -}}

--- a/layouts/partials/api/ramltype.html
+++ b/layouts/partials/api/ramltype.html
@@ -55,9 +55,9 @@
               {{- $desc := slice "Type: `" . "` " -}}
               {{- if (eq $showRequired false) -}}
                 {{- else if $propTypes.required -}}
-                {{- $desc = $desc | append "_Required._ " -}}
+                {{- $desc = $desc | append "<span class='dev-param dev-param--req'>Required</span> " -}}
                 {{- else -}}
-                {{- $desc = $desc | append "_Optional._ " -}}
+                {{- $desc = $desc | append "<span class='dev-param'>Optional</span> " -}}
               {{- end -}}
 
               {{- if (eq $propTypes.displayName $propTypes.name) -}}

--- a/layouts/partials/api/ramltyperow.html
+++ b/layouts/partials/api/ramltyperow.html
@@ -31,7 +31,7 @@
     {{- end -}}
 
     {{- if (ne .incProp.displayName .incProp.name) -}}
-      {{- $desc = $desc | append .incProp.displayName | append ". " -}}
+      {{- $desc = $desc | append (print .incProp.displayName ". ") -}}
     {{- end -}}
 
     {{- with .incProp.description -}}

--- a/layouts/partials/api/ramltyperow.html
+++ b/layouts/partials/api/ramltyperow.html
@@ -43,7 +43,7 @@
     {{- end -}}
 
     {{- with .incProp.enum -}}
-      <br />
+      <br>
       Possible values:
       <ul>
         {{- range . -}}
@@ -53,27 +53,27 @@
     {{- end -}}
 
     {{- with .incProp.default -}}
-      <br />
+      <br>
       Default value: <code>{{ . }}</code>
     {{- end -}}
 
     {{- with .incProp.pattern -}}
-      <br />
+      <br>
       Pattern: <code>{{ . }}</code>
     {{- end -}}
 
     {{- with .incProp.minItems -}}
-      <br />
+      <br>
       Minimum number of items: <code>{{ . }}</code>
     {{- end -}}
 
     {{- with .incProp.maxItems -}}
-      <br />
+      <br>
       Maximum number of items: <code>{{ . }}</code>
     {{- end -}}
 
     {{- with .incProp.example -}}
-      <br />
+      <br>
       Example: <code>{{ . }}</code>
     {{- end -}}
   </td>

--- a/layouts/partials/api/ramltyperow.html
+++ b/layouts/partials/api/ramltyperow.html
@@ -25,9 +25,9 @@
     {{- if (eq $showRequired false) -}}
       {{- $desc = $desc | append "" -}}
       {{- else if .incProp.required -}}
-      {{- $desc = $desc | append "_Required._ " -}}
+      {{- $desc = $desc | append "<span class='dev-param dev-param--req mrxs'>Required</span> " -}}
       {{- else -}}
-      {{- $desc = $desc | append "_Optional._ " -}}
+      {{- $desc = $desc | append "<span class='dev-param mrxs'>Optional</span> " -}}
     {{- end -}}
 
     {{- if (ne .incProp.displayName .incProp.name) -}}


### PR DESCRIPTION
Various detail adjustments to make the tables even more like the ones in Mybring. Keeping them a bit different form each other since these tables tend to have more text, so the line height is a bit taller.

Most prominent change is the optional/required badge making it easier to see what is what. There is a bug or setting somewhere removing the space after the badges when they are in tables inside the example sections, hence the `mrxs` class on those.

Other stuff:
- Adjusted blockquote styling forgotten in yesterday’s PR
- Changed a couple instances of `displayName` to `description` in Shipment API
- Changed `<br />` tags to ` <br>` in the documents I was working in.

![Screenshot 2021-02-17 at 16 52 13](https://user-images.githubusercontent.com/9307503/108243260-2e1d6c00-714e-11eb-95d0-047d77b8edf3.png)
![Screenshot 2021-02-17 at 16 51 14](https://user-images.githubusercontent.com/9307503/108243252-2cec3f00-714e-11eb-962b-d2e23829fb68.png)