### PR TITLE
Show VAS sections when anchor links clicked

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -6,12 +6,12 @@
   height: 100%;
 }
 
-.dev-anchored:target::before {
+/*.dev-anchored:target::before {
   content: "";
   display: block;
   height: 6.5rem;
   margin: -6.5rem 0 0;
-}
+}*/
 
 .dev-docs__page {
   display: flex;

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -6,12 +6,12 @@
   height: 100%;
 }
 
-/*.dev-anchored:target::before {
+.dev-anchored:not(#allVas *):target::before {
   content: "";
   display: block;
   height: 6.5rem;
   margin: -6.5rem 0 0;
-}*/
+}
 
 .dev-docs__page {
   display: flex;

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -209,7 +209,7 @@
                   <span data-filter="name">{{ $vas.vasName }}</span>
                 </button>
               </div>
-              <div class="mhxs mbxs phm pbm bg-white flex flex-wrap dev-collapsible__item--collapsed" id="vas__item{{ $index }}">
+              <div class="mhxs mbxs phm pbm bg-white flex flex-wrap dev-collapsible__item--collapsed" id="vas__item{{ $index }}" data-vas-element>
                 <div class="vas__codes mrm">
                   <div class="mtm">
                     <span class="text-note fw600">API request codes</span>

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,4 +1,4 @@
-<header class="dev-siteheader">
+<header class="dev-siteheader" data-siteheader>
   <a class="skip-to-content-link" href="#main">
   Skip to main content
   </a>

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -20,6 +20,10 @@ function vasHideCutoffs() {
   vasCutoff.hidden = true
 }
 
+function vasShowCutoffs() {
+  vasCutoff.hidden = false
+}
+
 function clearFilters() {
   vasHideCutoffs()
   const activeBtn = document.querySelector("[data-filterbtn].active")
@@ -172,6 +176,53 @@ filterBtns.forEach((filterBtn) => {
   })
 })
 
+function scrollToVasTarget(targetElement){
+  const element = document.getElementById(targetElement);
+  const headerOffset = document.querySelector('.dev-siteheader').offsetHeight + 20;
+  const elementPosition = element.getBoundingClientRect().top;
+  const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+
+  const vasBtnParent = document.getElementById(targetElement).parentElement
+    
+  const vasBtnToggler = vasBtnParent.querySelector('.dev-collapsible__toggler')
+  vasBtnToggler.classList.remove('dev-collapsible__toggler--collapsed')
+  vasBtnToggler.classList.add('dev-collapsible__toggler--expanded')
+
+  const vasItemContent = vasBtnParent.querySelector('.dev-collapsible__item--collapsed')
+  vasItemContent.classList.remove('dev-collapsible__item--collapsed')
+  vasItemContent.classList.add('dev-collapsible__item--expanded')
+
+  window.scrollTo({
+       top: offsetPosition,
+       behavior: "smooth"
+  })
+}
+
 document.addEventListener("DOMContentLoaded", function () {
-  vasTableCutoff()
+  const anchorTag = window.location.hash
+  
+  if(anchorTag) {
+    const cleanHashTag = anchorTag.replace(/#/,'')
+    const cleanAnchorTag = cleanHashTag.replace(/%20/g, ' ')
+
+    vasHideCutoffs()
+    setTimeout(function() {
+      scrollToVasTarget(cleanAnchorTag)
+    },100)
+  } else {
+    vasTableCutoff()
+    vasShowCutoffs()
+  }
+
+  const anchors = document.querySelectorAll('.anchorjs-link')
+  anchors.forEach(anchor => {
+    anchor.addEventListener('click', function() {
+      const anchorId = this.getAttribute('href')
+      const anchorParent = document.getElementById(anchorId.replace(/#/,'')).getAttribute('id')
+      setTimeout(function() {
+        scrollToVasTarget(anchorParent)
+      },100)
+    })
+  })
+  
 })

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -173,14 +173,14 @@ filterBtns.forEach((filterBtn) => {
 })
 
 function scrollToVasTarget(targetElement){
-  const element = document.getElementById(targetElement);
-  const headerOffset = document.querySelector('.dev-siteheader').offsetHeight + 20;
-  const elementPosition = element.getBoundingClientRect().top;
-  const offsetPosition = elementPosition + window.pageYOffset - headerOffset;
+  const element = document.getElementById(targetElement)
+  const headerOffset = document.querySelector('.dev-siteheader').offsetHeight + 20
+  const elementPosition = element.getBoundingClientRect().top
+  const offsetPosition = elementPosition + window.pageYOffset - headerOffset
 
-  const vasBtnParent = document.getElementById(targetElement).parentElement
+  const vasBtnParent = element.parentElement
     
-  const vasBtnToggler = vasBtnParent.querySelector('.dev-collapsible__toggler')
+  const vasBtnToggler = vasBtnParent.querySelector('[data-collapse]')
   vasBtnToggler.classList.remove('dev-collapsible__toggler--collapsed')
   vasBtnToggler.classList.add('dev-collapsible__toggler--expanded')
 
@@ -202,9 +202,10 @@ document.addEventListener("DOMContentLoaded", function () {
     const cleanAnchorTag = cleanHashTag.replace(/%20/g, ' ')
 
     vasHideCutoffs()
+    //Delay added for Chrome so window.scrollTo event will be triggered
     setTimeout(function() {
       scrollToVasTarget(cleanAnchorTag)
-    },200)
+    },100)
   } else {
     vasTableCutoff()
   }
@@ -216,7 +217,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const anchorParent = document.getElementById(anchorId.replace(/#/,'')).getAttribute('id')
       setTimeout(function() {
         scrollToVasTarget(anchorParent)
-      },200)
+      },100)
     })
   })
 

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -20,10 +20,6 @@ function vasHideCutoffs() {
   vasCutoff.hidden = true
 }
 
-function vasShowCutoffs() {
-  vasCutoff.hidden = false
-}
-
 function clearFilters() {
   vasHideCutoffs()
   const activeBtn = document.querySelector("[data-filterbtn].active")
@@ -211,7 +207,6 @@ document.addEventListener("DOMContentLoaded", function () {
     },100)
   } else {
     vasTableCutoff()
-    vasShowCutoffs()
   }
 
   const anchors = document.querySelectorAll('.anchorjs-link')
@@ -224,5 +219,5 @@ document.addEventListener("DOMContentLoaded", function () {
       },100)
     })
   })
-  
+
 })

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -174,7 +174,7 @@ filterBtns.forEach((filterBtn) => {
 
 function scrollToVasTarget(targetElement){
   const element = document.getElementById(targetElement)
-  const headerOffset = document.querySelector('.dev-siteheader').offsetHeight + 20
+  const headerOffset = document.querySelector('[data-siteheader]').offsetHeight + 20
   const elementPosition = element.getBoundingClientRect().top
   const offsetPosition = elementPosition + window.pageYOffset - headerOffset
 
@@ -184,7 +184,7 @@ function scrollToVasTarget(targetElement){
   vasBtnToggler.classList.remove('dev-collapsible__toggler--collapsed')
   vasBtnToggler.classList.add('dev-collapsible__toggler--expanded')
 
-  const vasItemContent = vasBtnParent.querySelector('.dev-collapsible__item--collapsed')
+  const vasItemContent = vasBtnParent.querySelector('[data-vas-element]')
   vasItemContent.classList.remove('dev-collapsible__item--collapsed')
   vasItemContent.classList.add('dev-collapsible__item--expanded')
 

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -198,8 +198,7 @@ document.addEventListener("DOMContentLoaded", function () {
   const anchorTag = window.location.hash
   
   if(anchorTag) {
-    const cleanHashTag = anchorTag.replace(/#/,'')
-    const cleanAnchorTag = cleanHashTag.replace(/%20/g, ' ')
+    const cleanAnchorTag = anchorTag.replace(/#/,'')
 
     vasHideCutoffs()
     //Delay added for Chrome so window.scrollTo event will be triggered

--- a/static/js/servicefiltering-vas.js
+++ b/static/js/servicefiltering-vas.js
@@ -204,7 +204,7 @@ document.addEventListener("DOMContentLoaded", function () {
     vasHideCutoffs()
     setTimeout(function() {
       scrollToVasTarget(cleanAnchorTag)
-    },100)
+    },200)
   } else {
     vasTableCutoff()
   }
@@ -216,7 +216,7 @@ document.addEventListener("DOMContentLoaded", function () {
       const anchorParent = document.getElementById(anchorId.replace(/#/,'')).getAttribute('id')
       setTimeout(function() {
         scrollToVasTarget(anchorParent)
-      },100)
+      },200)
     })
   })
 


### PR DESCRIPTION
- Expand VAS element and scroll to it if anchor link is clicked
- If URL contains anchor link, automatically display the whole VAS table, hide the cut-off, scroll to that VAS element by its ID, and expand that VAS element