### PR TITLE
Add defensive check for examples, colour code endpoint types

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -135,7 +135,7 @@
                           {{ $description := .description }}
                           {{ with .content }}
                           <details class="mbs">
-                            <summary class="{{ $responseColor }} pas">{{ $response }} {{ $description }}</summary>
+                            <summary class="{{ $responseColor }} pas"><span class="fw600">{{ $response }}</span> {{ $description }}</summary>
                           
                             <div class="bg-gray1 pam">
                               <label class="form__label text-basic dib" for="{{$endpointId}}">Response schema:</label>
@@ -166,7 +166,7 @@
                               </div>
                           </details>
                           {{ else }}
-                            <div class="{{ $responseColor }} pas mbs">{{ $response }} {{ $description }}</div>
+                            <div class="{{ $responseColor }} pas mbs"><span class="fw600">{{ $response }}</span> {{ $description }}</div>
                           {{ end }}
                         {{ end }}
                       </div>

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -112,7 +112,7 @@
                     <div class="flex flex-wrap mbxl pbxl mb-border bb gapm">
                       <div class="param-response-area">
                         <div class="flex align-ic mbm mts">
-                          <span class="mb-badge mb-badge--green text-note ttu mrs pas">{{ $type }}</span>
+                          {{- partial "api/endpoint-type" (dict "type" $type) -}}
                           <span class="flex-auto">
                             <pre class="flex align-ic pas mb0 wrap-text">
                               <span>{{ $path }}</span>

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -171,7 +171,9 @@
                         {{ end }}
                       </div>
                       <div class="example-area">
-                        {{- partial "api/responseexample.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}
+                        {{- if $components.examples -}}
+                          {{- partial "api/responseexample.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}
+                        {{- end -}}
                       </div>
                     </div>
                     {{ end }}

--- a/layouts/partials/api/endpoint-type.html
+++ b/layouts/partials/api/endpoint-type.html
@@ -1,0 +1,11 @@
+{{- $class := "" -}}
+
+{{- if eq .type "get" -}}
+  {{- $class = "mb-badge--green" -}}
+{{- else if eq .type "post" -}}
+  {{- $class = "mb-badge--blue" -}}
+{{- else if eq .type "delete" -}}
+  {{- $class = "mb-badge--red" -}}
+{{- end -}}
+
+<span class="mb-badge {{ $class }} text-note ttu mrs pas">{{ .type }}</span>


### PR DESCRIPTION
Ran a quick test of some of the other APIs and saw a couple of low-hanging fruits.

Blue badge variant is added in https://github.com/bring/mybring-design-system/pull/644