### PR TITLE
Dark syntax highlight

### DIFF
--- a/content/api/event-cast/api.raml
+++ b/content/api/event-cast/api.raml
@@ -221,7 +221,7 @@ documentation:
 
     Requests issued from Bring to your endpoint will look similar to this:
 
-    ```
+    ```json
       POST /callback/Webhook HTTP/1.1
       host: localhost:80
       Accept: application/json

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,82 +1,82 @@
-/* Background */ .chroma { background-color: hsl(0, 0%, 97%) }
+/* Background */ .chroma { color: hsl(0, 0%, 93%); background-color: hsl(200, 17%, 17%); border-radius: 2px; }
 /* Other */ .chroma .x {  }
-/* Error */ .chroma .err { color: #960050; }
+/* Error */ .chroma .err { color: hsl(3, 77.5%, 69%); }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
 /* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
 /* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
 /* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
 /* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
-/* Keyword */ .chroma .k { color: #00a8c8 }
-/* KeywordConstant */ .chroma .kc { color: #00a8c8 }
-/* KeywordDeclaration */ .chroma .kd { color: #00a8c8 }
-/* KeywordNamespace */ .chroma .kn { color: #f92672 }
-/* KeywordPseudo */ .chroma .kp { color: #00a8c8 }
-/* KeywordReserved */ .chroma .kr { color: #00a8c8 }
-/* KeywordType */ .chroma .kt { color: #00a8c8 }
-/* Name */ .chroma .n { color: #111111 }
-/* NameAttribute */ .chroma .na { color: #75af00 }
-/* NameBuiltin */ .chroma .nb { color: #111111 }
-/* NameBuiltinPseudo */ .chroma .bp { color: #111111 }
-/* NameClass */ .chroma .nc { color: #75af00 }
-/* NameConstant */ .chroma .no { color: #00a8c8 }
-/* NameDecorator */ .chroma .nd { color: #75af00 }
-/* NameEntity */ .chroma .ni { color: #111111 }
-/* NameException */ .chroma .ne { color: #75af00 }
-/* NameFunction */ .chroma .nf { color: #75af00 }
-/* NameFunctionMagic */ .chroma .fm { color: #111111 }
-/* NameLabel */ .chroma .nl { color: #111111 }
-/* NameNamespace */ .chroma .nn { color: #111111 }
-/* NameOther */ .chroma .nx { color: #75af00 }
-/* NameProperty */ .chroma .py { color: #111111 }
-/* NameTag */ .chroma .nt { color: #67678f }
-/* NameVariable */ .chroma .nv { color: #111111 }
-/* NameVariableClass */ .chroma .vc { color: #111111 }
-/* NameVariableGlobal */ .chroma .vg { color: #111111 }
-/* NameVariableInstance */ .chroma .vi { color: #111111 }
-/* NameVariableMagic */ .chroma .vm { color: #111111 }
-/* Literal */ .chroma .l { color: #ae81ff }
-/* LiteralDate */ .chroma .ld { color: #dd4800 }
-/* LiteralString */ .chroma .s { color: #dd4800 }
-/* LiteralStringAffix */ .chroma .sa { color: #dd4800 }
-/* LiteralStringBacktick */ .chroma .sb { color: #dd4800 }
-/* LiteralStringChar */ .chroma .sc { color: #dd4800 }
-/* LiteralStringDelimiter */ .chroma .dl { color: #dd4800 }
-/* LiteralStringDoc */ .chroma .sd { color: #dd4800 }
-/* LiteralStringDouble */ .chroma .s2 { color: #dd4800 }
-/* LiteralStringEscape */ .chroma .se { color: #8045ff }
-/* LiteralStringHeredoc */ .chroma .sh { color: #dd4800 }
-/* LiteralStringInterpol */ .chroma .si { color: #dd4800 }
-/* LiteralStringOther */ .chroma .sx { color: #dd4800 }
-/* LiteralStringRegex */ .chroma .sr { color: #dd4800 }
-/* LiteralStringSingle */ .chroma .s1 { color: #dd4800 }
-/* LiteralStringSymbol */ .chroma .ss { color: #dd4800 }
-/* LiteralNumber */ .chroma .m { color: #ae81ff }
-/* LiteralNumberBin */ .chroma .mb { color: #ae81ff }
-/* LiteralNumberFloat */ .chroma .mf { color: #ae81ff }
-/* LiteralNumberHex */ .chroma .mh { color: #ae81ff }
-/* LiteralNumberInteger */ .chroma .mi { color: #ae81ff }
-/* LiteralNumberIntegerLong */ .chroma .il { color: #ae81ff }
-/* LiteralNumberOct */ .chroma .mo { color: #ae81ff }
-/* Operator */ .chroma .o { color: #f92672 }
-/* OperatorWord */ .chroma .ow { color: #f92672 }
-/* Punctuation */ .chroma .p { color: #111111 }
-/* Comment */ .chroma .c { color: #75715e }
-/* CommentHashbang */ .chroma .ch { color: #75715e }
-/* CommentMultiline */ .chroma .cm { color: #75715e }
-/* CommentSingle */ .chroma .c1 { color: #75715e }
-/* CommentSpecial */ .chroma .cs { color: #75715e }
-/* CommentPreproc */ .chroma .cp { color: #75715e }
-/* CommentPreprocFile */ .chroma .cpf { color: #75715e }
+/* Keyword */ .chroma .k { color: hsl(288, 81%, 78%); }
+/* KeywordConstant */ .chroma .kc { color: hsl(288, 81%, 78%); }
+/* KeywordDeclaration */ .chroma .kd { color: hsl(288, 81%, 78%); }
+/* KeywordNamespace */ .chroma .kn { color: hsl(194, 100%, 65%); }
+/* KeywordPseudo */ .chroma .kp { color: hsl(288, 81%, 78%); }
+/* KeywordReserved */ .chroma .kr { color: hsl(288, 81%, 78%); }
+/* KeywordType */ .chroma .kt { color: hsl(41, 98%, 65%); }
+/* Name */ .chroma .n {  }
+/* NameAttribute */ .chroma .na { color: hsl(93.5, 75%, 65%); }
+/* NameBuiltin */ .chroma .nb {  }
+/* NameBuiltinPseudo */ .chroma .bp {  }
+/* NameClass */ .chroma .nc { color: hsl(41, 98%, 65%); }
+/* NameConstant */ .chroma .no { color: hsl(3, 77.5%, 69%); }
+/* NameDecorator */ .chroma .nd { color: hsl(194, 100%, 65%); }
+/* NameEntity */ .chroma .ni {  }
+/* NameException */ .chroma .ne { color: hsl(3, 77.5%, 69%); }
+/* NameFunction */ .chroma .nf { color: hsl(93.5, 75%, 65%); }
+/* NameFunctionMagic */ .chroma .fm {  }
+/* NameLabel */ .chroma .nl {  }
+/* NameNamespace */ .chroma .nn { color: hsl(41, 98%, 65%); }
+/* NameOther */ .chroma .nx { color: hsl(93.5, 75%, 65%); }
+/* NameProperty */ .chroma .py {  }
+/* NameTag */ .chroma .nt { color: hsl(194, 100%, 65%); }
+/* NameVariable */ .chroma .nv { color: hsl(3, 77.5%, 69%); }
+/* NameVariableClass */ .chroma .vc {  }
+/* NameVariableGlobal */ .chroma .vg {  }
+/* NameVariableInstance */ .chroma .vi {  }
+/* NameVariableMagic */ .chroma .vm {  }
+/* Literal */ .chroma .l { color: hsl(41, 98%, 65%); }
+/* LiteralDate */ .chroma .ld { color: hsl(152, 50%, 55%); }
+/* LiteralString */ .chroma .s { color: hsl(152, 50%, 55%); }
+/* LiteralStringAffix */ .chroma .sa { color: hsl(152, 50%, 55%); }
+/* LiteralStringBacktick */ .chroma .sb { color: hsl(152, 50%, 55%); }
+/* LiteralStringChar */ .chroma .sc {  }
+/* LiteralStringDelimiter */ .chroma .dl { color: hsl(152, 50%, 55%); }
+/* LiteralStringDoc */ .chroma .sd { color: hsl(75, 53%, 70.5%); }
+/* LiteralStringDouble */ .chroma .s2 { color: hsl(152, 50%, 55%); }
+/* LiteralStringEscape */ .chroma .se { color: hsl(41, 98%, 65%); }
+/* LiteralStringHeredoc */ .chroma .sh { color: hsl(152, 50%, 55%); }
+/* LiteralStringInterpol */ .chroma .si { color: hsl(41, 98%, 65%); }
+/* LiteralStringOther */ .chroma .sx { color: hsl(152, 50%, 55%); }
+/* LiteralStringRegex */ .chroma .sr { color: hsl(152, 50%, 55%); }
+/* LiteralStringSingle */ .chroma .s1 { color: hsl(152, 50%, 55%); }
+/* LiteralStringSymbol */ .chroma .ss { color: hsl(152, 50%, 55%); }
+/* LiteralNumber */ .chroma .m { color: hsl(41, 98%, 65%); }
+/* LiteralNumberBin */ .chroma .mb { color: hsl(41, 98%, 65%); }
+/* LiteralNumberFloat */ .chroma .mf { color: hsl(41, 98%, 65%); }
+/* LiteralNumberHex */ .chroma .mh { color: hsl(41, 98%, 65%); }
+/* LiteralNumberInteger */ .chroma .mi { color: hsl(41, 98%, 65%); }
+/* LiteralNumberIntegerLong */ .chroma .il { color: hsl(41, 98%, 65%); }
+/* LiteralNumberOct */ .chroma .mo { color: hsl(41, 98%, 65%); }
+/* Operator */ .chroma .o { color: hsl(194, 100%, 65%); }
+/* OperatorWord */ .chroma .ow { color: hsl(194, 100%, 65%); }
+/* Punctuation */ .chroma .p {  }
+/* Comment */ .chroma .c { color: hsl(75, 53%, 70.5%); }
+/* CommentHashbang */ .chroma .ch { color: hsl(75, 53%, 70.5%); }
+/* CommentMultiline */ .chroma .cm { color: hsl(75, 53%, 70.5%); }
+/* CommentSingle */ .chroma .c1 { color: hsl(75, 53%, 70.5%); }
+/* CommentSpecial */ .chroma .cs { color: hsl(75, 53%, 70.5%); }
+/* CommentPreproc */ .chroma .cp { color: hsl(75, 53%, 70.5%); }
+/* CommentPreprocFile */ .chroma .cpf { color: hsl(75, 53%, 70.5%); }
 /* Generic */ .chroma .g {  }
-/* GenericDeleted */ .chroma .gd {  }
+/* GenericDeleted */ .chroma .gd { color: hsl(3, 77.5%, 69%); }
 /* GenericEmph */ .chroma .ge { font-style: italic }
 /* GenericError */ .chroma .gr {  }
-/* GenericHeading */ .chroma .gh {  }
-/* GenericInserted */ .chroma .gi {  }
+/* GenericHeading */ .chroma .gh { font-weight: bold }
+/* GenericInserted */ .chroma .gi { color: hsl(152, 50%, 55%); }
 /* GenericOutput */ .chroma .go {  }
-/* GenericPrompt */ .chroma .gp {  }
+/* GenericPrompt */ .chroma .gp { color: hsl(75, 53%, 70.5%); font-weight: bold }
 /* GenericStrong */ .chroma .gs { font-weight: bold }
-/* GenericSubheading */ .chroma .gu {  }
+/* GenericSubheading */ .chroma .gu { color: hsl(194, 100%, 65%); font-weight: bold }
 /* GenericTraceback */ .chroma .gt {  }
 /* GenericUnderline */ .chroma .gl {  }
 /* TextWhitespace */ .chroma .w {  }


### PR DESCRIPTION
Based off paraiso-dark theme, with adjustments towards more green and blue hues and increased contrast.

### before
![Screenshot 2021-02-25 at 12 59 37](https://user-images.githubusercontent.com/9307503/109150997-e7d99580-7769-11eb-9f61-ada45a26e976.png)

### after
![Screenshot 2021-02-25 at 12 57 49](https://user-images.githubusercontent.com/9307503/109150995-e6a86880-7769-11eb-8c24-4d3410d6e546.png)
