### PR TITLE
Make checkout guide figs. sticky

### DIFF
--- a/content/api/checkout-guide/_index.html
+++ b/content/api/checkout-guide/_index.html
@@ -74,14 +74,14 @@ hidden: true
   <h2 class="mbm">Display basic information</h2>
   <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
-      <img src="assets/generell_info.png" alt="" class="ba mb-border mbm maxw24r" />
+      <img src="assets/generell_info.png" alt="" class="ba mb-border mbm maxw24r sticky-6r" />
 
       <p>
         The illustration show Package to mailbox, but all delivery options
         should have the same basic information
       </p>
 
-      <div class="pal bg-green1">
+      <div class="pal bg-green1 mbl">
         <h3>Technical documentation</h3>
 
         See request example in

--- a/content/api/checkout-guide/_index.html
+++ b/content/api/checkout-guide/_index.html
@@ -72,7 +72,7 @@ hidden: true
 
 <section class="dev-docscontent__section">
   <h2 class="mbm">Display basic information</h2>
-  <div class="flex flex-wrap">
+  <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
       <img src="assets/generell_info.png" alt="" class="ba mb-border mbm maxw24r" />
 

--- a/content/api/checkout-guide/home-delivery.html
+++ b/content/api/checkout-guide/home-delivery.html
@@ -25,7 +25,7 @@ hidden: true
 <section class="dev-docscontent__section">
   <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
-      <img src="../assets/home_delivery.png" alt="" class="mbm maxw24r" />
+      <img src="../assets/home_delivery.png" alt="" class="mbm maxw24r sticky-6r" />
     </div>
 
     <div class="dev-guide-l">

--- a/content/api/checkout-guide/home-delivery.html
+++ b/content/api/checkout-guide/home-delivery.html
@@ -23,7 +23,7 @@ hidden: true
 ---
 
 <section class="dev-docscontent__section">
-  <div class="flex flex-wrap">
+  <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
       <img src="../assets/home_delivery.png" alt="" class="mbm maxw24r" />
     </div>

--- a/content/api/checkout-guide/implement-estimated-delivery.html
+++ b/content/api/checkout-guide/implement-estimated-delivery.html
@@ -16,7 +16,7 @@ hidden: true
 <section class="dev-docscontent__section">
   <div>
     <h2 class="mbm">Configuration of internal lead time and cut-off time</h2>
-    <div class="flex flex-wrap">
+    <div class="flex flex-wrap flex-dir-row-rev">
       <div class="dev-guide-m">
         <img
           src="../assets/leadtime.png"
@@ -69,7 +69,7 @@ hidden: true
   </div>
   <div class="mtxl">
     <h2 class="mbm">Examples of different ways to show ETA</h2>
-    <div class="flex flex-wrap">
+    <div class="flex flex-wrap flex-dir-row-rev">
       <div class="dev-guide-m">
         <img
           src="../assets/eta.png"

--- a/content/api/checkout-guide/implement-estimated-delivery.html
+++ b/content/api/checkout-guide/implement-estimated-delivery.html
@@ -21,7 +21,7 @@ hidden: true
         <img
           src="../assets/leadtime.png"
           alt="Internal leadtime"
-          class="mbm maxw24r"
+          class="mbm maxw24r sticky-6r"
         />
       </div>
       <div class="dev-guide-l">
@@ -74,7 +74,7 @@ hidden: true
         <img
           src="../assets/eta.png"
           alt="Estimated time of arrival"
-          class="mbm maxw24r"
+          class="mbm maxw24r sticky-6r"
         />
       </div>
 

--- a/content/api/checkout-guide/mailbox-parcel.html
+++ b/content/api/checkout-guide/mailbox-parcel.html
@@ -25,7 +25,7 @@ hidden: true
   <h2 class="mbm">Pakke i postkassen in checkout</h2>
   <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
-      <img src="../assets/til_postkassen.png" alt="" class="mbm maxw24r" />
+      <img src="../assets/til_postkassen.png" alt="" class="mbm maxw24r sticky-6r" />
     </div>
 
     <div class="dev-guide-l">

--- a/content/api/checkout-guide/mailbox-parcel.html
+++ b/content/api/checkout-guide/mailbox-parcel.html
@@ -23,7 +23,7 @@ hidden: true
 
 <section class="dev-docscontent__section">
   <h2 class="mbm">Pakke i postkassen in checkout</h2>
-  <div class="flex flex-wrap">
+  <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
       <img src="../assets/til_postkassen.png" alt="" class="mbm maxw24r" />
     </div>

--- a/content/api/checkout-guide/pickup-parcel.html
+++ b/content/api/checkout-guide/pickup-parcel.html
@@ -25,7 +25,7 @@ hidden: true
 
 <section class="dev-docscontent__section">
   <h2 class="mbm">Pakke til hentested i chekout</h2>
-  <div class="flex flex-wrap">
+  <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
       <img
         src="../assets/pickup_point.png"

--- a/content/api/checkout-guide/pickup-parcel.html
+++ b/content/api/checkout-guide/pickup-parcel.html
@@ -27,16 +27,18 @@ hidden: true
   <h2 class="mbm">Pakke til hentested i chekout</h2>
   <div class="flex flex-wrap flex-dir-row-rev">
     <div class="dev-guide-m">
-      <img
-        src="../assets/pickup_point.png"
-        alt="illustration of all element of to pickup point"
-        class="mbm maxw24r"
-      />
-      <img
-        src="../assets/pickup_point_opened.png"
-        alt="illustration of open dornw for pickup points"
-        class="mbm maxw24r"
-      />
+      <div class="sticky-6r">
+        <img
+          src="../assets/pickup_point.png"
+          alt="illustration of all element of to pickup point"
+          class="mbm maxw24r"
+        />
+        <img
+          src="../assets/pickup_point_opened.png"
+          alt="illustration of open dornw for pickup points"
+          class="mbm maxw24r"
+        />
+      </div>
     </div>
 
     <div class="dev-guide-l">

--- a/css/guide.css
+++ b/css/guide.css
@@ -16,6 +16,11 @@
   max-width: 100%;
 }
 
+.sticky-6r {
+  position: sticky;
+  top: 6rem;
+}
+
 @media screen and (min-width: 50em) {
   .dev-guide-l,
   .dev-guide-m,

--- a/css/siteheader.css
+++ b/css/siteheader.css
@@ -2,6 +2,7 @@
   background-color: var(--green-darker);
   flex: 1 0 100%;
   min-height: 4.4rem;
+  z-index: 20;
 }
 
 @media screen and (min-width: 64em) {

--- a/layouts/partials/api/guide.html
+++ b/layouts/partials/api/guide.html
@@ -3,85 +3,80 @@
 
 <section class="dev-docscontent__section">
   <h2>Service codes</h2>
-  <div class="flex flex-wrap align-ifs">
-    {{- if isset .Params "services" -}}
-      <div class="dev-guide-l">
-        <table>
-          <thead>
-            <tr>
-              <th rowspan="2">Service name</th>
-              <th rowspan="2">When to use</th>
-              <th rowspan="2">Service group</th>
-              <th rowspan="2" class="minw10r">Size limit</th>
-              <th rowspan="2">Service code</th>
-              <th rowspan="2">API&nbsp;ID</th>
-              <th colspan="2">Value&nbsp;added&nbsp;services</th>
-            </tr>
-            <tr>
-              <th class="ptxs">Code</th>
-              <th class="ptxs">Description</th>
-            </tr>
-          </thead>
-          <tbody>
-            {{- $rowSpan := 1 -}}
-            {{- range .Params.services -}}
-              {{- $service := index $serviceData . -}}
-              {{- if gt (len $service.vas) 0 -}}
-                {{- $rowSpan = (len $service.vas) -}}
-              {{- end -}}
-              <tr>
-                <th scope="row" rowspan="{{ $rowSpan }}">
-                  {{- $serviceName := $service.nameEn -}}
-                  {{- if and $service.nameNo $service.nameEn -}}
-                    {{- $serviceName = print $service.nameNo "<span class='db text-note fwn'>" $service.nameEn "</span>" -}}
-                    {{- else if not $service.nameEn -}}
-                    {{ $serviceName = $service.nameNo }}
-                  {{- end -}}
-                  {{ $serviceName | markdownify }}
-                </th>
-                <td rowspan="{{ $rowSpan }}">{{ $service.usage }}</td>
-                <td rowspan="{{ $rowSpan }}">{{ $service.serviceGroup }}</td>
-                <td rowspan="{{ $rowSpan }}">
-                  {{ $service.weightLimit }}<br />{{ $service.sizeLimit }}
-                </td>
-                <td rowspan="{{ $rowSpan }}">{{ $service.code }}</td>
-                <td rowspan="{{ $rowSpan }}">
-                  <code>{{ $service.apiId }}</code>
-                </td>
-                {{- if gt (len $service.vas) 0 -}}
-                  {{- range first 1 $service.vas -}}
-                    {{- partial "api/vas.html" (dict "vas" (index $vasData .)) -}}
-                  {{- end -}}
-                  {{- else -}}
-                  <td rowspan="{{ $rowSpan }}" colspan="2"></td>
-                {{- end -}}
-              </tr>
-              {{- range after 1 $service.vas -}}
-                <tr>
-                  {{- partial "api/vas.html" (dict "vas" (index $vasData .) "padding" "ptxs") -}}
-                </tr>
-              {{- end -}}
-            {{- end -}}
-          </tbody>
-        </table>
-
-        {{- if in .Params.services "3570" -}}
-          <p class="text-note">
-            * Tracking with RFID adds additional scanning points for tracking
-            (require RFID printer)
-          </p>
-        {{- end -}}
-      </div>
-    {{- end -}}
-    {{- if isset .Params "examples" -}}
-      <div class="dev-guide-s bg-green1 pal">
-        <h3>Technical examples</h3>
-        <ul>
-          {{- range .Params.examples -}}
-            <li>{{ . | markdownify }}</li>
+  {{- if isset .Params "services" -}}
+    <table>
+      <thead>
+        <tr>
+          <th rowspan="2">Service name</th>
+          <th rowspan="2">When to use</th>
+          <th rowspan="2">Service group</th>
+          <th rowspan="2" class="minw10r">Size limit</th>
+          <th rowspan="2">Service code</th>
+          <th rowspan="2">API&nbsp;ID</th>
+          <th colspan="2">Value&nbsp;added&nbsp;services</th>
+        </tr>
+        <tr>
+          <th class="ptxs">Code</th>
+          <th class="ptxs">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        {{- $rowSpan := 1 -}}
+        {{- range .Params.services -}}
+          {{- $service := index $serviceData . -}}
+          {{- if gt (len $service.vas) 0 -}}
+            {{- $rowSpan = (len $service.vas) -}}
           {{- end -}}
-        </ul>
-      </div>
+          <tr>
+            <th scope="row" rowspan="{{ $rowSpan }}">
+              {{- $serviceName := $service.nameEn -}}
+              {{- if and $service.nameNo $service.nameEn -}}
+                {{- $serviceName = print $service.nameNo "<span class='db text-note fwn'>" $service.nameEn "</span>" -}}
+                {{- else if not $service.nameEn -}}
+                {{ $serviceName = $service.nameNo }}
+              {{- end -}}
+              {{ $serviceName | markdownify }}
+            </th>
+            <td rowspan="{{ $rowSpan }}">{{ $service.usage }}</td>
+            <td rowspan="{{ $rowSpan }}">{{ $service.serviceGroup }}</td>
+            <td rowspan="{{ $rowSpan }}">
+              {{ $service.weightLimit }}<br />{{ $service.sizeLimit }}
+            </td>
+            <td rowspan="{{ $rowSpan }}">{{ $service.code }}</td>
+            <td rowspan="{{ $rowSpan }}">
+              <code>{{ $service.apiId }}</code>
+            </td>
+            {{- if gt (len $service.vas) 0 -}}
+              {{- range first 1 $service.vas -}}
+                {{- partial "api/vas.html" (dict "vas" (index $vasData .)) -}}
+              {{- end -}}
+              {{- else -}}
+              <td rowspan="{{ $rowSpan }}" colspan="2"></td>
+            {{- end -}}
+          </tr>
+          {{- range after 1 $service.vas -}}
+            <tr>
+              {{- partial "api/vas.html" (dict "vas" (index $vasData .) "padding" "ptxs") -}}
+            </tr>
+          {{- end -}}
+        {{- end -}}
+      </tbody>
+    </table>
+    {{- if in .Params.services "3570" -}}
+      <p class="text-note">
+        * Tracking with RFID adds additional scanning points for tracking
+        (require RFID printer)
+      </p>
     {{- end -}}
-  </div>
+  {{- end -}}
+  {{- if isset .Params "examples" -}}
+    <div class="bg-green1 pal maxw40r">
+      <h3>Technical examples</h3>
+      <ul>
+        {{- range .Params.examples -}}
+          <li>{{ . | markdownify }}</li>
+        {{- end -}}
+      </ul>
+    </div>
+  {{- end -}}
 </section>


### PR DESCRIPTION
- Reverse main flex axis, so the descriptions are to the left, but still below the figure when it wraps.
- Make checkout figs sticky, except the one that has two since they pretty much takes up the entire height of the text content.
- Organise table and example links vertically, to give the table more space.