### PR TITLE
Codetabs layout

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -6,8 +6,7 @@ h1 {
 }
 
 h2,
-h3,
-h4 {
+h3 {
   margin-bottom: 0.25rem;
 }
 
@@ -49,7 +48,20 @@ p + h3 {
 
 h4 {
   font-size: 1.12rem;
+  line-height: 1.35;
   font-weight: 700;
+  margin-bottom: 0;
+}
+
+blockquote + h4,
+table + h4,
+ol + h4,
+ul + h4,
+code + h4,
+.highlight + h4,
+pre + h4,
+p + h4 {
+  margin-top: 1.8rem;
 }
 
 p,
@@ -64,11 +76,10 @@ samp {
 }
 
 pre {
-  border-left: 2px solid hsl(0, 0%, 86%);
   background-color: hsl(0, 0%, 97%);
   font-family: Monaco, Consolas, "Lucida Console", monospace;
   font-size: 0.82rem;
-  padding: 1.5ch;
+  padding: 0.75rem;
   overflow: auto;
 }
 
@@ -79,7 +90,6 @@ blockquote {
   font-style: italic;
   margin: 0.5em 0 1em;
   max-width: 54ch;
-
 }
 
 img {
@@ -99,5 +109,6 @@ ul ul {
 }
 
 ol {
+  list-style-type: decimal;
   margin-left: 1.6em;
 }

--- a/css/code.css
+++ b/css/code.css
@@ -1,5 +1,5 @@
 .chroma {
-    max-height: 30rem;
+    max-height: 36rem;
 }
 
 .filename {

--- a/css/codetabs.css
+++ b/css/codetabs.css
@@ -1,51 +1,62 @@
 h4 + .dev-codetabs {
   margin-top: 1rem;
 }
+
 ul.dev-codetabs {
+  max-width: 100%;
   list-style-type: none;
-  margin: 0;
-  margin-left: 0.6rem;
+  margin: 1rem 0 0;
   display: flex;
   flex-flow: row wrap;
   gap: 0.25rem;
 }
+
 .dev-codetabs__item {
-  position: relative;
-  border-top-width: 3px;
-  border-top-style: solid;
-  max-width: initial;
-}
-.dev-codetabs__item:not(.active) {
-  border-top-color: hsl(0, 0%, 95%);
   background-color: hsl(0, 0%, 95%);
-  top: 0;
+  border-radius: 2px;
+  border-bottom: 2px solid hsl(0, 0%, 95%);;
 }
+
+.dev-codetabs__item:focus,
+.dev-codetabs__item:hover {
+  background-color: hsl(86, 40%, 96%);
+  border-bottom-color: hsl(86, 40%, 96%);
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.14);
+}
+
+.dev-codetabs__item .format {
+  padding-top: 0.8em;
+  padding-bottom: 0.8em;
+}
+
 .dev-codetabs__item.active {
-  border-top-color: #7bc144;
-  border-left: 1px solid hsl(0, 0%, 86%);
-  border-right: 1px solid hsl(0, 0%, 86%);
-  top: 1px;
-  background-color: #fff;
+  background-color: hsl(86, 40%, 94%);
+  border-bottom-color: hsl(155, 100%, 19.6%);
+  box-shadow: none;
 }
+
+.dev-codetabs__item.active a {
+  cursor: default;
+}
+
 .dev-codetabs__link {
-  display: inline-block;
-  padding: 0.7rem 1.6rem 0.6rem;
+  display: flex;
+  padding: 0.5rem 1rem 0.3rem;
   color: #414141;
+  flex-flow: column nowrap;
 }
+
 .dev-codetabs__content {
-  padding-top: 1.2rem;
-  padding-right: 1.2rem;
-  padding-left: 1.2rem;
-  margin-bottom: 2rem;
-  border: 1px solid hsl(0, 0%, 86%);
+  margin-top: 1.25rem;
+  margin-bottom: 3rem;
 }
+
 .dev-codetabs__panel:not(.active) {
   display: none;
 }
 
-.dev-extext {
-  font-size: 85%;
-  margin-left: -0.4em;
-  font-weight: 500;
+.dev-codetabs__textex {
+  font-size: 0.83rem;
+  line-height: 1;
   color: hsl(0, 0%, 40%);
 }

--- a/css/table.css
+++ b/css/table.css
@@ -88,3 +88,7 @@ td > ul {
     width: 10rem;
   }
 }
+
+.fancy-dl dt {
+  margin-top: 1rem;
+}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -42,11 +42,11 @@
                   {{- end -}}
                 </section>
                 <section class="dev-documentation__section">
-                  <h2 class="anchored" id="overview-of-endpoints">
+                  <h2 class="anchored mbm" id="overview-of-endpoints">
                     Overview of endpoints
                   </h2>
 
-                  <h3>Base URL</h3>
+                  <h3 class="dn">Base URL</h3>
                   <pre>{{ .baseUri }}</pre>
                   <table>
                     <thead>
@@ -80,7 +80,7 @@
                   {{- $resources := . -}}
                   {{- $displayName := .displayName -}}
                   <section class="dev-documentation__section">
-                    <h2 class="large anchored" id="{{ $displayName | urlize }}">
+                    <h2 class="anchored mbm" id="{{ $displayName | urlize }}">
                       {{- $displayName -}}
                     </h2>
                     {{- with .description -}}
@@ -92,7 +92,7 @@
                     {{- end -}}
 
                     {{- range .methods -}}
-                      <h3>URL</h3>
+                      <h3 class="dn">URL</h3>
                       {{- $urlOutput := slice -}}
                       {{- $absUri := $resources.absoluteUri -}}
                       {{- $hasExtension := false -}}
@@ -152,7 +152,7 @@
                       {{- end -}}
 
                       {{- if (or ($otherUriParamsMediaType) ($hasMethodHeaders) ($hasMethodQueryParams)) -}}
-                        <h3>Request params</h3>
+                        <h3>Request parameters</h3>
                       {{- end -}}
 
                       {{/* For each endpoint: List all URI parameters */}}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -21,9 +21,14 @@
             {{/* this conditional ensures that only the right api doc shows up, it can probably be improved */}}
             {{- if (eq .title $.Title) -}}
               {{- $types := .types -}}
-              <article class="dev-documentation {{ replace .title "API" "" | urlize }}">
+              <article
+                class="dev-documentation {{ replace .title "API" "" | urlize }}"
+              >
                 <h1>{{ .title }}</h1>
-                <section id="api-documentation" class="dev-documentation__section">
+                <section
+                  id="api-documentation"
+                  class="dev-documentation__section"
+                >
                   {{- with $.Content -}}<div>{{ . }}</div>{{ end -}}
                   {{- range .documentation -}}
                     <h2 class="anchored" id="{{ .title | urlize }}">

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -109,9 +109,10 @@
                         {{- $urlOutput = $urlOutput | append $absUri -}}
                       {{- end -}}
 
-                      <pre
-                        class="api__url"
-                      >{{ .method | upper }}<br>{{ delimit $urlOutput "<br>" }}</pre>
+                      <pre class="flex align-ic">
+                        <span class="mrs phs pvxs bg-gray4">{{ .method | upper }}</span>
+                        <span>{{ delimit $urlOutput "<br>" }}</span>
+                      </pre>
 
                       {{/* uri params exists and first one is not mediaTypeExtension */}}
                       {{- $otherUriParamsMediaType := false -}}

--- a/layouts/partials/api/tabs.html
+++ b/layouts/partials/api/tabs.html
@@ -14,7 +14,7 @@
   {{- end -}}
 
   {{- if $multiMethods -}}
-    <p><b>Media type:</b> <code>{{ .name }}</code></p>
+    <p>Media type: <code>{{ .name }}</code></p>
   {{- end -}}
 
   <ul class="dev-codetabs" role="tablist">

--- a/layouts/partials/api/tabs.html
+++ b/layouts/partials/api/tabs.html
@@ -38,7 +38,7 @@
                 href="#{{ $tabIDFormat }}"
                 role="tab"
                 aria-controls="{{ $tabIDFormat }}"
-                class="dev-codetabs__link"
+                class="dev-codetabs__link format"
                 data-toggle="tab"
                 >{{ $formatType }} format</a
               >
@@ -61,7 +61,7 @@
           aria-controls="{{ $tabIDExample }}"
           class="dev-codetabs__link"
           data-toggle="tab"
-          ><span class="dev-extext">Example:</span> {{ .displayName }}</a
+          ><span class="dev-codetabs__textex">Example:</span> {{ .displayName }}</a
         >
       </li>
     {{- end -}}
@@ -91,7 +91,7 @@
         class="dev-codetabs__panel {{ $firstActive }}"
         id="{{ $tabIDExample }}"
       >
-        <div class="content">
+        <div>
           {{- with .description -}}
             {{- if in (string .) "\n\n" -}}
               {{ .| markdownify }}


### PR DESCRIPTION
### before
<img width="992" alt="Screenshot 2021-02-25 at 10 40 24" src="https://user-images.githubusercontent.com/9307503/109135792-bf48a000-7757-11eb-96a4-501f1708d365.png">

### after
<img width="984" alt="Screenshot 2021-02-25 at 10 45 38" src="https://user-images.githubusercontent.com/9307503/109135800-c1aafa00-7757-11eb-9a02-c7f6ada848c1.png">
