### PR TITLE
Request area refinement

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -206,12 +206,17 @@ summary:hover {
 .schema-type-select {
   height:auto;
 }
-.desc-list {
-  margin-bottom:0;
+
+.desc-list > div {
+  gap: 0.25rem;
 }
-.desc-list dt,
+
+.desc-list dt {
+  flex: 1 1 10rem;
+}
+
 .desc-list dd {
-  width:50%;
+  flex: 2 1 12rem;
 }
 .param-toggle-icon {
   transition:all 0.2s ease-in-out;

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -113,7 +113,7 @@
 
                       {{- partial "api/params.html" (dict "parameters" .parameters) -}}
 
-                        <p class="text-title">Responses</p>
+                        <h3>Responses</h3>
 
                         {{ $responseCodeColor := "" }}
                         {{ $successCodes := "200 204" }}

--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -1,24 +1,31 @@
-{{ $paramsHeader := "" }}
+{{ $parameters := .parameters }}
 {{ $name := "" }}
 
+{{ $parameterTypes := slice }}
 {{ range .parameters }}
-  {{ $example := "" }}
-  {{ $enum := slice }}
-  {{ $type := "any" }}
+  {{ $parameterTypes = $parameterTypes | append .in }}
+{{ end }}
+{{ $parameterTypes = uniq $parameterTypes }}
 
-  {{ if ne $paramsHeader .in }}
-    {{ $paramsHeader = .in }}
-    <h4 class="ttu mb-border bb mbs pbxs mts"> {{ $paramsHeader }} parameters</h4>
-  {{ end }}
-  
-  <dl class="desc-list flex">
-    <dt class="fwn">
+<h3>Request</h3>
+{{ range $parameterTypes }}
+  {{ $paramsHeader := . }}
+  <h4 class="mb-border bb pbxs fw600"><span class="ttc">{{ $paramsHeader }}</span> parameters</h4>
+  <dl class="desc-list mbl">
+  {{ range $parameters }}
+    {{ if eq .in $paramsHeader }}
+      {{ $example := "" }}
+      {{ $enum := slice }}
+      {{ $type := "any" }}
+
+  <div class="flex flex-wrap mb-border bb bw1 pvs">
+    <dt class="fwn plxs">
       <code class="bg-white">{{ .name }}</code>
       {{ if eq .required true }}
-        <span class="mb-badge mb-badge--red paxs">Required</span>
+        <br><span class="mb-badge mb-badge--red">Required</span>
       {{ end }}
     </dt>
-    <dd>
+    <dd class="plxs">
       {{ .description }}
       {{ range $key,$value := . }}
         {{ if eq $key "name" }}
@@ -42,12 +49,14 @@
       {{ end }}
 
       {{ if and (reflect.IsSlice $enum) ( gt (len $enum) 0 ) }}
-        <div class="ptxs mbs">
-          {{ if gt (len $enum) 1 }}
-            <div class="text-note mb0">Enum:</div>
-          {{ else }}
-            <div class="text-note mb0">Value:</div>
-          {{ end }}
+        <div class="mbs">
+          <div class="text-note">
+            {{ if gt (len $enum) 1 }}
+              Enum:
+            {{ else }}
+              Value:
+            {{ end }}
+          </div>
           {{ range $enum }}
             <code class="mbxs db maxwmaxc">{{.}}</code>
           {{ end }}
@@ -56,14 +65,17 @@
 
       {{ if gt (len $example) 0 }}
         <div class="ptxs mbs">
-          <div class="text-note mb0">Example:</div>
+          <div class="text-note">Example:</div>
           <code>{{$example}}</code>
         </div>
       {{ end }}
 
-      <div class="mbm">
-        <span class="mb-badge">{{$type}}</span>
+      <div class="text-note gray">
+        {{$type}}
       </div>
     </dd>
+  </div>
+    {{ end }}
+  {{ end }}
   </dl>
 {{ end }}

--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -1,19 +1,19 @@
 {{ $parameters := .parameters }}
 {{ $name := "" }}
 
-{{ $parameterTypes := slice }}
+{{ $paramArr := slice }}
 {{ range .parameters }}
-  {{ $parameterTypes = $parameterTypes | append .in }}
+  {{ $paramArr = $paramArr | append .in }}
 {{ end }}
-{{ $parameterTypes = uniq $parameterTypes }}
+{{ $paramArr = uniq $paramArr }}
 
 <h3>Request</h3>
-{{ range $parameterTypes }}
-  {{ $paramsHeader := . }}
-  <h4 class="mb-border bb pbxs fw600"><span class="ttc">{{ $paramsHeader }}</span> parameters</h4>
+{{ range $paramArr }}
+  {{ $paramType := . }}
+  <h4 class="mb-border bb pbxs fw600"><span class="ttc">{{ $paramType }}</span> parameters</h4>
   <dl class="desc-list mbl">
   {{ range $parameters }}
-    {{ if eq .in $paramsHeader }}
+    {{ if eq .in $paramType }}
       {{ $example := "" }}
       {{ $enum := slice }}
       {{ $type := "any" }}

--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -49,7 +49,6 @@
       {{ end }}
 
       {{ if and (reflect.IsSlice $enum) ( gt (len $enum) 0 ) }}
-        <div class="mbs">
           <div class="text-note">
             {{ if gt (len $enum) 1 }}
               Enum:
@@ -60,14 +59,11 @@
           {{ range $enum }}
             <code class="mbxs db maxwmaxc">{{.}}</code>
           {{ end }}
-        </div>
       {{ end }}
 
       {{ if gt (len $example) 0 }}
-        <div class="ptxs mbs">
           <div class="text-note">Example:</div>
-          <code>{{$example}}</code>
-        </div>
+          <code class="mbxs db maxwmaxc">{{$example}}</code>
       {{ end }}
 
       <div class="text-note gray">


### PR DESCRIPTION
- Added header to the area – looks like "request" can be a better name than "parameters"
- Made the columns flex wrap
- Made each header type into a `dl` by iterating over header types instead of the parameters alone
- various spacing, border and detailing
- Tried to format as little as possible to avoid a bunch of whitespace changes this time (let’s do a separate PR with a bunch of that instead)
- Still uncertain about some details, let’s discuss further improvements to this after launch

![Screenshot 2022-02-24 at 19 09 24](https://user-images.githubusercontent.com/9307503/155582344-ce49cddf-eb91-4e0f-837d-e76eb91873c1.png)
