### PR TITLE
Improve structure and responsiveness of schema data

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -234,10 +234,6 @@ summary.error-code:hover {
   padding: 0;
 }
 
-.desc-list dd code {
-  overflow-wrap: anywhere;
-}
-
 .desc-list dd {
   flex: 2 1 14rem;
   font-weight: 400;

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -214,21 +214,32 @@ summary.error-code:hover {
   height:auto;
 }
 
+.schema__sublist {
+  border-left-style: dashed;
+  border-width: 1px;
+  margin: 0 0.75rem;
+}
+
 .desc-list > div {
   gap: 0.25rem;
 }
 
 .desc-list dt {
-  flex: 1 1 10rem;
+  flex: 1 1 8rem;
   font-weight: 400;
 }
 
 .desc-list dt code {
   background: transparent;
+  padding: 0;
+}
+
+.desc-list dd code {
+  overflow-wrap: anywhere;
 }
 
 .desc-list dd {
-  flex: 2 1 12rem;
+  flex: 2 1 14rem;
   font-weight: 400;
 }
 

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -150,7 +150,7 @@
                               </select>
 
                               {{ range $application, $_ := . }}
-                                <div class="schema-type-container pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
+                                <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
                                 {{/*  Finding the schemarefs and using those in the partial to recursively output the schema data  */}}
                                 {{ range $key, $_ := .schema }}
                                   {{ if reflect.IsMap . }}
@@ -161,8 +161,9 @@
                                       {{- partial "api/schema.html" (dict "ctx" . "schemas" $components "nested" false "endpointId" $endpointId) -}}
                                   {{ end }}
                                 {{ end }}
-                                </div>
+                                </dl>
                               {{ end }}
+                              </div>
                           </details>
                           {{ else }}
                             <div class="{{ $responseColor }} pas mbs">{{ $response }} {{ $description }}</div>

--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -18,35 +18,33 @@
       {{ $enum := slice }}
       {{ $type := "any" }}
 
+      {{ range $key, $value := . }}
+      {{ if eq $key "name" }}
+        {{ $name = $value }}
+      {{ else if eq $key "schema" }}
+        {{ with .type }}
+          {{ $type = . }}
+        {{ end }}
+        {{ with .enum }}
+          {{ $enum = . }}
+        {{ end }}
+      {{ else if eq $key "example" }}
+        {{ $example = delimit (slice $name $value) "=" }}
+      {{ end }}
+    {{ end }}
+
   <div class="flex flex-wrap mb-border bb bw1 pvs">
-    <dt class="plxs">
+    <dt class="pls">
       <code>{{ .name }}</code>
       {{ if eq .required true }}
         <br><span class="mb-badge mb-badge--red">Required</span>
       {{ end }}
     </dt>
-    <dd class="plxs">
+    <dd class="pls">
       {{ .description }}
-      {{ range $key,$value := . }}
-        {{ if eq $key "name" }}
-          {{ $name = $value }}
-        {{ end }}
-
-        {{ if reflect.IsMap . }}
-          {{ if eq $key "schema" }}
-            {{ range $k,$v := $value }}
-              {{ if eq $k "type" }}
-                {{ $type = $v }}
-              {{ end }}
-              {{ if eq $k "enum" }}
-                {{ $enum = $v }}
-              {{ end }}
-            {{ end }}
-          {{ end }}
-        {{ else if eq $key "example" }}
-          {{ $example = delimit (slice $name $value) "=" }}
-        {{ end }}
-      {{ end }}
+      <div class="text-note gray">
+        {{ $type }}
+      </div>
 
       {{ if and (reflect.IsSlice $enum) ( gt (len $enum) 0 ) }}
           <div class="text-note">
@@ -65,10 +63,6 @@
           <div class="text-note">Example:</div>
           <code class="mbxs db maxwmaxc">{{$example}}</code>
       {{ end }}
-
-      <div class="text-note gray">
-        {{$type}}
-      </div>
     </dd>
   </div>
     {{ end }}

--- a/layouts/partials/api/schema.html
+++ b/layouts/partials/api/schema.html
@@ -36,25 +36,24 @@
           {{- end -}}
 
           {{- if and (eq $nested true) (reflect.IsMap .) -}}
-            <div>
-              <dl class="desc-list flex mb-border bb bw1 mbs pbs">
+              <div class="flex flex-wrap mb-border bb bw1 mbs pbs">
                 <dt class="pls">
                   <code>{{- $param -}}</code>
                   {{if eq $param $requiredParam}}{{- partial "api/required.html" -}}{{- end -}}
                 </dt>
-                <dd>
+                <dd class="pls">
                   {{- partial "api/schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
                 </dd>
 
           {{- else if $typeArrObj -}}
             {{ $isParent = true }}
-            <dl class="desc-list mb-border bb bw1 mbs pbs">
-              <div class="flex align-ifs">
+            <div class="mbs mb-border bb bw1">
+              <div class="flex flex-wrap align-ifs pbs">
                 <dt>
                   <button id="{{$endpointId}}-{{$param}}" class="btn-link param-collapsed-btn param-toggle-btn">
                     <span
                       data-mybicon="mybicon-arrow-right"
-                      data-mybicon-class="icon-ui param-toggle-icon"
+                      data-mybicon-class="icon-ui mrxs param-toggle-icon"
                       data-mybicon-width="16"
                       data-mybicon-height="16">
                     </span>
@@ -66,7 +65,7 @@
                     </div>
                   {{- end -}}
                 </dt>
-                <dd>
+                <dd class="ptxs pls">
                   {{- partial "api/schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
                 </dd>
               </div>
@@ -74,19 +73,20 @@
           {{- else -}}
             {{ $isParent = false }}
             {{if reflect.IsMap $_ -}}
-            <dl class="desc-list flex mb-border bb bw1 mbs pbs">
-              <dt class="plm mlxs">
-                <code>{{- $param -}}</code>
-                {{if eq $param $requiredParam}}{{- partial "api/required.html" -}}{{- end -}}
+            <div class="flex flex-wrap mb-border bb bw1 mbs pbs">
+              <dt>
+                <code class="mls">{{- $param -}}</code>
+                {{if eq $param $requiredParam}}<div class="mls">{{- partial "api/required.html" -}}</div>{{- end -}}
               </dt>
-              <dd>
+              <dd class="pls">
                 {{- partial "api/schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
               </dd>
+            </div>
             {{- end -}}
           {{- end -}}
 
         {{- if $isParent -}}
-          <dd data-sublevel-id='{{$endpointId}}-{{$param}}' class="pls mls mb-border bl bw1 dn">
+          <dd data-sublevel-id='{{$endpointId}}-{{$param}}' class="schema__sublist mb-border dn">
             {{- if eq $nested false -}}
               <dl class="desc-list mbm pts">
             {{- end -}}
@@ -109,13 +109,12 @@
               </dl>
             {{- end -}}
           </dd>
+        </div>
         {{- end -}}
 
-          {{- if and (eq $nested true) (reflect.IsMap $_) -}}
-            </div>
-          {{- else -}}
-            </dl>
-          {{- end -}}
+        {{- if and (eq $nested true) (reflect.IsMap $_) -}}
+          </div>
+        {{- end -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
Makes the output sturcture of the schema follow a logic of:
dl > dt + dd + dd > restarting if nested ♾
With divs where needed
This makes the responsiveness work better
![Screenshot 2022-03-01 at 15 55 27](https://user-images.githubusercontent.com/9307503/156200058-665a479a-634a-43cf-a43e-a655f4c3fd7d.png)

Paddings and margin have also been adjusted to have things align better

The request parameter data has also been sorted to be like the response data – the template has also been simplified and there is room for more, probably not as simple as schema-dd.html, but along those lines.

