### PR TITLE
Fix prominent layout issues in ie11

### DIFF
--- a/content/api/revision-history/2021-02-16.md
+++ b/content/api/revision-history/2021-02-16.md
@@ -1,5 +1,5 @@
 ---
-title: Pickup point API
+title: Pickup Point API
 publishDate: 2021-02-16
 layout: api
 ---

--- a/content/jobs/index.html
+++ b/content/jobs/index.html
@@ -2,7 +2,7 @@
 title: Ledige stillinger i webavdelingen
 ---
 
-<div class="dev-blog phl">
+<div class="maxw48r w100p m-auto mvl phl">
   <h2>Ledige stillinger i webavdelingen</h2>
 
   <p>

--- a/css/base.css
+++ b/css/base.css
@@ -119,5 +119,5 @@ ol {
 }
 
 .icon-ui--green-dark {
-  fill: var(--green-dark)
+  fill: var(--green-dark);
 }

--- a/css/base.css
+++ b/css/base.css
@@ -69,6 +69,11 @@ ul {
   max-width: 68ch;
 }
 
+_:-ms-fullscreen,
+:root p, :root ul {
+  max-width: 106ch;
+}
+
 kbd,
 samp {
   font-family: monospace, monospace;

--- a/css/siteheader.css
+++ b/css/siteheader.css
@@ -1,6 +1,7 @@
 .dev-siteheader {
   background-color: var(--green-darker);
   flex: 1 0 100%;
+  min-height: 4.4rem;
 }
 
 @media screen and (min-width: 64em) {

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -30,7 +30,7 @@
             {{- end -}}
           </div>
         {{- end -}}
-        <h2 class="mtm mbs text-title">API changelog</h2>
+        <h2 class="mbs">API changelog</h2>
         {{- range where .Site.Pages "Section" "api" -}}
           {{- if (in .CurrentSection "revision-history") -}}
             {{- range first 4 .Pages -}}

--- a/static/svg/systems.svg
+++ b/static/svg/systems.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1200 400" class="mbm maxw44r">
+<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1200 400" class="mbm maxw44r" height="234">
   <rect fill="#EEE" width="1200" height="390"/>
 
   <g id="systems">


### PR DESCRIPTION
Some quick fixes to get the pages to display correctly in IE11.
There are still a few alignment issues in the docs, but they are too small to spend any time on and would require a lot of extra code. Going below 1024 px width causes more serious issues, but I doubt there are a lot of IE on pads and phones.