### PR TITLE
Rename changelog to API updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,27 @@ The site is being improved throughout 2021. Ruby and Jekyll has been replaced
 with Hugo and Webpack. Structure, content and features are being worked on
 iteratively.
 
+## Publish an item in API updates
+
+Revision history and Changelog has been renamed to _API updates_ to better
+reflect that it covers past, current and upcoming changes.
+
+New items are added with publish date as the file name `yyyy-mm-dd.md` in the
+`conten/api/revision-history` folder with the following frontmatter:
+
+```
+---
+title: {Should at least contain the name of the API}
+publishDate: yyyy-mm-dd
+layout: api
+---
+```
+
+If the publish date is set in the future, either the branch must be merged or a
+build must be triggered at or after that point in time. In most cases, publish
+date is the same as change date, but if the message is about an upcoming change,
+the change date should be mentioned in the body text.
+
 ## Adding an important message to the frontpage
 
 Important messages are added as list items in the frontmatter of the frontpage
@@ -35,7 +56,7 @@ important:
     for unauthenticated requests
 ```
 
-Also keep in mind that the four latest items in the changelog are featured on
+Also keep in mind that the four latest items in the API updates are featured on
 the frontpage.
 
 ## Adding a new API

--- a/content/api/revision-history/_index.html
+++ b/content/api/revision-history/_index.html
@@ -1,9 +1,9 @@
 ---
-title: API changelog
+title: API updates
 layout: api
 notanapi: true
 menu:
   api:
-    title: API changelog
+    title: API updates
 weight: 5
 ---

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -76,6 +76,10 @@
   overflow-y: auto;
 }
 
+.changelog-small {
+  flex: 1 1 24rem;
+}
+
 @media screen and (max-width: 64em) {
   .dev-docs__menu {
     flex: 1 0 100%;

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -32,7 +32,7 @@
             </div>
           {{- end -}}
           <div class="mbxl">
-            <h2 class="mbs">API changelog</h2>
+            <h2 class="mbs">API updates</h2>
             {{- range where .Site.Pages "Section" "api" -}}
               {{- if (in .CurrentSection "revision-history") -}}
                 {{- range first 4 .Pages -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
               {{- end -}}
             {{- end -}}
             <div class="w100p mtl">
-              <a class="text-heading" href="./api/revision-history">View all changes &RightArrow;</a
+              <a class="text-heading" href="./api/revision-history">Show all updates &RightArrow;</a
               ><br />
               <a href="./api/revision-history/index.xml">Subscribe via RSS</a>
             </div>

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -2,7 +2,7 @@
   <p class="text-heading mbl">
     Important API changes and updates.<br /><a
       class="text-basic"
-      href="./index.xml"
+      href="index.xml"
       >Subscribe to updates via RSS.</a
     >
   </p>

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -1,20 +1,39 @@
 <section class="dev-docscontent__section">
   <p class="text-heading mbl">
-    Important API changes and updates. <br /><a
+    Important API changes and updates.<br /><a
       class="text-basic"
       href="./index.xml"
       >Subscribe to updates via RSS.</a
     >
   </p>
-  {{- range .Pages -}}
-    <div class="flex flex-dir-row-rev align-ic justify-cfe flex-wrap-reverse">
-      <h2 class="text-heading fwb mb0">{{ .Title }}</h2>
+  {{- range first 10 .Pages -}}
+  <div class="bg-gray1 pam mbxs">
+    <div class="flex flex-dir-col-rev">
+      <h2 class="text-heading fw600 mb0">{{ .Title }}</h2>
       <time
-        class="fwb text-heading mrs"
+        class="mrm text-note fw600"
         datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
         >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
       >
     </div>
     {{ .Content }}
+  </div>
   {{- end -}}
+
+  <div class="flex flex-wrap mtxs">
+  {{- range after 10 .Pages -}}
+  <div class="changelog-small bg-gray1 pam mbxs">
+    <div class="flex flex-dir-col-rev">
+      <h2 class="text-basic fw600 mb0">{{ .Title }}</h2>
+      <time
+        class="mrm text-note fw600"
+        datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+        >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
+      >
+    </div>
+    {{ .Content }}
+  </div>
+  {{- end -}}
+</div>
+
 </section>


### PR DESCRIPTION
Changelog has been renamed to _API updates_ to better reflect that it covers past, current and upcoming changes. The page layout also got a slight update to focus less on the dates.

The URL remains unchanged – too much hassle ATM to change it since we have an RSS feed using it.