### PR TITLE
Fix $name value to .name

### DIFF
--- a/layouts/partials/api/params.html
+++ b/layouts/partials/api/params.html
@@ -17,11 +17,10 @@
       {{ $example := "" }}
       {{ $enum := slice }}
       {{ $type := "any" }}
+      {{ $name := .name }}
 
-      {{ range $key, $value := . }}
-      {{ if eq $key "name" }}
-        {{ $name = $value }}
-      {{ else if eq $key "schema" }}
+      {{ range $key, $value := .}}
+      {{ if eq $key "schema" }}
         {{ with .type }}
           {{ $type = . }}
         {{ end }}


### PR DESCRIPTION
It is currently displaying wrong property name in the example. as the  range operator on the map is not working in the same order. 

<img width="672" alt="Screenshot 2022-03-10 at 6 35 45 AM" src="https://user-images.githubusercontent.com/20452385/157598533-aa372a1b-5616-44b5-b09b-29552cb19162.png">


<img width="620" alt="Screenshot 2022-03-10 at 6 48 55 AM" src="https://user-images.githubusercontent.com/20452385/157598547-e3b7c54d-bb38-4487-939a-92cb2061734c.png">
