### PR TITLE
Add warning about removing "Preliminary Freight calculation" report

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -6,6 +6,7 @@ start:
   Developing an e-commerce site? Or dealing with logistics software in the Nordic
   countries? Find out how to integrate with Bring’s API platform.
 important:
+- <strong class="mrs">The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21st of June.</strong> <br> Historical data will be available for one year. You will find the same information in Detailed freight calculation report.
 - <strong class="mrs">Shipping Guide API 1.0 will finally be decommissioned on 01.07.2021</strong> <br> 3 years ago, Shipping Guide API 2.0 was launched. Since then, schemas belonging to 1.0 have been phased out one by one. The last active schema, 11, will be decomissioned on 01.07.2021. If you haven't upgraded to <a href="api/shipping-guide_2">Shipping Guide 2.0</a> yet, we strongly recommend to do that as soon as possible, and latest by 01.07.2021. We will progressively rate limit incoming 1.0 requests towards this final deadline.
 ---
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -6,7 +6,7 @@ start:
   Developing an e-commerce site? Or dealing with logistics software in the Nordic
   countries? Find out how to integrate with Bring’s API platform.
 important:
-- <strong class="mrs">The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21.06.2021.</strong> <br> The Preliminary freight calculation report for Parcel Norway customers fetched using API id PARCELS-CURRENT_CALCULATED_SHIPPING today, will be disabled from 21.06.2021. Historical data will be available for one year. You will find the same information in Detailed freight calculation report using API id PARCELS-ECONOMY_AND_STATISTICS instead.
+- <strong class="mrs">The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21.06.2021.</strong> <br> <a href="api/reports">Read more</a>
 - <strong class="mrs">Shipping Guide API 1.0 will finally be decommissioned on 01.07.2021</strong> <br> 3 years ago, Shipping Guide API 2.0 was launched. Since then, schemas belonging to 1.0 have been phased out one by one. The last active schema, 11, will be decomissioned on 01.07.2021. If you haven't upgraded to <a href="api/shipping-guide_2">Shipping Guide 2.0</a> yet, we strongly recommend to do that as soon as possible, and latest by 01.07.2021. We will progressively rate limit incoming 1.0 requests towards this final deadline.
 ---
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -6,7 +6,7 @@ start:
   Developing an e-commerce site? Or dealing with logistics software in the Nordic
   countries? Find out how to integrate with Bring’s API platform.
 important:
-- <strong class="mrs">The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21st of June.</strong> <br> Historical data will be available for one year. You will find the same information in Detailed freight calculation report.
+- <strong class="mrs">The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21.06.2021.</strong> <br> The Preliminary freight calculation report for Parcel Norway customers fetched using API id PARCELS-CURRENT_CALCULATED_SHIPPING today, will be disabled from 21.06.2021. Historical data will be available for one year. You will find the same information in Detailed freight calculation report using API id PARCELS-ECONOMY_AND_STATISTICS instead.
 - <strong class="mrs">Shipping Guide API 1.0 will finally be decommissioned on 01.07.2021</strong> <br> 3 years ago, Shipping Guide API 2.0 was launched. Since then, schemas belonging to 1.0 have been phased out one by one. The last active schema, 11, will be decomissioned on 01.07.2021. If you haven't upgraded to <a href="api/shipping-guide_2">Shipping Guide 2.0</a> yet, we strongly recommend to do that as soon as possible, and latest by 01.07.2021. We will progressively rate limit incoming 1.0 requests towards this final deadline.
 ---
 

--- a/content/api/reports/_index.html
+++ b/content/api/reports/_index.html
@@ -12,9 +12,8 @@ weight: 51
 ---
 
 <div class="message--warn maxw48r pam mbl">
-  <strong>The Preliminary freight calculation report</strong>
+  <strong>The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21.06.2021</strong>
   <br /><br />
-  The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21st of June.
   Historical data will be available for one year.
   You will find the same information in Detailed freight calculation report.
   <br /><br />

--- a/content/api/reports/_index.html
+++ b/content/api/reports/_index.html
@@ -12,9 +12,13 @@ weight: 51
 ---
 
 <div class="message--warn maxw48r pam mbl">
-  <strong
-    >API changes after your company is converted to use new services</strong
-  >
+  <strong>The Preliminary freight calculation report</strong>
+  <br /><br />
+  The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21st of June.
+  Historical data will be available for one year.
+  You will find the same information in Detailed freight calculation report.
+  <br /><br />
+  <strong>API changes after your company is converted to use new services</strong>
   <br /><br />
   Bring is revising the service portfolio. Some of our services have been given
   new service names, service codes and pricing models.

--- a/content/api/reports/_index.html
+++ b/content/api/reports/_index.html
@@ -14,8 +14,9 @@ weight: 51
 <div class="message--warn maxw48r pam mbl">
   <strong>The Preliminary freight calculation report for Parcel Norway customers will be disabled from 21.06.2021</strong>
   <br /><br />
-  Historical data will be available for one year.
-  You will find the same information in Detailed freight calculation report.
+  The Preliminary freight calculation report for Parcel Norway customers fetched using API id PARCELS-CURRENT_CALCULATED_SHIPPING today,
+  will be disabled from 21.06.2021. Historical data will be available for one year.
+  You will find the same information in Detailed freight calculation report using API id PARCELS-ECONOMY_AND_STATISTICS instead.
   <br /><br />
   <strong>API changes after your company is converted to use new services</strong>
   <br /><br />


### PR DESCRIPTION
As we are in process of removing "Preliminary Freight calculation" report for Parcel Norway customers, we need to inform our API users. 
<img width="563" alt="Skjermbilde 2021-05-25 kl  11 36 57" src="https://user-images.githubusercontent.com/35545655/119475583-92535b80-bd4d-11eb-825b-3e176296a2dc.png">
<img width="816" alt="Skjermbilde 2021-05-25 kl  11 37 38" src="https://user-images.githubusercontent.com/35545655/119475673-a26b3b00-bd4d-11eb-8e8c-1a2f752a9de6.png">


