### PR TITLE
Spacing and endpoint overview adjustments

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -109,9 +109,9 @@
                   {{ range $type, $_ := . }}
                     {{ $endpointId := .summary | anchorize }}
                     <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
-                    <div class="flex flex-wrap mbxl ptm pbxl mb-border bb gapm">
+                    <div class="flex flex-wrap mbxl pbxl mb-border bb gapm">
                       <div class="param-response-area">
-                        <div class="flex align-ic mbs">
+                        <div class="flex align-ic mbm mts">
                           <span class="mb-badge mb-badge--green text-note ttu mrs pas">{{ $type }}</span>
                           <span class="flex-auto">
                             <pre class="flex align-ic pas mb0">
@@ -119,12 +119,11 @@
                             </pre>
                           </span>
                         </div>
-                        <p class="text-heading">{{ .description }}</p>
+                        <p class="mbl text-heading">{{ .description }}</p>
 
                         {{- partial "api/params.html" (dict "parameters" .parameters) -}}
 
-                        <h3>Responses</h3>
-
+                        <h3 class="mbm">Responses</h3>
                         {{ $responseCodeColor := "" }}
                         {{ $successCodes := "200 204" }}
                         {{ $errorCodes := "400 404 429 500" }}

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -64,17 +64,17 @@
           </div>
         </section>
         <section class="dev-docscontent__section maxw64r">
-          <h2 class="dev-anchored mbm" id="overview-of-endpoints">
-            Overview of endpoints
+          <h2 class="dev-anchored mbm" id="endpoints">
+            Endpoints
           </h2>
 
           <h3 class="dn">Base URL</h3>
           <pre>{{ .baseUri }}</pre>
           <table>
             <thead>
+              <th>Usage</th>
               <th>Method</th>
               <th>Endpoint</th>
-              <th>Usage</th>
             </thead>
             {{- range .resources -}}
               {{ $resDisplayName := .displayName | urlize }}
@@ -83,15 +83,15 @@
               {{- range .methods -}}
                 <tr>
                   <td>
-                    {{- .method | upper -}}
-                  </td>
-                  <td>
-                    {{- $resRelUri -}}
-                  </td>
-                  <td>
                     <a href="#{{ $resDisplayName }}" title="{{- $displayName -}}">
                       {{- .description | safeHTML -}}
                     </a>
+                  </td>
+                  <td>
+                    {{- .method | upper -}}
+                  </td>
+                  <td>
+                    <code>{{- $resRelUri -}}</code>
                   </td>
                 </tr>
               {{- end -}}

--- a/layouts/partials/api/endpoints.html
+++ b/layouts/partials/api/endpoints.html
@@ -1,38 +1,35 @@
-{{ $oasData := . }}
-{{ with $oasData }}
-  {{ $components := .components }}
-  <section class="dev-docscontent__section maxw64r">
-    <h2 class="dev-anchored mbm" id="overview-of-endpoints">
-    Overview of endpoints
+{{- with . -}}
+  <section class="dev-docscontent__section maxw96r">
+    <h2 class="dev-anchored mbm" id="endpoints">
+    Endpoints
     </h2>
     {{ range .servers }}
-    <pre>{{ .url }}</pre>
+      <pre class="maxw40r">{{ .url }}</pre>
     {{ end }}
 
     <table class="maxw96r">
       <thead>
+        <th>Usage</th>
         <th>Method</th>
         <th>Endpoint</th>
-        <th>Usage</th>
       </thead>
       {{ range $path, $_ := .paths }}
           {{ range $method, $_ := . }}
-          {{ $summary := .summary }}
           <tr>
+            <td>
+              <a href="#{{ .summary | anchorize }}" title="{{- .summary -}}">
+                  {{- .summary -}}
+              </a>
+            </td>
             <td>
               {{- $method | upper -}}
             </td>
             <td>
-              {{- $path -}}
-            </td>
-            <td>
-              <a href="#{{ $summary | anchorize }}" title="{{- $summary -}}">
-                  {{- $summary -}}
-              </a>
+              <code>{{ $path }}</code>
             </td>
           </tr>
           {{ end }}
       {{ end }}
     </table>
   </section>
-{{ end }}
+{{- end -}}

--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -7,7 +7,7 @@
 {{ end }}
 {{ $paramArr = uniq $paramArr }}
 
-<h3>Request</h3>
+<h3 class="mbm">Request</h3>
 {{ range $paramArr }}
   {{ $paramType := . }}
   <h4 class="mb-border bb pbxs fw600"><span class="ttc">{{ $paramType }}</span> parameters</h4>

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -112,9 +112,9 @@
                   {{- end -}}
 
                   <li>
-                    <a href="#overview-of-endpoints">
-                      <span data-hover="overview-of-endpoints"
-                        >Overview of endpoints</span
+                    <a href="#endpoints">
+                      <span data-hover="endpoints"
+                        >Endpoints</span
                       >
                     </a>
                   </li>

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -24,8 +24,8 @@ class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $curre
 
       {{- with or (index .apiData .identifier) $oasData -}}
         <li>
-          <a href="#overview-of-endpoints">
-            <span data-hover="overview-of-endpoints">Overview of endpoints</span>
+          <a href="#endpoints">
+            <span data-hover="endpoints">Endpoints</span>
           </a>
         </li>
       {{- end -}}


### PR DESCRIPTION
- Some spacing adjustments to get a better sense of the different layout groups
- Renamed and rearranged the endpoint sections – "overview of endpoints" always felt a bit long and is difficult to find in the menu. Placed "usage" first in the table. More detail work can be done here, maybe we can replace the table. This was done on both the new and the current versions.