### PR TITLE
Service portfolio syntax adjustments

### DIFF
--- a/css/vas.css
+++ b/css/vas.css
@@ -2,6 +2,11 @@
     max-height: 24rem;
 }
 
+.pv\.75r {
+    padding-top: 0.75rem;
+    padding-bottom: 0.75rem;
+}
+
 .vas__item .dev-collapsible__toggler {
     padding: 0;
 }

--- a/css/vas.css
+++ b/css/vas.css
@@ -16,9 +16,12 @@
     visibility: hidden;
 }
 
-.vas__item--maxw66r {
-    max-width: 66rem;
-    flex-grow: 100;
+.vas-item__codes {
+    flex: 1 1 10rem;
+}
+
+.vas-item__tables {
+    flex: 15 1 30rem;
 }
 
 #vas-cutoff.cutoff-overlay {

--- a/css/vas.css
+++ b/css/vas.css
@@ -16,11 +16,11 @@
     visibility: hidden;
 }
 
-.vas-item__codes {
+.vas__codes {
     flex: 1 1 10rem;
 }
 
-.vas-item__tables {
+.vas__docs {
     flex: 15 1 30rem;
 }
 

--- a/css/vas.css
+++ b/css/vas.css
@@ -1,5 +1,5 @@
 .vasfilter {
-    max-height: 30rem;
+    max-height: 24rem;
 }
 
 .vas__item .dev-collapsible__toggler {

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -191,7 +191,7 @@
           <div class="flex flex-dir-col" id="allVas">
             {{- range $index, $vas := (sort $.Site.Data.services_vas "vasName") -}}
             <div class="vas__item bg-gray2 mbxs dev-collapsible">
-              <div class="dev-anchored" id="{{ $vas.vasName | urlize }}">
+              <div class="dev-anchored" id="{{ $vas.vasName|anchorize }}">
                 <button
                   data-collapse="#vas__item{{ $index }}"
                   class="btn-link fw600 pas w100p dev-collapsible__toggler--collapsed justify-cfs"

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -212,28 +212,31 @@
               <div class="mhxs mbxs phm pbm bg-white flex dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
                 <div class="w16r">
                   <div class="mtm">
-                    <span class="text-note fwb">API request codes</span>
-                    <dl class="bl b--gray4 pls mts">
+                    <span class="text-note fw600">API request codes</span>
+                    <dl class="text-note bl mb-border pls mtxs">
                       <div>
-                        <span class="text-note">Booking: <span class="fwn mb-badge paxs"><code data-filter="bookcode">{{ $vas.bookingCode }}</code></span></span>
+                        <dt class="fwn di mrxs">Booking:</dt>
+                        <dd class="di"><code data-filter="bookcode">{{ $vas.bookingCode }}</code></dd>
                       </div>
                       <div>
-                        <span class="text-note">Shipping Guide: <span class="fwn mb-badge paxs"><code data-filter="sgcode">{{ $vas.shippingGuideNpbCode }}</code></span></span>
+                        <dt class="fwn di mrxs">Shipping Guide:</dt>
+                        <dd class="di"><code data-filter="sgcode">{{ $vas.shippingGuideNpbCode }}</code></dd>
                       </div>
                       {{ if ne $vas.shippingGuideCode $vas.shippingGuideNpbCode }}
                       <div>
-                        <span class="text-note">Shipping Guide (<span class="fsi">legacy</span>): <span class="fwn mb-badge paxs"><code data-filter="sgcode">{{ $vas.shippingGuideCode }}</code></span></span>
+                        <dt class="fwn di mrxs">Shipping Guide (<span class="fsi">legacy</span>):</dt>
+                        <dd class="di"><code data-filter="sgcode">{{ $vas.shippingGuideCode }}</code></dd>
                       </div>
                       {{ end }}
                     </dl>
                   </div>
                   {{ if ($vas.incompatibleVases) }}
                   <div class="mtm">
-                    <span class="text-note fwb">Incompatible with</span>
-                    <dl class="bl b--gray4 pls mts">
+                    <span class="text-note fw“600">Incompatible with</span>
+                    <dl class="bl mb-border pls mtxs">
                       {{- range $vas.incompatibleVases -}}
                       <div>
-                        <a href="#{{ . }}"><span class="text-note">{{ . }}</span></a>
+                        <a href="#{{ . | anchorize }}"><span class="text-note">{{ . }}</span></a>
                       </div>
                       {{- end -}}
                     </dl>

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -210,7 +210,7 @@
                 </button>
               </div>
               <div class="mhxs mbxs phm pbm bg-white flex flex-wrap dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
-                <div class="vas-item__codes mrm">
+                <div class="vas__codes mrm">
                   <div class="mtm">
                     <span class="text-note fw600">API request codes</span>
                     <dl class="text-note bl mb-border pls mtxs">
@@ -243,7 +243,7 @@
                   </div>
                   {{ end }}
                 </div>
-                <div class="vas-item__tables ptm">
+                <div class="vas__docs ptm">
                   <p>
                     {{ $vas.description }}
                   </p>

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -168,7 +168,7 @@
               </label>
               <button class="btn-link--dark mtl mlr dn" id="clearfilters">Clear filters</button>
             </div>
-            <div id="filtersets" class="bg-gray1 plm pbm">
+            <div id="filtersets" class="bg-gray1 phm pbm">
 
               {{- $.Scratch.Add "servicetype" slice -}}
               {{- $.Scratch.Add "servicefamily" slice -}}
@@ -188,15 +188,13 @@
             </div>
           </div>
 
-          <div class="flex-auto flex-wrap" id="allVas">
+          <div class="flex flex-dir-col" id="allVas">
             {{- range $index, $vas := (sort $.Site.Data.services_vas "vasName") -}}
-            <div class="vas__item bg-gray2 pas mbxs mrxs dev-collapsible">
-              <div class="dev-anchored" id="{{ $vas.vasName }}">
-                <a
-                  href="#"
+            <div class="vas__item bg-gray2 mbxs dev-collapsible">
+              <div class="dev-anchored" id="{{ $vas.vasName | urlize }}">
+                <button
                   data-collapse="#vas__item{{ $index }}"
-                  class="dev-collapsible__toggler dev-collapsible__toggler--collapsed"
-                  style="background: transparent; padding: 0;"
+                  class="btn-link fw600 pas w100p dev-collapsible__toggler--collapsed justify-cfs"
                 >
                   <svg
                     class="dev-collapsible__toggler__icon"
@@ -208,10 +206,10 @@
                       d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
                     ></path>
                   </svg>
-                  <h4 data-filter="name">{{ $vas.vasName }}</h4>
-                </a>
+                  <span data-filter="name">{{ $vas.vasName }}</span>
+                </button>
               </div>
-              <div class="plm pbm bg-white mts flex dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
+              <div class="mhxs mbxs phm pbm bg-white flex dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
                 <div class="w16r">
                   <div class="mtm">
                     <span class="text-note fwb">API request codes</span>

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -194,7 +194,7 @@
               <div class="dev-anchored" id="{{ $vas.vasName|anchorize }}">
                 <button
                   data-collapse="#vas__item{{ $index }}"
-                  class="btn-link fw600 pas w100p dev-collapsible__toggler--collapsed justify-cfs"
+                  class="btn-link fw600 pv.75r phs w100p dev-collapsible__toggler--collapsed justify-cfs"
                 >
                   <svg
                     class="dev-collapsible__toggler__icon"

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -249,12 +249,10 @@
                   <div class="text-basic pvm">{{ . }}</div>
                   {{- end -}}
                   {{ end }}
-                  <div class="rad-a2px">
-                    <a
-                      href="#"
+                  <div>
+                    <button
                       data-collapse="#vascountry{{ $index }}"
-                      class="dev-collapsible__toggler dev-collapsible__toggler--collapsed pa0"
-                      style="background: transparent"
+                      class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
                     ><svg
                       class="dev-collapsible__toggler__icon"
                       width="16"
@@ -265,8 +263,8 @@
                         d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
                       ></path>
                     </svg>
-                      <h5 class="mts">Supported services & countries</h5>
-                    </a>
+                      <span>Supported services & countries</span>
+                    </button>
                     <div class="dev-collapsible__item--collapsed pas" id="vascountry{{ $index }}" style="background: white">
                       <table class="vascountry">
                         <thead>
@@ -303,12 +301,10 @@
                   <div>
                     {{- range where $.Site.Data.examples "api" "booking" -}}
                     {{- range where .vas "id" $vas.bookingCode -}}
-                    <div class="rad-a2px">
-                      <a
-                        href="#"
+                    <div>
+                      <button
                         data-collapse="#example{{ $vas.bookingCode }}"
-                        class="dev-collapsible__toggler dev-collapsible__toggler--collapsed"
-                        style="background: transparent"
+                        class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
                       ><svg
                         class="dev-collapsible__toggler__icon"
                         width="16"
@@ -319,8 +315,8 @@
                           d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
                         ></path>
                       </svg>
-                        <h5 class="mts">Booking API request examples</h5>
-                      </a>
+                        <span>Booking API request examples</span>
+                    </button>
                       <div class="dev-collapsible__item--collapsed pas pt0" id="example{{ $vas.bookingCode }}">
                         {{ if (.html) }}
                         <div class="pam">

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -281,7 +281,7 @@
                         <tbody>
                         {{- range .supportedServices -}}
                         <tr class="vascountryrow">
-                          <td class="maxw16r">{{ .serviceName }} (<span class="mb-badge paxs"><code>{{ .serviceCode }}</code></span>)</td>
+                          <td class="maxw16r">{{ .serviceName }} (<code class="bg-gray3">{{ .serviceCode }}</code>)</td>
                           <td data-filter="type" hidden>{{ .serviceType }}</td>
                           <td data-filter="family" hidden>{{ .serviceFamily }}</td>
                           <td data-filter="service" hidden>{{ .serviceCode }}</td>

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -370,6 +370,9 @@
         {{- end -}}
 
         {{ if in .title "Reports" }}
+          <p class="mtm mbl">
+            <a href="/services/service_portfolio.xlsx" class="btn-link--dark mrm di">Download spreadsheet</a>Information applies to revised services only.
+          </p>
           <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
             <div class="mrl">
               <div class="flex flex-wrap-reverse align-ifs">

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -209,8 +209,8 @@
                   <span data-filter="name">{{ $vas.vasName }}</span>
                 </button>
               </div>
-              <div class="mhxs mbxs phm pbm bg-white flex dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
-                <div class="w16r">
+              <div class="mhxs mbxs phm pbm bg-white flex flex-wrap dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
+                <div class="vas-item__codes mrm">
                   <div class="mtm">
                     <span class="text-note fw600">API request codes</span>
                     <dl class="text-note bl mb-border pls mtxs">
@@ -232,7 +232,7 @@
                   </div>
                   {{ if ($vas.incompatibleVases) }}
                   <div class="mtm">
-                    <span class="text-note fw“600">Incompatible with</span>
+                    <span class="text-note fw600">Incompatible with</span>
                     <dl class="bl mb-border pls mtxs">
                       {{- range $vas.incompatibleVases -}}
                       <div>
@@ -243,16 +243,16 @@
                   </div>
                   {{ end }}
                 </div>
-                <div class="vas__item--maxw66r mlm">
-                  <div class="text-basic pvm">
+                <div class="vas-item__tables ptm">
+                  <p>
                     {{ $vas.description }}
-                  </div>
+                  </p>
                   {{ if gt (len .vasFootNotes) 0 }}
                   {{- range .vasFootNotes -}}
-                  <div class="text-basic pvm">{{ . }}</div>
+                  <p>{{ . }}</p>
                   {{- end -}}
                   {{ end }}
-                  <div>
+                  <div class="mbs">
                     <button
                       data-collapse="#vascountry{{ $index }}"
                       class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
@@ -268,7 +268,7 @@
                     </svg>
                       <span>Supported services & countries</span>
                     </button>
-                    <div class="dev-collapsible__item--collapsed pas" id="vascountry{{ $index }}" style="background: white">
+                    <div class="dev-collapsible__item--collapsed pas" id="vascountry{{ $index }}">
                       <table class="vascountry">
                         <thead>
                         <tr class="vascountryrow">
@@ -301,10 +301,9 @@
                       {{ end }}
                     </div>
                   </div>
-                  <div>
-                    {{- range where $.Site.Data.examples "api" "booking" -}}
+                  {{- range where $.Site.Data.examples "api" "booking" -}}
                     {{- range where .vas "id" $vas.bookingCode -}}
-                    <div>
+                    <div class="mbs">
                       <button
                         data-collapse="#example{{ $vas.bookingCode }}"
                         class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
@@ -355,8 +354,7 @@
                       </div>
                     </div>
                     {{- end -}}
-                    {{- end -}}
-                  </div>
+                  {{- end -}}
                 </div>
               </div>
             </div>

--- a/layouts/partials/api/vasfilter.html
+++ b/layouts/partials/api/vasfilter.html
@@ -1,6 +1,6 @@
 {{ $filter := .filter }}
-<fieldset class="flex-dir-col mbm mlm bg-white pam bshadow" id="{{ $filter }}" hidden>
-  <div {{ if gt (len (uniq .scratcher)) 10 }} class="flex flex-wrap flex-dir-col vasfilter justify-cse" {{ end }}>
+<fieldset class="flex-dir-col mbm mhm bg-white pam bshadow" id="{{ $filter }}" hidden>
+  <div {{ if gt (len (uniq .scratcher)) 10 }} class="flex flex-wrap flex-dir-col vasfilter" {{ end }}>
     {{- range .scratcher }}
     {{ if and (ne .name "-") (ne .name "") }}
     <div>

--- a/static/js/servicefiltering-bsg.js
+++ b/static/js/servicefiltering-bsg.js
@@ -11,7 +11,7 @@ const bsgCutoffBtn = bsgCutoff.querySelector("button")
 // Initial cutoff
 function bsgTableCutoff() {
   bsgRows.forEach((row, i) => {
-    if (i > 7) {
+    if (i > 5) {
       row.hidden = true
     }
   })

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -10,7 +10,7 @@ const showAll = document.querySelector("#showAll")
 
 function vasTableCutoff() {
   rows.forEach((row, i) => {
-    if (i > 12) {
+    if (i > 10) {
       row.hidden = true
     }
   })

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -10,7 +10,7 @@ const showAll = document.querySelector("#showAll")
 
 function vasTableCutoff() {
   rows.forEach((row, i) => {
-    if (i > 7) {
+    if (i > 12) {
       row.hidden = true
     }
   })


### PR DESCRIPTION
This mainly turns `a` elements that aren’t links into buttons and anchorizes ids used as anchors.

Linking to each one is still buggy as the cutoff is in the way and the items don’t open (and elements above the item that is supposed to be opened becomes unclickable). But that’s a separate task to fix.