### PR TITLE
OAS examples

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -173,11 +173,34 @@
                         {{ end }}
                         {{ range $response, $_ := .responses }}
                           <div id="{{ $response }}">
-                            <pre class="chroma"><code>
-{
-Create a scratch that can be reused?
-}
-                            </code></pre>
+                            {{ range $application, $_ := .content }}
+                              <div>
+                                {{ $application }}
+                                {{ range $key, $_ := .schema }}
+
+                                  {{ if in $application "application/json" }}
+                                    {{- if reflect.IsMap . -}}
+                                      {{- range . -}}
+                                        {{- . -}}
+                                      {{- end -}}
+                                    {{- else -}}
+                                      {{- if eq $key "$ref" -}}
+                                      {{- with partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" 0 "ind" 0) -}}
+                                      {{ $codeExample := print "{\n" . "\n}" }}
+                                      {{ highlight $codeExample "json" "tabWidth=2" }}
+                                      {{ end }}
+                                      {{- else -}}
+                                      Not ref not map
+                                        {{- . -}}
+                                      {{- end -}}
+                                    {{ end }}
+                                  {{ end }}
+
+                                {{ end }}
+
+                          </div>
+                          {{ end }}
+
                           </div>
                         {{ end }}
                       {{ end }}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -214,21 +214,38 @@
           showInitialSchemaType();
         </script>
         <script>
-          const responseExBtns = document.querySelectorAll("[data-response-exbtn]")
+          function switchExample(containerArr, id) {
+            containerArr.forEach(container => {
+              if (container.dataset.responseEx === id) {
+                container.hidden = false
+              } else {
+                container.hidden = true
+              }
+            })
+          }
+
+          const responseExBtns = document.querySelectorAll("input[data-response-ex]")
           responseExBtns.forEach(btn => {
             btn.addEventListener("click", function (e) {
-              const resIdBtn = e.target.dataset.responseExbtn
-              const resId = e.target.name
+              const element = e.target
+              const resIdBtn = element.dataset.responseEx
+              const resId = element.name
               const responseSection = document.querySelector('#' + resId)
-              const exampleContainers = responseSection.querySelectorAll("[data-response-exctr]")
+              const exampleContainers = responseSection.querySelectorAll("div[data-response-ex]")
 
-              exampleContainers.forEach( container => {
-                if (container.dataset.responseExctr === resIdBtn) {
-                  container.hidden = false
-                } else {
-                  container.hidden = true
-                }
-              })
+              switchExample(exampleContainers, resIdBtn)
+            })
+          })
+
+          const responseExSelects = document.querySelectorAll("select[data-response-subex]")
+          responseExSelects.forEach(select => {
+            select.addEventListener("change", function (e) {
+              const element = e.target
+              const exId = element.value
+              const responseSection = element.parentNode
+              const exampleSubContainers = responseSection.querySelectorAll("div[data-response-subex]")
+
+              switchExample(exampleSubContainers, exId)
             })
           })
         </script>

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -101,13 +101,13 @@
             <section class="dev-docscontent__section maxw96r">
               {{ $oasData := getJSON $.Params.oas }}
               {{ with $oasData }}
-                {{ $schemas := .components }}
+                {{ $components := .components }}
                 {{ range $path, $_ := .paths }}
                 {{ $endpointId := delimit (shuffle (seq 1 9)) "" }}
                 <span class="gray text-note">ID: {{$endpointId}}</span>
-                  <div class="flex flex-wrap mbm ptm">
-                    <div class="flex-1 flex-basis-20 pas">
-                      {{ range $type, $_ := . }}
+                  <div class="flex flex-wrap mbxl ptm mb-border bb">
+                    {{ range $type, $_ := . }}
+                      <div class="flex-1 flex-basis-20">
                         <h2>{{ .summary }}</h2>
                         <p><span class="mb-badge mb-badge--green ttu mrs pas">{{ $type }}</span> {{ $path }}</p>
                         <p class="text-heading">{{ .description }}</p>
@@ -115,7 +115,7 @@
                         {{- partial "api/params.html" (dict "parameters" .parameters) -}}
 
                         <p class="text-title">Responses</p>
-                        
+
                         {{ $responseCodeColor := "" }}
                         {{ $successCodes := "200 204" }}
                         {{ $errorCodes := "400 404 500" }}
@@ -150,11 +150,11 @@
                                 {{ range $key, $_ := .schema }}
                                   {{ if reflect.IsMap . }}
                                     {{ range . }}
-                                      {{- partial "api/schema.html" (dict "ctx" . "schemas" $schemas) -}}
+                                      {{- partial "api/schema.html" (dict "ctx" . "schemas" $components) -}}
                                     {{ end }}
                                   {{ else }}
                                     {{ if eq $key "$ref" }}
-                                      {{- partial "api/schema.html" (dict "ctx" . "schemas" $schemas) -}}
+                                      {{- partial "api/schema.html" (dict "ctx" . "schemas" $components) -}}
                                     {{ else }}
                                       {{ . }}
                                     {{ end }}
@@ -167,46 +167,10 @@
                         {{ end }}
                       </div>
                       <div class="flex-1 pas">
-                        <h3>Response examples</h3>
-                        {{ range $response, $_ := .responses }}
-                          <button class="btn">{{ $response }}</button>
-                        {{ end }}
-                        {{ range $response, $_ := .responses }}
-                          <div id="{{ $response }}">
-                            {{ range $application, $_ := .content }}
-                              <div>
-                                {{ $application }}
-                                {{ range $key, $_ := .schema }}
-
-                                  {{ if in $application "application/json" }}
-                                    {{- if reflect.IsMap . -}}
-                                      {{- range . -}}
-                                        {{- . -}}
-                                      {{- end -}}
-                                    {{- else -}}
-                                      {{- if eq $key "$ref" -}}
-                                      {{- with partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" 0 "ind" 0) -}}
-                                      {{ $codeExample := print "{\n" . "\n}" }}
-                                      {{ highlight $codeExample "json" "tabWidth=2" }}
-                                      {{ end }}
-                                      {{- else -}}
-                                      Not ref not map
-                                        {{- . -}}
-                                      {{- end -}}
-                                    {{ end }}
-                                  {{ end }}
-
-                                {{ end }}
-
-                          </div>
-                          {{ end }}
-
-                          </div>
-                        {{ end }}
-                      {{ end }}
-                    </div>
+                        {{- partial "api/responseexample.html" (dict "components" $components "responses" .responses ) -}}
+                      </div>
+                    {{ end }}
                   </div>
-                  <hr>
                 {{ end }}
               {{ end }}
             </section>

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -103,11 +103,11 @@
               {{ with $oasData }}
                 {{ $components := .components }}
                 {{ range $path, $_ := .paths }}
-                {{ $endpointId := delimit (shuffle (seq 1 9)) "" }}
-                <span class="gray text-note">ID: {{$endpointId}}</span>
-                  <div class="flex flex-wrap mbxl ptm mb-border bb">
-                    {{ range $type, $_ := . }}
+                  {{ range $type, $_ := . }}
+                    {{ $endpointId := .summary | anchorize }}
+                    <div id="{{ $endpointId }}" class="flex flex-wrap mbxl ptm mb-border bb">
                       <div class="flex-1 flex-basis-20">
+                        <span class="gray text-note">ID: {{$endpointId}}</span>
                         <h2>{{ .summary }}</h2>
                         <p><span class="mb-badge mb-badge--green ttu mrs pas">{{ $type }}</span> {{ $path }}</p>
                         <p class="text-heading">{{ .description }}</p>
@@ -167,10 +167,10 @@
                         {{ end }}
                       </div>
                       <div class="flex-1 pas">
-                        {{- partial "api/responseexample.html" (dict "components" $components "responses" .responses ) -}}
+                        {{- partial "api/responseexample.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}
                       </div>
-                    {{ end }}
                   </div>
+                    {{ end }}
                 {{ end }}
               {{ end }}
             </section>
@@ -212,6 +212,25 @@
           }
 
           showInitialSchemaType();
+        </script>
+        <script>
+          const responseExBtns = document.querySelectorAll("[data-response-exbtn]")
+          responseExBtns.forEach(btn => {
+            btn.addEventListener("click", function (e) {
+              const resIdBtn = e.target.dataset.responseExbtn
+              const resId = e.target.name
+              const responseSection = document.querySelector('#' + resId)
+              const exampleContainers = responseSection.querySelectorAll("[data-response-exctr]")
+
+              exampleContainers.forEach( container => {
+                if (container.dataset.responseExctr === resIdBtn) {
+                  container.hidden = false
+                } else {
+                  container.hidden = true
+                }
+              })
+            })
+          })
         </script>
       {{- else -}}
       {{- partial "api/docs.html" . -}}

--- a/layouts/partials/api/response.html
+++ b/layouts/partials/api/response.html
@@ -1,0 +1,99 @@
+{{- $schemas := .schemas -}}
+{{- $schemaPath := path.Split .ctx -}}
+{{- $schemaRef := $schemaPath.File -}}
+{{- $level := add .level 1 -}}
+{{- $prevLevel := .level -}}
+{{- $ind := .ind -}}
+{{- $iLen := 0 }}
+
+{{- range $schemas -}}
+    {{- $responseSchema := index . $schemaRef -}}
+    {{- range $key, $_ := $responseSchema -}}
+
+      {{- if reflect.IsMap . -}}
+            {{- $iLen = add (len .) 1 -}}
+            {{/* {{ len . }} */}}
+          {{- range $param, $_ := . -}}
+            {{ if ne $param "name" }}
+              {{$level}} {{ $prevLevel }} {{ $ind }}
+              {{ if ne $level $prevLevel }}
+              {
+              {{ end }}
+              {{- /* KEY  */ -}}
+                  "{{ $param }}": 
+                  {{- if reflect.IsMap . -}}
+                    {{- $ind = add $ind 1 -}}
+                    {{- range $i, $_ := . -}}
+                      {{- if or (not (reflect.IsMap .)) (not (reflect.IsSlice .)) -}}
+                        {{- if eq $i "type" -}}
+{{ if eq . "array" }}
+  [
+{{- else -}}
+                            {{- /* TYPE "{{- . -}}" */ -}}
+                          {{- end -}}
+                        {{- end -}}
+                      {{- end -}}
+                    {{- end -}}
+                  {{/* {{- else -}}
+                   NAME {{- . -}}<br> */}}
+                  {{- end -}}
+
+                  {{- if reflect.IsMap . -}}
+                    {{- range $i, $_ := . -}}
+                        {{- if reflect.IsMap . -}}
+                            {{- range $j, $_ := . -}}
+                              {{- if eq $j "$ref" -}}
+                                {{- partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
+                              {{- end -}}
+                            {{- end -}}
+                        {{- else if reflect.IsSlice . -}}
+                          {{/* Enum:
+                            {{- range . -}}
+                              <code>{{- . -}}</code><br>
+                            {{- end -}} */}}
+                        {{- else -}}
+                          {{- if eq $i "$ref" -}}
+                            {{- partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
+                          {{- else if eq $i "type" -}}
+{{ if eq . "array" }}
+  ]
+{{- else -}}
+                              {{- /* TYPE  */ -}}
+                              "{{- . -}}"
+                            {{- if ne $iLen $ind -}},{{- end -}}
+                          {{- end -}}
+                          {{- end -}}
+                        {{- end -}}
+                    {{- end -}}
+                  {{/* {{- else -}}
+                   NAME {{- . -}}<br> */}}
+                  {{- end -}}
+
+            {{- end -}}
+            {{- $prevLevel = $level -}}
+          {{- end -}}
+
+      {{- else if reflect.IsSlice . -}}
+        {{/* <div class="flex">
+          <div class="flex-1">
+            {{- $key -}}
+          </div>
+          <div class="flex-1">
+            {{- range . -}}
+              - {{- . -}} <br>
+            {{- end -}}
+          </div>
+        </div> */}}
+
+      {{- else -}}
+      {{/* <div class="flex">
+        <div class="flex-1">
+          {{- $key -}}
+        </div>
+        <div class="flex-1">
+         description {{- . -}}
+        </div>
+      </div> */}}
+      {{- end -}}
+    {{- end -}}
+{{- end -}}

--- a/layouts/partials/api/response.html
+++ b/layouts/partials/api/response.html
@@ -4,96 +4,102 @@
 {{- $level := add .level 1 -}}
 {{- $prevLevel := .level -}}
 {{- $ind := .ind -}}
-{{- $iLen := 0 }}
+{{- $iLen := 0 -}}
+{{- $codeExample := "" -}}
 
 {{- range $schemas -}}
-    {{- $responseSchema := index . $schemaRef -}}
-    {{- range $key, $_ := $responseSchema -}}
+  {{- $responseSchema := index . $schemaRef -}}
+  {{- range $key, $_ := $responseSchema -}}
+    {{- $scratches := newScratch -}}
 
-      {{- if reflect.IsMap . -}}
-            {{- $iLen = add (len .) 1 -}}
-            {{/* {{ len . }} */}}
-          {{- range $param, $_ := . -}}
-            {{ if ne $param "name" }}
-              {{$level}} {{ $prevLevel }} {{ $ind }}
-              {{ if ne $level $prevLevel }}
-              {
-              {{ end }}
-              {{- /* KEY  */ -}}
-                  "{{ $param }}": 
-                  {{- if reflect.IsMap . -}}
-                    {{- $ind = add $ind 1 -}}
-                    {{- range $i, $_ := . -}}
-                      {{- if or (not (reflect.IsMap .)) (not (reflect.IsSlice .)) -}}
-                        {{- if eq $i "type" -}}
-{{ if eq . "array" }}
-  [
-{{- else -}}
-                            {{- /* TYPE "{{- . -}}" */ -}}
-                          {{- end -}}
-                        {{- end -}}
-                      {{- end -}}
-                    {{- end -}}
-                  {{/* {{- else -}}
-                   NAME {{- . -}}<br> */}}
+    {{- if reflect.IsMap . -}}
+      {{- $iLen = add (len .) 1 -}}
+      {{/* {{- len . -}} */}}
+      {{- range $param, $_ := . -}}
+        {{- if ne $param "name" -}}
+          {{- /* {{$level}} {{- $prevLevel -}} {{- $ind -}} */ -}}
+          {{- if ne $level $prevLevel -}}
+
+          {{- end -}}
+          {{- /* KEY  */ -}}
+          {{- if lt $level 2 -}}
+            {{- $codeExample = print $codeExample "\"" $param "\": " $level $prevLevel $iLen  -}}
+          {{- end -}}
+          {{/* "{{- $param -}}":  */}}
+
+          {{- if reflect.IsMap . -}}
+            {{- $ind = add $ind 1 -}}
+            {{- range $i, $_ := . -}}
+              {{- if or (not (reflect.IsMap .)) (not (reflect.IsSlice .)) -}}
+                {{- if eq $i "type" -}}
+                  {{- if eq . "array" -}}
+                    {{- $codeExample = print $codeExample "[\n" -}}
+                  {{- else -}}
+                    {{- $kvPair := print "\"" $param "\": \"" . "\"" -}}
+                    {{- $scratches.SetInMap $schemaRef $param $kvPair -}}
+                    {{- /* TYPE "{{- . -}}" */ -}}
                   {{- end -}}
-
-                  {{- if reflect.IsMap . -}}
-                    {{- range $i, $_ := . -}}
-                        {{- if reflect.IsMap . -}}
-                            {{- range $j, $_ := . -}}
-                              {{- if eq $j "$ref" -}}
-                                {{- partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
-                              {{- end -}}
-                            {{- end -}}
-                        {{- else if reflect.IsSlice . -}}
-                          {{/* Enum:
-                            {{- range . -}}
-                              <code>{{- . -}}</code><br>
-                            {{- end -}} */}}
-                        {{- else -}}
-                          {{- if eq $i "$ref" -}}
-                            {{- partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
-                          {{- else if eq $i "type" -}}
-{{ if eq . "array" }}
-  ]
-{{- else -}}
-                              {{- /* TYPE  */ -}}
-                              "{{- . -}}"
-                            {{- if ne $iLen $ind -}},{{- end -}}
-                          {{- end -}}
-                          {{- end -}}
-                        {{- end -}}
-                    {{- end -}}
-                  {{/* {{- else -}}
-                   NAME {{- . -}}<br> */}}
-                  {{- end -}}
-
+                {{- end -}}
+              {{- end -}}
             {{- end -}}
-            {{- $prevLevel = $level -}}
+
+          {{/* {{- else -}}
+            NAME {{- . -}}<br> */}}
           {{- end -}}
 
-      {{- else if reflect.IsSlice . -}}
-        {{/* <div class="flex">
-          <div class="flex-1">
-            {{- $key -}}
-          </div>
-          <div class="flex-1">
-            {{- range . -}}
-              - {{- . -}} <br>
-            {{- end -}}
-          </div>
-        </div> */}}
+          {{- if reflect.IsMap . -}}
+            {{- range $i, $_ := . -}}
 
-      {{- else -}}
-      {{/* <div class="flex">
-        <div class="flex-1">
-          {{- $key -}}
-        </div>
-        <div class="flex-1">
-         description {{- . -}}
-        </div>
-      </div> */}}
+              {{- if reflect.IsMap . -}}
+                {{- range $j, $_ := . -}}
+                  {{- if eq $j "$ref" -}}
+                    {{- with partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
+                      {{- $codeExample = print $codeExample . -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+
+              {{- else if reflect.IsSlice . -}}
+                {{/* Enum:
+                {{- range . -}}
+                  <code>{{- . -}}</code><br>
+                {{- end -}} */}}
+
+              {{- else -}}
+                {{- if eq $i "$ref" -}}
+                  {{- with partial "api/response.html" (dict "ctx" . "schemas" $schemas "level" $level "ind" $ind) -}}
+                    {{- $codeExample = print $codeExample . -}}
+                  {{- end -}}
+                {{- else if eq $i "type" -}}
+                  {{- if eq . "array" -}}
+                    {{- $codeExample = print $codeExample "]\n" -}}
+                  {{- else -}}
+                    {{- /* TYPE  */ -}}
+                    {{- /* "{{- . -}}" */ -}}
+                    {{- /* {{- if ne $iLen $ind -}},{{- end -}} */ -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          {{/* {{- else -}}
+            NAME {{- . -}}<br> */}}
+          {{- end -}}
+        {{- end -}}
+        {{- $prevLevel = $level -}}
       {{- end -}}
-    {{- end -}}
+    {{- else if reflect.IsSlice . -}}
+  {{- else -}}
+  {{- end -}}
+  {{- if gt (len $scratches.Values) 0 -}}
+    {{- $codeExample = print $codeExample "{\n" -}}
+  {{- end -}}
+  {{- range $scratches.Values -}}
+    {{- $codeExample = print $codeExample "  " (delimit . ", \n  ") -}}
+  {{- end -}}
+  {{- if gt (len $scratches.Values) 0 -}}
+    {{- $codeExample = print $codeExample "\n}" -}}
+  {{- end -}}
 {{- end -}}
+{{- end -}}
+
+{{- return $codeExample -}}

--- a/layouts/partials/api/responseexample.html
+++ b/layouts/partials/api/responseexample.html
@@ -8,14 +8,14 @@
 <fieldset>
   {{ range $response, $_ := .responses }}
     {{ $responseId := print $endpointId "-" $response }}
-    <label class="form__radio mrm"><input type="radio" name="{{ $endpointId}}" data-response-exbtn="{{ $responseId }}" {{if eq $resInd 0 }}checked{{ end }}>{{ $response }}</label>
+    <label class="form__radio mrm"><input type="radio" name="{{ $endpointId}}" data-response-ex="{{ $responseId }}" {{if eq $resInd 0 }}checked{{ end }}>{{ $response }}</label>
     {{ $resInd = add $resInd 1 }}
   {{ end }}
 </fieldset>
 {{ $resInd = 0 }}
 {{ range $response, $_ := .responses }}
   {{ $responseId := print $endpointId "-" $response }}
-  <div data-response-exctr="{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
+  <div data-response-ex="{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
     {{ range $application, $_ := .content }}
       {{/* {{ $response }} {{ $application }} */}}
 
@@ -31,15 +31,31 @@
           {{/* If application type contains examples object */}}
           {{ else }}
             {{/* if there is only one object */}}
+            {{ if gt (len .examples) 1 }}
+              <select class="form__control w100p" data-response-subex>
+                {{ range .examples }}
+                    {{ range . }}
+                      {{ $exPath := path.Split . }}
+                      {{ $exId := print $responseId "-" $exPath.File }}
+                      <option value="{{ $exId }}">{{ $exPath.File }}</option>
+                    {{ end }}
+                {{ end }}
+              </select>
+            {{ end }}
+              {{ $exInd := 0 }}
+
             {{ range .examples }}
               {{ range . }}
                 {{ $exPath := path.Split . }}
-                {{ $exPath.File }}
-                {{ range index $components.examples $exPath.File }}
-                  {{ $codeExample = . | jsonify (dict "indent" "  ") }}
-                  {{ highlight $codeExample "json" }}
-                {{ end }}
+                {{ $exId := print $responseId "-" $exPath.File }}
+                <div data-response-subex="{{ $exId }}" {{ if ne $exInd 0 }}hidden{{ end }}>
+                  {{ range index $components.examples $exPath.File }}
+                    {{ $codeExample = . | jsonify (dict "indent" "  ") }}
+                    {{ highlight $codeExample "json" }}
+                  {{ end }}
+                </div>
               {{ end }}
+              {{ $exInd = add $exInd 1 }}
             {{ end }}
             <br>
             {{/* TODO: if there are more than one object/example */}}

--- a/layouts/partials/api/responseexample.html
+++ b/layouts/partials/api/responseexample.html
@@ -1,0 +1,68 @@
+{{ $response := .response }}
+{{ $components := .components }}
+
+<h3>Response examples</h3>
+{{ range $response, $_ := .responses }}
+  <button class="btn">{{ $response }}</button>
+{{ end }}
+{{ $codeExample := "" }}
+{{ range $response, $_ := .responses }}
+  <div id="{{ $response }}">
+    {{ range $application, $_ := .content }}
+      {{ $response }} {{ $application }}
+      
+      {{ if in $application "json" }}
+
+        {{ if isset . "examples" }}
+
+          {{/* If response code corresponds to example */}}
+          {{ range index $components.examples $response }}
+            {{ $codeExample = . | jsonify (dict "indent" "  ") }}
+            {{ highlight $codeExample "json" }}
+          
+          {{/* If application type contains examples object */}}
+          {{ else }}
+            {{/* if there is only one object */}}
+            {{ range .examples }}
+              {{ range . }}
+                {{ $exPath := path.Split . }}
+                {{ $exPath.File }}
+                {{ range index $components.examples $exPath.File }}
+                  {{ $codeExample = . | jsonify (dict "indent" "  ") }}
+                  {{ highlight $codeExample "json" }}
+                {{ end }}
+              {{ end }}
+            {{ end }}
+            <br>
+            {{/* TODO: if there are more than one object/example */}}
+          {{ end }}
+
+        {{/* If application type only contains schema */}}
+        {{ else if isset . "schemas" }}
+          {{ range $key, $_ := .schema }}
+            {{- if reflect.IsMap . -}}
+              {{- range . -}}
+                {{- . -}}
+              {{- end -}}
+            {{- else -}}
+              {{- if eq $key "$ref" -}}
+                {{ range $components.examples }}
+                    {{ .value }}
+                {{ end }}
+                {{- with partial "api/responsejson.html" (dict "ctx" . "components" $components "level" 0 "ind" 0) -}}
+                  {{ $codeExample = print . | jsonify (dict "indent" "  ") }}
+                  {{ highlight $codeExample "json" "tabWidth=2" }}
+                {{ end }}
+              {{- else -}}
+                Not ref not map
+                {{- . -}}
+              {{- end -}}
+            {{ end }}
+          {{ else }}
+            No samples
+          {{ end }}
+        {{ end }}
+      {{ end }}
+    {{ end }}
+  </div>
+{{ end }}

--- a/layouts/partials/api/responseexample.html
+++ b/layouts/partials/api/responseexample.html
@@ -1,16 +1,24 @@
 {{ $response := .response }}
 {{ $components := .components }}
+{{ $endpointId := .endpointId }}
 
 <h3>Response examples</h3>
-{{ range $response, $_ := .responses }}
-  <button class="btn">{{ $response }}</button>
-{{ end }}
 {{ $codeExample := "" }}
+{{ $resInd := 0 }}
+<fieldset>
+  {{ range $response, $_ := .responses }}
+    {{ $responseId := print $endpointId "-" $response }}
+    <label class="form__radio mrm"><input type="radio" name="{{ $endpointId}}" data-response-exbtn="{{ $responseId }}" {{if eq $resInd 0 }}checked{{ end }}>{{ $response }}</label>
+    {{ $resInd = add $resInd 1 }}
+  {{ end }}
+</fieldset>
+{{ $resInd = 0 }}
 {{ range $response, $_ := .responses }}
-  <div id="{{ $response }}">
+  {{ $responseId := print $endpointId "-" $response }}
+  <div data-response-exctr="{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
     {{ range $application, $_ := .content }}
-      {{ $response }} {{ $application }}
-      
+      {{/* {{ $response }} {{ $application }} */}}
+
       {{ if in $application "json" }}
 
         {{ if isset . "examples" }}
@@ -65,4 +73,5 @@
       {{ end }}
     {{ end }}
   </div>
+  {{ $resInd = add $resInd 1 }}
 {{ end }}

--- a/layouts/partials/api/responsejson.html
+++ b/layouts/partials/api/responsejson.html
@@ -1,0 +1,106 @@
+{{- $components := .components -}}
+{{- $schemaPath := path.Split .ctx -}}
+{{- $schemaRef := $schemaPath.File -}}
+{{- $level := add .level 1 -}}
+{{- $prevLevel := .level -}}
+{{- $ind := .ind -}}
+{{- $iLen := 0 -}}
+{{- $codeExample := dict -}}
+{{/*  {{ $.Scratch.Add "codex" }}  */}}
+
+{{- range $components -}}
+  {{- $responseSchema := index . $schemaRef -}}
+  {{- range $key, $_ := $responseSchema -}}
+    {{- $scratches := newScratch -}}
+
+    {{- if reflect.IsMap . -}}
+      {{- $iLen = add (len .) 1 -}}
+      {{/* {{- len . -}} */}}
+      {{- range $param, $_ := . -}}
+        {{- if ne $param "name" -}}
+          {{- /* {{$level}} {{- $prevLevel -}} {{- $ind -}} */ -}}
+          {{- if ne $level $prevLevel -}}
+
+          {{- end -}}
+          {{- /* KEY  */ -}}
+          {{- if lt $level 2 -}}
+            {{- $codeExample = $codeExample | append $param -}}
+          {{- end -}}
+          {{/* "{{- $param -}}":  */}}
+
+          {{- if reflect.IsMap . -}}
+            {{- $ind = add $ind 1 -}}
+            {{- range $i, $_ := . -}}
+              {{- if or (not (reflect.IsMap .)) (not (reflect.IsSlice .)) -}}
+                {{- if eq $i "type" -}}
+                  {{- if eq . "array" -}}
+                    {{/*  {{- $codeExample = $codeExample | append "[" -}}  */}}
+                  {{- else -}}
+                    {{- $kvPair := print "\"" $param "\": \"" . "\"" -}}
+                    {{- $scratches.SetInMap $schemaRef $param $kvPair -}}
+                    {{- /* TYPE "{{- . -}}" */ -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+
+          {{/* {{- else -}}
+            NAME {{- . -}}<br> */}}
+          {{- end -}}
+
+          {{- if reflect.IsMap . -}}
+            {{- range $i, $_ := . -}}
+
+              {{- if reflect.IsMap . -}}
+                {{- range $j, $_ := . -}}
+                  {{- if eq $j "$ref" -}}
+                    {{- with partial "api/response.html" (dict "ctx" . "components" $components "level" $level "ind" $ind) -}}
+                      {{- $codeExample = $codeExample | append . -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+
+              {{- else if reflect.IsSlice . -}}
+                {{/* Enum:
+                {{- range . -}}
+                  <code>{{- . -}}</code><br>
+                {{- end -}} */}}
+
+              {{- else -}}
+                {{- if eq $i "$ref" -}}
+                  {{- with partial "api/response.html" (dict "ctx" . "components" $components "level" $level "ind" $ind) -}}
+                    {{- $codeExample = $codeExample | append . -}}
+                  {{- end -}}
+                {{- else if eq $i "type" -}}
+                  {{- if eq . "array" -}}
+                    {{/*  {{- $codeExample = $codeExample | append "]" -}}  */}}
+                  {{- else -}}
+                    {{- /* TYPE  */ -}}
+                    {{- /* "{{- . -}}" */ -}}
+                    {{- /* {{- if ne $iLen $ind -}},{{- end -}} */ -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          {{/* {{- else -}}
+            NAME {{- . -}}<br> */}}
+          {{- end -}}
+        {{- end -}}
+        {{- $prevLevel = $level -}}
+      {{- end -}}
+    {{- else if reflect.IsSlice . -}}
+  {{- else -}}
+  {{- end -}}
+  {{- if gt (len $scratches.Values) 0 -}}
+    {{- $codeExample = $codeExample | append "{" -}}
+  {{- end -}}
+  {{- range $scratches.Values -}}
+    {{- $codeExample = $codeExample | append . -}}
+  {{- end -}}
+  {{- if gt (len $scratches.Values) 0 -}}
+    {{- $codeExample = $codeExample | append "}" -}}
+  {{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- return $codeExample -}}


### PR DESCRIPTION
This is part of a work in progress, but still hidden except for the new API.

It adds support for examples that are either directly tied to a response code or via refs. The examples are read as JSON from the JSON file. The functionality for switching between the examples and subexamples is also in place. The styling is not done at all. The layout needs more work as well.

response.html and responsejson.html will either be merged into one file or have split functionality – keeping both now for reference for each other.

Next up is doing some additional formatting and extracting the JS into separate files and bundling them.