### PR TITLE
Put titles in api template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,30 @@
 # developer.bring.com
 
 ## Issues
-If you have issues or questions regarding the API, please post in the respective API’s comments and help section. The issue tracker is for the site itself, as reflected in the template.
+
+If you have issues or questions regarding the API, please post in the respective
+API’s comments and help section. The issue tracker is for the site itself, as
+reflected in the template.
 
 ## Tech
+
 The Bring Developer site uses [Hugo](https://gohugo.io/) and
-[RAML 1.0](https://raml.org/). Hugo is the world’s fastest static site generator, and RAML
-is a a YAML-based modeling language for APIs. We use CSS with some light post processing.
+[RAML 1.0](https://raml.org/). Hugo is the world’s fastest static site
+generator, and RAML is a a YAML-based modeling language for APIs. We use CSS
+with some light post processing.
 
 ## Revamped dev site 2021
-The site is being improved throughout 2021, the first step was to get rid of Ruby and Jekyll in favour of Hugo, Node and Webpack. We currently operate with generated parts of the old CSS mixed with some new, temporary, code.
+
+The site is being improved throughout 2021, the first step was to get rid of
+Ruby and Jekyll in favour of Hugo, Node and Webpack. We currently operate with
+generated parts of the old CSS mixed with some new, temporary, code.
 
 ## Adding a new API
-Make a new folder in `content/api`, the folder name will be the url slug.
-Use RAML 1.0 for you documentation file.
-Make a index.html file containing the following frontmatter:
+
+Make a new folder in `content/api`, the folder name will be the url slug. Use
+RAML 1.0 for you documentation file. Make a index.html file containing the
+following frontmatter:
+
 ```
 ---
 title: {Name of API, similar to the name in the raml file}
@@ -35,16 +45,21 @@ If you have an alert, it can be added below the frontmatter, here, instead of in
 Open config.toml and add the new raml file path to the `apis` array.
 
 ## Adding a new article/blog post
-If you only have text, make a new .md file in `content/blog`
-Use the article title or something close to it as filename, make sure to use dashes instead of spaces. This will be the url slug.
 
-If you have images or other files, make a new folder in `content/blog`
-Use the article title or something close to it as foldername, make sure to use dashes instead of spaces. This will be the url slug.
-Make an index.md file.
-Add your other files to the folder, you can make subfolders if it helps you organise the content.
+If you only have text, make a new .md file in `content/blog` Use the article
+title or something close to it as filename, make sure to use dashes instead of
+spaces. This will be the url slug.
+
+If you have images or other files, make a new folder in `content/blog` Use the
+article title or something close to it as foldername, make sure to use dashes
+instead of spaces. This will be the url slug. Make an index.md file. Add your
+other files to the folder, you can make subfolders if it helps you organise the
+content.
 
 ### Frontmatter and content
-Add the following frontmatter to your article file. It supports multi authors and multi tags.
+
+Add the following frontmatter to your article file. It supports multi authors
+and multi tags.
 
 ```
 ---
@@ -60,24 +75,29 @@ tags:
 ---
 ```
 
-Then add your content below that.
-Files are linked relative to your .md file
+Then add your content below that. Files are linked relative to your .md file
 
 ### Excerpt and image
-The excerpts on the list page is auto generated form the first 60 words in your article. It’s possible to manually set the cutoff and add an image.
+
+The excerpts on the list page is auto generated form the first 60 words in your
+article. It’s possible to manually set the cutoff and add an image.
 
 Add `<!--more-->` where you want the cutoff to happen.
 
-To add an image in your excerpt, add the file to your post’s folder and the following to the frontmatter:
+To add an image in your excerpt, add the file to your post’s folder and the
+following to the frontmatter:
+
 ```
 resources:
   - src: {filename.jpg}
 ```
 
 ## Syntax highlighting
-To get syntax highlighting in Markdown, you can specify the programming language of the code example after the opening fence.
 
-~~~
+To get syntax highlighting in Markdown, you can specify the programming language
+of the code example after the opening fence.
+
+````
 ```html
 <form>
   <fieldset>
@@ -86,22 +106,27 @@ To get syntax highlighting in Markdown, you can specify the programming language
   </fieldset>
 </form>
 ```
-~~~
+````
 
 ## Building, running and updating
+
 `npm install` installs the needed dependencies.
 
-`npm run build` builds CSS and JSON based in the raml files. Hugo needs this in order to run.
+`npm run build` builds CSS and JSON based in the raml files. Hugo needs this in
+order to run.
 
-Run `npm start` to run locally. The non-api pages will update instantly. But when you make changes to the api files or CSS, you have to run `npm run build` again to generate new files for that.
-We are working on a more automated solution for this.
+Run `npm start` to run locally. The non-api pages will update instantly. But
+when you make changes to the api files or CSS, you have to run `npm run build`
+again to generate new files for that. We are working on a more automated
+solution for this.
 
-`npm run buildtest` builds the entire site for test env
-`npm run buildqa` builds the entire site for qa env
-`npm run buildprod` builds the entire site for production env
+`npm run buildtest` builds the entire site for test env `npm run buildqa` builds
+the entire site for qa env `npm run buildprod` builds the entire site for
+production env
 
 ## Deploy and release
 
 Deploy to test or QA using b deploy {test|qa}
 
-Merging a PR to master generates a production build and automatically deploys it to test, QA and production.
+Merging a PR to master generates a production build and automatically deploys it
+to test, QA and production.

--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -9,7 +9,6 @@ weight: 1
 disqus_identifier: https-developer-bring-com-api
 ---
 
-<h1>Getting started</h1>
 <section class="dev-documentation__section">
   <h2 class="anchored " id="authentication">Authentication</h2>
 

--- a/content/api/booking-shipment/index.html
+++ b/content/api/booking-shipment/index.html
@@ -4,7 +4,6 @@ layout: api
 notanapi: true
 ---
 
-<h1 class="mbl">Booking API vs Shipment API</h1>
 <section class="dev-documentation__section">
   <h2 class="anchored">Similarities and differences</h2>
 

--- a/content/api/ecommerce/index.html
+++ b/content/api/ecommerce/index.html
@@ -8,7 +8,6 @@ menu:
 weight: 3
 ---
 
-<h1 class="nowrap">E-commerce</h1>
 <section class="dev-documentation__section">
   <img
     src="ecommerce.jpg"

--- a/content/api/reports/agreement_conversion.html
+++ b/content/api/reports/agreement_conversion.html
@@ -1,28 +1,32 @@
 ---
-title: Shipping Guide upgrade guide
+title: Reports API changes after conversion to new services
 layout: api
 notanapi: true
 ---
 
-<h1 class="mbl">Reports API changes after conversion to new services</h1>
 <section class="dev-documentation__section">
-  <div style="margin-top: 1rem">
+  <p>
     Bring is revising the service portfolio. Some of our services have been
     given new service names, service codes and pricing models.
-    <a href="https://www.bring.no/tjenester/endringer">Read more</a>
-    about the changes <br /><br />
+    <a href="https://www.bring.no/tjenester/endringer"
+      >Read more about the changes</a
+    >.
+  </p>
+  <p>
     Old services will be phased out. From a given date, your company will be
     converted to use revised services during Booking, and you can no longer book
     old services. All customers belongs to your company will be converted. The
     revised services are booked using main customer number.
-
-    <br /><br />
+  </p>
+  <p>
     In Reports API , we have made changes to support Main Customer Number for
     some service types and for some service types new definitions are available.
-    <br />
+  </p>
+  <p>
     API users after conversion need to use appropriate customer number and
     definition combination to get the correct result set from the reports.
-    <br /><br />
+  </p>
+  <p>
     We recommend API users to execute
     <a href="/api/reports/#list-available-customers"
       >List available customers</a
@@ -32,74 +36,65 @@ notanapi: true
       >List available reports for a customer</a
     >
     to understand what parameters to be used for report execution.
-    <br /><br />
+  </p>
+  <p>
     Below Table is gives a snapshot view about what changes API users need to do
     for reports belongs different service type after conversion.
-    <br /><br />
-    <table>
-      <thead>
-        <tr>
-          <th>Service Type</th>
-          <th>Customer Number to Use</th>
-          <th>Report Definition to use</th>
-        </tr>
-      </thead>
-      <tbody>
-        <tr>
-          <td>Parcel Norway</td>
-          <td>
-            <div style="text-decoration: line-through;">
-              API Customer Number
-            </div>
-            <div>Main Customer Number</div>
-          </td>
-          <td>Existing Definition</td>
-        </tr>
-        <tr>
-          <td>Parcel International</td>
-          <td>API Customer Number</td>
-          <td>Existing Definition</td>
-        </tr>
-        <tr>
-          <td>Cargo</td>
-          <td>
-            <div style="text-decoration: line-through;">
-              API Customer Number
-            </div>
-            <div>Main Customer Number</div>
-          </td>
-          <td>
-            <div style="text-decoration: line-through;">
-              Existing Definition
-            </div>
-            <div>New Definition</div>
-          </td>
-        </tr>
-        <tr>
-          <td>Oil Express</td>
-          <td>
-            <div style="text-decoration: line-through;">
-              API Customer Number
-            </div>
-            <div>Main Customer Number</div>
-          </td>
-          <td>Existing Definition</td>
-        </tr>
-        <tr>
-          <td>Warehousing</td>
-          <td>
-            <div style="text-decoration: line-through;">
-              API Customer Number
-            </div>
-            <div>Main Customer Number</div>
-          </td>
-          <td>Existing Definition</td>
-        </tr>
-      </tbody>
-    </table>
-    <div style="font-size: .8rem; font-style: italic">
-      Example : Main Customer Number(20000012345) , API Customer
-      Number(CARGO-12345 or PARCELS_SWEDEN-12345)
-    </div>
-  </div>
+  </p>
+  <table>
+    <thead>
+      <tr>
+        <th>Service Type</th>
+        <th>Customer Number to Use</th>
+        <th>Report Definition to use</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Parcel Norway</td>
+        <td>
+          <div style="text-decoration: line-through;">API Customer Number</div>
+          <div>Main Customer Number</div>
+        </td>
+        <td>Existing Definition</td>
+      </tr>
+      <tr>
+        <td>Parcel International</td>
+        <td>API Customer Number</td>
+        <td>Existing Definition</td>
+      </tr>
+      <tr>
+        <td>Cargo</td>
+        <td>
+          <div style="text-decoration: line-through;">API Customer Number</div>
+          <div>Main Customer Number</div>
+        </td>
+        <td>
+          <div style="text-decoration: line-through;">Existing Definition</div>
+          <div>New Definition</div>
+        </td>
+      </tr>
+      <tr>
+        <td>Oil Express</td>
+        <td>
+          <div style="text-decoration: line-through;">API Customer Number</div>
+          <div>Main Customer Number</div>
+        </td>
+        <td>Existing Definition</td>
+      </tr>
+      <tr>
+        <td>Warehousing</td>
+        <td>
+          <div style="text-decoration: line-through;">API Customer Number</div>
+          <div>Main Customer Number</div>
+        </td>
+        <td>Existing Definition</td>
+      </tr>
+    </tbody>
+  </table>
+  <p class="text-note">
+    Example:<br />
+    Main Customer Number(20000012345) , API Customer Number(CARGO-12345 or
+    PARCELS_SWEDEN-12345)
+  </p>
 </section>

--- a/content/api/services/_index.html
+++ b/content/api/services/_index.html
@@ -9,7 +9,6 @@ menu:
 weight: 4
 ---
 
-<h1 class="mbl">API service list</h1>
 <section class="dev-documentation__section" id="apiServiceList">
   <p>
     All the services available in the

--- a/content/api/services/revisedservice.html
+++ b/content/api/services/revisedservice.html
@@ -4,7 +4,6 @@ layout: api
 notanapi: true
 ---
 
-<h1 class="mbl">Revised Services</h1>
 <section class="dev-documentation__section">
   Bring is revising the service portfolio. Some of our services have been given
   new service names, service codes and pricing models.<a

--- a/content/api/shipping-guide_2/topics.html
+++ b/content/api/shipping-guide_2/topics.html
@@ -1,10 +1,8 @@
 ---
-title: Let us talk about Shipping Guide
+title: About Shipping Guide
 layout: api
 notanapi: true
 ---
-
-<h1 class="mbl">Let's talk about Shipping Guide</h1>
 
 <section class="dev-documentation__section">
   <h2>No applicable services found</h2>

--- a/content/api/shipping-guide_2/upgrade-to-version-2.html
+++ b/content/api/shipping-guide_2/upgrade-to-version-2.html
@@ -1,10 +1,9 @@
 ---
-title: Shipping Guide upgrade guide
+title: Upgrading to Shipping Guide API 2.0
 layout: api
 notanapi: true
 ---
 
-<h1 class="mbl">Upgrading to version 2.0</h1>
 <section class="dev-documentation__section">
   <p>
     This is a short summary of the differences between version 1.xx and 2.0 of

--- a/css/codetabs.css
+++ b/css/codetabs.css
@@ -22,7 +22,7 @@ ul.dev-codetabs {
 .dev-codetabs__item:hover {
   background-color: var(--green-lighter-hover);
   border-bottom-color: var(--green-lighter-hover);
-  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.14);
+  box-shadow: var(--shadow);
 }
 
 .dev-codetabs__item .format {

--- a/css/variables.css
+++ b/css/variables.css
@@ -14,5 +14,7 @@
 --green-dark: hsl(155, 100%, 19.6%); /* #00643a */
 --green-darker: hsl(152, 100%, 9%);
 
+--shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.14);
+
 --easeout-15: 0.15s ease-out;
 }

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -13,6 +13,12 @@
       <div class="dev-pagewmenu__page">
         {{- if (eq $notAnApi true) -}}
           <article class="dev-documentation w100p {{ $maxwidth }}">
+            <h1>
+              {{- .Title -}}
+              {{- with .Params.titlesub -}}
+                <span class="db text-title mts">{{ . }}</span>
+              {{- end -}}
+            </h1>
             {{- .Content -}}
             {{- if (in .CurrentSection "revision-history") -}}
               {{- partial "api/changelog.html" . -}}

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -1,4 +1,3 @@
-<h1>{{ .Title }}</h1>
 <section class="dev-documentation__section">
   <p class="text-heading mbl">Important API changes and updates</p>
   {{- range .Pages -}}

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -1,6 +1,5 @@
 {{- $currentPage := . -}}
 {{- $pageUrl := .URL -}}
-{{- $currentSection := .Section -}}
 
 <nav class="dev-sidemenu" aria-label="Section">
 


### PR DESCRIPTION
Puts the non-api api documentation’s title into a h1 in the template so we don't have to add it manually to all pages.