### PR TITLE
Text changes and add icons to portfolio buttons

### DIFF
--- a/content/api/dns-api-bring-com/_index.html
+++ b/content/api/dns-api-bring-com/_index.html
@@ -20,8 +20,8 @@ weight: 4
   <h2>Upcoming change</h2>
 
   <p>
-    At <strong>1st of April</strong> we will switch DNS for <code>api.bring.com</code> to point to a new
-    load balancer component. This change will have the following affects:
+    At <strong>1st of April 2022</strong> we will switch DNS for <code>api.bring.com</code> to point to a new
+    load balancer component. This change will have the following effects:
   </p>
 
   <ul>
@@ -82,10 +82,10 @@ weight: 4
   <h2>Time schedule</h2>
 
   <ul>
-    <li><strong>Today:</strong> DNS <code>api-new.bring.com</code> is available for customers to use.</li>
-    <li><strong>January - March:</strong> Customers switch towards <code>api-new.bring.com</code>.</li>
+    <li><strong>December 2021:</strong> DNS <code>api-new.bring.com</code> is available for customers to use.</li>
+    <li><strong>January-March:</strong> Customers switch towards <code>api-new.bring.com</code>.</li>
     <li><strong>1st of April:</strong> Bring changes DNS for <code>api.bring.com</code>.</li>
-    <li><strong>April - June:</strong> Customers switch back towards <code>api.bring.com</code>.</li>
+    <li><strong>April–June:</strong> Customers switch back towards <code>api.bring.com</code>.</li>
     <li><strong>4th of July:</strong> Bring removes the temporary DNS <code>api-new.bring.com</code>.</li>
   </ul>
 

--- a/content/api/shipment/index.md
+++ b/content/api/shipment/index.md
@@ -10,24 +10,30 @@ menu:
     parent: book
 weight: 22
 
-documentation:
-  - title: Introduction
-    content: |
-      The Shipment API is a logged-in service that lets Mybring users (customers of Mybring) programatically create a instruction or a booking by invoking a Web Service by posting XML/JSON over HTTP.
+introduction: |
+  The Shipment API is used to book shipments and send transport instructions to Bring. For customers using EDIFACT today, switching to the Shipment API is a good alternative when implementing new automated order solutions. The API supports the majority of services in Bring's service portfolio and offers options to both create, update and delete bookings and instructions. You may use your own SSCC-compliant labels and your own shipment number series. Using the API requires a good knowledge of Bring's service portfolio and logistics value chain as the level of content validation is low [compared to the Booking API](/api/booking-shipment/).
 
-      The Shipment API uses Shipping Guide as the source for price and availability (when supported in the Shipping Guide) for the different products. We advise clients of the Shipment API to use Shipping Guide API for getting the list price and checking availability before sending a booking request. Note that invoice payment is the only available payment option for the Shipment API. This means that the Mybring user ID used in the booking request must have access to the customer number specified as payer of the booking.
-
-      We are continually rolling out support for more of Posten / Brings products and aim to support all available products in this API within a short time. In addition to the documentation on this pages feel free to check out our [swagger page](https://bapiqa.bring.com/Shipment/swagger) for this API.
-
-      This API has similarities with the Booking API, but there are differences. Read more about the [differences between the Booking API and the Shipment API](/api/booking-shipment/).
-
+information:
   - title: Authentication
     content: |
       To make API requests, you will need an API key from Mybring. Steps for getting a key and description of headers can be found on the general API [Getting Started / Authentication](/api/#authentication) page.
 
-  - title: ShipmentAPI Instructions
+  - title: Formats
     content: |
-      A submission to ShipmentAPI must have a ShipmentType of one of the following
+      REST XML/JSON over HTTP.
+
+documentation:
+  - title:
+    content: |
+      In addition to the documentation on this pages feel free to check out our [swagger page](https://bapiqa.bring.com/Shipment/swagger) for this API.
+
+  - title: Checking prices and availability
+    content: |
+      The Shipment API uses Shipping Guide as the source for price and availability (when supported in the Shipping Guide) for the different products. We advise clients of the Shipment API to use [Shipping Guide API](/api/shipping-guide_2/) for getting the list price and checking availability before sending a booking request. Note that invoice payment is the only available payment option for the Shipment API. This means that the Mybring user ID used in the booking request must have access to the customer number specified as payer of the booking.
+
+  - title: Shipment API Instructions
+    content: |
+      A submission to Shipment API must have a ShipmentType of one of the following
       - [Instruction](/api/shipment/#create-shipment)
       - [Booking](/api/shipment/#create-shipment-booking)
       - Healthcheck
@@ -38,7 +44,7 @@ documentation:
 
   - title: Unit Codes
     content: |
-      A number of different unit codes are used throughout ShipmentAPI. Many of which are listed in the layouts below but the definative list is displayed here for ease of reference.
+      A number of different unit codes are used throughout Shipment API. Many of which are listed in the layouts below but the definative list is displayed here for ease of reference.
       #### Cash On Delivery Account Type
       - Bank
       - Bankgiro

--- a/content/api/testing.html
+++ b/content/api/testing.html
@@ -25,14 +25,17 @@ disqus_identifier: https-developer-bring-com-api-testing
 
   <div class="bg-gray1 phl pvm mbm">
     <p>
-      For users in Norway, contact
+      In order to get access to test customer numbers, users in Norway can
+      contact
       <a href="mailto:integrasjon.norge@bring.com"
         >integrasjon.norge@bring.com</a
-      >; for other countries, contact
-      <a href="mailto:edi@bring.com">edi@bring.com</a>. State which test customer you
-      want access to and that you need financial rights as well. Financial
-      rights are required to get pricing information when using
-      <a href='{{< relref "shipping-guide_2" >}}'>Shipping Guide API 2.0</a>. The services covered by each number can be found in the <a href='{{< relref "services" >}}'>Service Portfolio</a>.
+      >. Users in Sweden, Denmark and Finland can contact
+      <a href="mailto:edi@bring.com">edi@bring.com</a>. State which test
+      customer number you want access to, and that you need financial rights as
+      well. Financial rights are required to get pricing information when using
+      <a href='{{< relref "shipping-guide_2" >}}'>Shipping Guide API 2.0</a>.
+      The services covered by each test customer number can be found in the
+      <a href='{{< relref "services" >}}'>Service Portfolio</a>.
     </p>
 
     <dl>

--- a/content/api/warehousing/index.md
+++ b/content/api/warehousing/index.md
@@ -16,6 +16,18 @@ important:
       **Please note:** Our Warehousing APIs are changing. Please contact our sales department <a
       href="mailto:bwsalg@bring.com">bwsalg@bring.com</a> for a correct documentation version
 
+introduction: |
+  The Warehousing API is used to submit order and article information to Bring's warehouses. Users are also able to extract detailed order information from our warehouse while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.
+
+information:
+  - title: Authentication
+    content: |
+      To make API requests, you will need an API key from Mybring. Steps for getting a key and description of headers can be found on the general API [Getting Started / Authentication](/api/#authentication) page.
+
+  - title: Formats
+    content: |
+      REST XML/JSON and SOAP over HTTP. This API doesn't support JSON for all methods yet. Look in the example section to see which are supported.
+
 documentation:
   - title: Introduction
     content: |
@@ -32,10 +44,6 @@ documentation:
       We make an effort not to return new elements in the response when an old schema version is specified. When changes in the schema are made, the SchemaVersion is incremented by one. The new schema is used at the same endpoint URL as before and uses the same namespace for its XML elements. A TraceMessage element (info message) in the response is added to inform the client that its schema should be updated. Old schema versions might in the future be unsupported.
 
       Regarding the XML API (not Web Services), an XML Schema is not used at all. Therefore, clients of the XML API are expected to handle new elements that appear. Nevertheless, the response will be backwards compatible in the sense that elements are not renamed or deleted.
-
-  - title: Authentication
-    content: |
-      To make API requests, you will need an API key from Mybring. Steps for getting a key and description of headers can be found on the general API [Getting Started / Authentication](/api/#authentication) page.
 
   - title: SOAP
     content: |

--- a/css/collapsible.css
+++ b/css/collapsible.css
@@ -20,7 +20,8 @@
     fill: var(--gray-60);
     transition: transform var(--easeout-15);
   }
-  .dev-collapsible__toggler--expanded .dev-collapsible__toggler__icon {
+  .dev-collapsible__toggler--expanded .dev-collapsible__toggler__icon, 
+  .active .dev-collapsible__toggler__icon {
     transform: rotate(90deg);
   }
   .dev-collapsible__toggler:hover::after {

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -30,9 +30,9 @@
                 <div class="mrl">
                   <p class="form__label">Filter by</p>
                   <div class="btngroup">
-                    <button class="btn btn--white" data-bsgfilterbtn="type">Service type</button>
-                    <button class="btn btn--white" data-bsgfilterbtn="family">Service family</button>
-                    <button class="btn btn--white" data-bsgfilterbtn="cntype">Customer number type</button>
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-bsgfilterbtn='type'" "btnText" "Service type") -}}
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-bsgfilterbtn='family'" "btnText" "Service family") -}}
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-bsgfilterbtn='cntype'" "btnText" "Customer number type") -}}
                   </div>
                 </div>
                 <label class="form__label" for="bsg-textfilter">
@@ -157,9 +157,9 @@
               <div class="mrl">
                 <p class="form__label">Filter by</p>
                 <div class="btngroup">
-                  <button class="btn btn--white" data-filterbtn="service">Service</button>
-                  <button class="btn btn--white" data-filterbtn="type">Service type</button>
-                  <button class="btn btn--white" data-filterbtn="family">Service family</button>
+                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='service'" "btnText" "Service") -}}
+                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='type'" "btnText" "Service type") -}}
+                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='family'" "btnText" "Service family") -}}
                 </div>
               </div>
               <label class="form__label mrxl" for="vasfilter">
@@ -366,9 +366,9 @@
                 <div class="mrl">
                   <p class="form__label">Filter by</p>
                   <div class="btngroup">
-                    <button class="btn btn--white" data-rifilterbtn="rifamily">Service family</button>
-                    <button class="btn btn--white" data-rifilterbtn="riapi">API</button>
-                    <button class="btn btn--white" data-rifilterbtn="rireptype">Report type</button>
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-rifilterbtn='rifamily'" "btnText" "Service family") -}}
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-rifilterbtn='riapi'" "btnText" "API") -}}
+                    {{- partial "filterbtn.html" (dict "dataAtt" "data-rifilterbtn='rireptype'" "btnText" "Report type") -}}
                   </div>
                 </div>
                 <label class="form__label" for="ri-textfilter">

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -22,7 +22,14 @@
         <h2 class="dev-anchored mrl" id="{{ .title|anchorize }}" >{{ .title }}</h2>
         {{ if in .title "Booking" }}
           <p class="mtm mbl">
-            <a href="/services/service_portfolio.xlsx" class="btn-link--dark mrm di">Download spreadsheet</a>Information applies to revised services only.
+            <a href='{{ "/services/service_portfolio.xlsx" | relURL }}' class="btn-link--dark mrm di">
+            <span
+              data-mybicon="mybicon-download_file"
+              data-mybicon-class="icon-ui mrxs"
+              data-mybicon-width="16"
+              data-mybicon-height="16"
+            ></span>Download spreadsheet</a>
+            Information applies to revised services only.
           </p>
           <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
             <div class="mrl">
@@ -358,7 +365,14 @@
 
         {{ if in .title "Reports" }}
           <p class="mtm mbl">
-            <a href="/services/service_portfolio.xlsx" class="btn-link--dark mrm di">Download spreadsheet</a>Information applies to revised services only.
+            <a href='{{ "/services/service_portfolio.xlsx" | relURL }}' class="btn-link--dark mrm di">
+              <span
+                data-mybicon="mybicon-download_file"
+                data-mybicon-class="icon-ui mrxs"
+                data-mybicon-width="16"
+                data-mybicon-height="16"
+              ></span>Download spreadsheet</a>
+              Information applies to revised services only.
           </p>
           <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
             <div class="mrl">

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -196,16 +196,12 @@
                   data-collapse="#vas__item{{ $index }}"
                   class="btn-link fw600 pv.75r phs w100p dev-collapsible__toggler--collapsed justify-cfs"
                 >
-                  <svg
-                    class="dev-collapsible__toggler__icon"
-                    width="16"
-                    height="16"
-                    viewBox="0 0 320 512"
-                  >
-                    <path
-                      d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-                    ></path>
-                  </svg>
+                  <span
+                    data-mybicon="mybicon-arrow-right"
+                    data-mybicon-class="dev-collapsible__toggler__icon"
+                    data-mybicon-width="16"
+                    data-mybicon-height="16"
+                  ></span>
                   <span data-filter="name">{{ $vas.vasName }}</span>
                 </button>
               </div>
@@ -256,16 +252,13 @@
                     <button
                       data-collapse="#vascountry{{ $index }}"
                       class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
-                    ><svg
-                      class="dev-collapsible__toggler__icon"
-                      width="16"
-                      height="16"
-                      viewBox="0 0 320 512"
                     >
-                      <path
-                        d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-                      ></path>
-                    </svg>
+                      <span
+                        data-mybicon="mybicon-arrow-right"
+                        data-mybicon-class="dev-collapsible__toggler__icon"
+                        data-mybicon-width="16"
+                        data-mybicon-height="16"
+                      ></span>
                       <span>Supported services & countries</span>
                     </button>
                     <div class="dev-collapsible__item--collapsed pas" id="vascountry{{ $index }}">
@@ -307,16 +300,13 @@
                       <button
                         data-collapse="#example{{ $vas.bookingCode }}"
                         class="btn-link text-note fw600 dev-collapsible__toggler--collapsed"
-                      ><svg
-                        class="dev-collapsible__toggler__icon"
-                        width="16"
-                        height="16"
-                        viewBox="0 0 320 512"
                       >
-                        <path
-                          d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-                        ></path>
-                      </svg>
+                        <span
+                          data-mybicon="mybicon-arrow-right"
+                          data-mybicon-class="dev-collapsible__toggler__icon"
+                          data-mybicon-width="16"
+                          data-mybicon-height="16"
+                        ></span>
                         <span>Booking API request examples</span>
                     </button>
                       <div class="dev-collapsible__item--collapsed pas pt0" id="example{{ $vas.bookingCode }}">

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -241,16 +241,13 @@
                             href="#"
                             data-collapse="#{{ $exampleID }}"
                             class="dev-collapsible__toggler dev-collapsible__toggler--collapsed"
-                            ><svg
-                              class="dev-collapsible__toggler__icon"
-                              width="16"
-                              height="16"
-                              viewBox="0 0 320 512"
                             >
-                              <path
-                                d="M285.476 272.971L91.132 467.314c-9.373 9.373-24.569 9.373-33.941 0l-22.667-22.667c-9.357-9.357-9.375-24.522-.04-33.901L188.505 256 34.484 101.255c-9.335-9.379-9.317-24.544.04-33.901l22.667-22.667c9.373-9.373 24.569-9.373 33.941 0L285.475 239.03c9.373 9.372 9.373 24.568.001 33.941z"
-                              ></path>
-                            </svg>
+                            <span
+                              data-mybicon="mybicon-arrow-right"
+                              data-mybicon-class="dev-collapsible__toggler__icon"
+                              data-mybicon-width="16"
+                              data-mybicon-height="16"
+                            ></span>
                             <span>{{ .displayName }}</span>
                           </a>
                           <div

--- a/layouts/partials/filterbtn.html
+++ b/layouts/partials/filterbtn.html
@@ -1,0 +1,10 @@
+
+<button class="btn btn--white flex align-ic" {{ .dataAtt | safeHTMLAttr }}>
+  <span
+    data-mybicon="mybicon-arrow-right"
+    data-mybicon-class="dev-collapsible__toggler__icon"
+    data-mybicon-width="16"
+    data-mybicon-height="16"
+  ></span>
+  {{ .btnText }}
+</button>

--- a/layouts/partials/filterbtn.html
+++ b/layouts/partials/filterbtn.html
@@ -1,4 +1,3 @@
-
 <button class="btn btn--white flex align-ic" {{ .dataAtt | safeHTMLAttr }}>
   <span
     data-mybicon="mybicon-arrow-right"


### PR DESCRIPTION
- Add intro texts to Shipment and Warehousing APIs, and give them the same structure as the APIs owned by Mybring teams.
- Update texts on testing and DNS page
- Add icons to filter and download buttons, and extracts the filter buttons to a reusable partial template

<img width="640" alt="Screenshot 2022-01-21 at 21 10 55" src="https://user-images.githubusercontent.com/9307503/150593687-2121da69-b6b3-4bbc-b969-115969bbfa03.png">
