### PR TITLE
Adjust VAS filter responsiveness

### DIFF
--- a/css/vas.css
+++ b/css/vas.css
@@ -1,7 +1,17 @@
 .vasfilter {
-    max-height: 24rem;
+    display:grid;
+    grid-template-columns: auto auto auto;
 }
-
+@media only screen and (max-width:1200px) {
+    .vasfilter {
+        grid-template-columns: auto auto;
+    }
+}
+@media only screen and (max-width:700px) {
+    .vasfilter {
+        grid-template-columns: auto;
+    }
+}
 .pv\.75r {
     padding-top: 0.75rem;
     padding-bottom: 0.75rem;

--- a/css/vas.css
+++ b/css/vas.css
@@ -1,16 +1,6 @@
 .vasfilter {
     display:grid;
-    grid-template-columns: auto auto auto;
-}
-@media only screen and (max-width:1200px) {
-    .vasfilter {
-        grid-template-columns: auto auto;
-    }
-}
-@media only screen and (max-width:700px) {
-    .vasfilter {
-        grid-template-columns: auto;
-    }
+    grid-template-columns: repeat(auto-fill, minmax(16rem, 1fr));
 }
 .pv\.75r {
     padding-top: 0.75rem;

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -160,38 +160,42 @@
             Information applies to revised services only. Services without any supported value added services are not part of the table.
           </p>
           <div class="mbs">
-            <div class="flex flex-wrap align-ifs bg-gray1 pal pbm rad-a2px pr0">
+            <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
               <div class="mrl">
-                <p class="form__label">Filter by</p>
-                <div class="btngroup">
-                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='service'" "btnText" "Service") -}}
-                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='type'" "btnText" "Service type") -}}
-                  {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='family'" "btnText" "Service family") -}}
+                <div class="flex flex-wrap-reverse align-ifs justify-csb">
+                  <div class="mrl">
+                    <p class="form__label">Filter by</p>
+                    <div class="btngroup">
+                      {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='service'" "btnText" "Service") -}}
+                      {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='type'" "btnText" "Service type") -}}
+                      {{- partial "filterbtn.html" (dict "dataAtt" "data-filterbtn='family'" "btnText" "Service family") -}}
+                    </div>
+                  </div>
+                  <label class="form__label mrxl" for="vasfilter">
+                    VAS name, booking or shipping guide API request code
+                    <input id="vasfilter" type="text" class="form__control mrxs w100p maxw32r"/>
+                  </label>
+                </div>
+                <div id="filtersets">
+
+                  {{- $.Scratch.Add "servicetype" slice -}}
+                  {{- $.Scratch.Add "servicefamily" slice -}}
+                  {{- $.Scratch.Add "service" slice -}}
+                  {{- range $.Site.Data.services_vas -}}
+                  {{- range .supportedServices -}}
+                  {{- $.Scratch.Add "servicetype" (dict "name" .serviceType "value" .serviceType) -}}
+                  {{- $.Scratch.Add "servicefamily" (dict "name" .serviceFamily "value" .serviceFamily "sortOrder" .serviceFamilySortOrder) -}}
+                  {{- $.Scratch.Add "service" (dict "name" .serviceName "value" .serviceCode) -}}
+                  {{- end -}}
+                  {{- end -}}
+
+                  {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "servicetype")) "name") "filter" "type" ) -}}
+                  {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "servicefamily")) "sortOrder") "filter" "family" ) -}}
+                  {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "service")) "name") "filter" "service" ) -}}
+
                 </div>
               </div>
-              <label class="form__label mrxl" for="vasfilter">
-                VAS name, booking or shipping guide API request code
-                <input id="vasfilter" type="text" class="form__control mrxs w100p maxw32r"/>
-              </label>
               <button class="btn-link--dark mtl mlr dn" id="clearfilters">Clear filters</button>
-            </div>
-            <div id="filtersets" class="bg-gray1 phm pbm">
-
-              {{- $.Scratch.Add "servicetype" slice -}}
-              {{- $.Scratch.Add "servicefamily" slice -}}
-              {{- $.Scratch.Add "service" slice -}}
-              {{- range $.Site.Data.services_vas -}}
-              {{- range .supportedServices -}}
-              {{- $.Scratch.Add "servicetype" (dict "name" .serviceType "value" .serviceType) -}}
-              {{- $.Scratch.Add "servicefamily" (dict "name" .serviceFamily "value" .serviceFamily "sortOrder" .serviceFamilySortOrder) -}}
-              {{- $.Scratch.Add "service" (dict "name" .serviceName "value" .serviceCode) -}}
-              {{- end -}}
-              {{- end -}}
-
-              {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "servicetype")) "name") "filter" "type" ) -}}
-              {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "servicefamily")) "sortOrder") "filter" "family" ) -}}
-              {{- partial "api/vasfilter.html" (dict "scratcher" (sort (uniq ($.Scratch.Get "service")) "name") "filter" "service" ) -}}
-
             </div>
           </div>
 

--- a/layouts/partials/api/vasfilter.html
+++ b/layouts/partials/api/vasfilter.html
@@ -1,6 +1,6 @@
 {{ $filter := .filter }}
 <fieldset class="flex-dir-col mbm bg-white pam bshadow" id="{{ $filter }}" hidden>
-  <div {{ if gt (len (uniq .scratcher)) 10 }} class="flex flex-wrap flex-dir-col vasfilter" {{ end }}>
+  <div {{ if gt (len (uniq .scratcher)) 10 }} class="vasfilter" {{ end }}>
     {{- range .scratcher }}
     {{ if and (ne .name "-") (ne .name "") }}
     <div>

--- a/layouts/partials/api/vasfilter.html
+++ b/layouts/partials/api/vasfilter.html
@@ -1,5 +1,5 @@
 {{ $filter := .filter }}
-<fieldset class="flex-dir-col mbm mhm bg-white pam bshadow" id="{{ $filter }}" hidden>
+<fieldset class="flex-dir-col mbm bg-white pam bshadow" id="{{ $filter }}" hidden>
   <div {{ if gt (len (uniq .scratcher)) 10 }} class="flex flex-wrap flex-dir-col vasfilter" {{ end }}>
     {{- range .scratcher }}
     {{ if and (ne .name "-") (ne .name "") }}


### PR DESCRIPTION
- Wrap the input field and buttons so it follows the same logic as in "Booking and Shipping Guide"
- Spread the filters in grid columns if there are more than 10 filters