### PR TITLE
updated Get report with compress request param and fixed typo

### DIFF
--- a/content/api/reports/api.raml
+++ b/content/api/reports/api.raml
@@ -241,10 +241,15 @@ types:
       type: string
       required: true
     mediaTypeExtension:
-      enum: [ .xls, .xml ]
-      description: Use .xls to get Excel file or .xml to get XML file.
+      enum: [ .xlsx, .xml ]
+      description: Use .xlsx to get Excel file or .xml to get XML file.
   get:
     description: Get report
+    queryParameters:
+      compress:
+        description: Get the XML report as a compressed ZIP archive.
+        type: boolean
+        required: false
     headers:
       Accept-Language:
         description: A comma-separated list of language codes, `no` for Norwegian, `en` for English, etc.


### PR DESCRIPTION
It is now possible to get a report as a compressed file. Added the request parameter for this to the documentation. 
There was also a typo in the endpoint for excel format which is now corrected. 