### PR TITLE
Update VOEC request example to use product id 'BUSINESS_PARCEL'.

### DIFF
--- a/content/api/booking/examples/customsImportDeclaration.json
+++ b/content/api/booking/examples/customsImportDeclaration.json
@@ -36,7 +36,7 @@
         }
       },
       "product": {
-        "id": "HOME_DELIVERY_PARCEL",
+        "id": "BUSINESS_PARCEL",
         "customerNumber": "PARCELS_NORWAY_INTERNATIONAL-***********",
         "messageForRecipient": null,
         "ediCustomsDeclarations": {


### PR DESCRIPTION
During testing, the former id 'HOME_DELIVERY_PARCEL' resulted in a HTTP 400.