### PR TITLE
Adding support for multiple request examples

### DIFF
--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -14,6 +14,7 @@
   {{ range $parameters }}
     {{ if eq .in $paramType }}
       {{ $example := "" }}
+      {{ $examples := slice }}
       {{ $enum := slice }}
       {{ $type := "any" }}
       {{ $name := .name }}
@@ -43,6 +44,8 @@
           {{- end -}}
         {{- else if eq $key "example" -}}
           {{- $example = delimit (slice $name $value) "=" -}}
+        {{- else if eq $key "examples" -}}
+          {{- $examples = $value -}}
         {{- end -}}
       {{- end -}}
 
@@ -75,6 +78,15 @@
           {{- if gt (len $example) 0 -}}
               <div class="text-note">Example:</div>
               <code class="mbxs db maxwmaxc">{{$example}}</code>
+          {{- end -}}
+
+          {{- if gt (len $examples) 0 -}}
+            <div class="text-note">Examples:</div>
+            {{- range $key, $value := $examples -}}
+              <p class="text-note fwb mb0">{{$key}}</p>
+              <p class="text-note mb0">{{$value.description}}</p>
+              <code class="mbxs db maxwmaxc">{{- delimit (slice $name $value.value) "=" -}}</code>
+            {{- end -}}
           {{- end -}}
         </dd>
       </div>


### PR DESCRIPTION
When a param is documented with mulitple examples, the examples has to be fetched from the examples element. This contains named examples with descriptions.

<img width="820" alt="Screen Shot 2022-03-11 at 11 16 20" src="https://user-images.githubusercontent.com/1623401/157848004-d417d61f-cb43-4905-9abe-b4befffcf3ca.png">

<img width="830" alt="Screen Shot 2022-03-11 at 11 11 17" src="https://user-images.githubusercontent.com/1623401/157848027-315a60d1-444f-49b0-a631-48f7ee9ca99a.png">
