### PR TITLE
Reports and invoice combo filtering

### DIFF
--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -5,9 +5,11 @@ const riFilterBtns = document.querySelectorAll("[data-rifilterbtn]")
 const riFilterSets = document.querySelectorAll("#ri-filtersets fieldset")
 const riFilterChecks = document.querySelectorAll(".checkitem")
 const riClearBtn = document.querySelector("#ri-clearfilters")
+const riFilterCombo = document.querySelector("#ri-filtercombo")
 const originalEls = document.querySelectorAll(".originalel")
 const riCutoff = document.querySelector("#ri-cutoff")
 const riCutoffBtn = riCutoff.querySelector("button")
+let allFilters
 
 // Initial cutoff
 function riTableCutoff() {
@@ -61,11 +63,7 @@ function hideOriginals(bool) {
   })
 }
 
-// Clear all filters
-function riClearFilters() {
-  riHideCutoffs()
-  removeInsCells()
-  hideOriginals(false)
+function riCloseFilter() {
   const activeBtn = document.querySelector("[data-rifilterbtn].active")
 
   if (activeBtn) {
@@ -75,6 +73,25 @@ function riClearFilters() {
     set.hidden = true
     set.classList.remove("flex")
   })
+
+  let clearFilters = true
+  riFilterChecks.forEach((filterCheck) => {
+    if (filterCheck.checked == true) {
+      clearFilters = false
+    }
+  })
+  if (clearFilters) {
+    riClearFilters()
+  }
+
+}
+
+// Clear all filters
+function riClearFilters() {
+  riHideCutoffs()
+  removeInsCells()
+  hideOriginals(false)
+
   riFilterChecks.forEach((filterCheck) => {
     filterCheck.checked = false
   })
@@ -85,10 +102,13 @@ function riClearFilters() {
   riFilterInput.value = ""
 
   riEmptyCheck()
+  allFilters = {}
+  riFilterCombo.innerHTML = ""
   riClearBtn.classList.add("dn")
 }
 
 riCutoffBtn.addEventListener("click", function () {
+  riCloseFilter()
   riClearFilters()
 })
 
@@ -96,10 +116,77 @@ riClearBtn.addEventListener("click", function () {
   riClearFilters()
 })
 
+// Remove filters via combo overview
+riFilterCombo.addEventListener("click", function (e) {
+  // Delete all
+  if (e.target.dataset.rititle && !e.target.dataset.ritype) {
+    let subButtons = document.querySelectorAll(
+      'button[data-ritype="' + e.target.dataset.rititle + '"]'
+    )
+    subButtons.forEach((subButton) => {
+      toggleCheckbox(subButton)
+    })
+  }
+
+  // Delete one
+  if (e.target.dataset.ritype && e.target.dataset.rititle) {
+    toggleCheckbox(e.target)
+  }
+})
+
+allFilters = {}
+riFilterSets.forEach((set) => {
+  allFilters[set.id] = []
+})
+
+// Render combofilter overview
+function comboFilter(allFilters) {
+  riFilterCombo.innerHTML = ""
+  for (let activeFilter in allFilters) {
+    if (allFilters[activeFilter].length > 0) {
+      const filterTitle = document.querySelector(
+        '[data-rifilterbtn="' + activeFilter + '"]'
+      ).textContent
+      let appliedFilter =
+        '<button type="button" data-rititle="' +
+        activeFilter +
+        '" class="btn-link btn-link--filter"><span data-mybicon="mybicon-cross" data-mybicon-class="icon-ui mrxs" data-mybicon-width="16" data-mybicon-height="16"></span>' +
+        filterTitle +
+        '</button><div class="plm flex flex-wrap">'
+      allFilters[activeFilter].forEach((filter) => {
+        appliedFilter =
+          appliedFilter +
+          '<button type="button"' +
+          'data-ritype="' +
+          activeFilter +
+          '" data-rititle="' +
+          filter +
+          '" class="btn-link btn-link--filter mrxs"><span data-mybicon="mybicon-cross" data-mybicon-class="icon-ui mrxs" data-mybicon-width="16" data-mybicon-height="16"></span>' +
+          filter +
+          "</button>"
+      })
+      appliedFilter = appliedFilter + "</div>"
+      riFilterCombo.insertAdjacentHTML("beforeend", appliedFilter)
+      window.loadMybringIcons()
+    }
+  }
+}
+
+function toggleCheckbox(box) {
+  const checkEl = document.querySelector(
+    'input[data-filter="' +
+      box.dataset.ritype +
+      '"][value="' +
+      box.dataset.rititle +
+      '"'
+  )
+  checkEl.click()
+}
+
 // Render result
-function renderResult(showAllRows, queries, filterKey) {
+function renderResult(activeFilterSets, allFilters, showAllRows, queries, filterKey) {
   removeInsCells()
-  if (showAllRows) {
+  if (/*activeFilterSets <= 0 ||*/ showAllRows) {
     riRows.forEach((row) => {
       hideOriginals(false)
       row.hidden = false
@@ -114,71 +201,95 @@ function renderResult(showAllRows, queries, filterKey) {
     let apiCount = 1
     riRows.forEach((row) => {
       row.hidden = true
-      queries.forEach((query) => {
-        if (row.dataset[filterKey].toLowerCase().includes(query)) {
-          row.hidden = false
-          if (row.dataset.rifamily != prevFamily) {
-            setId++
-          }
 
-          if (
-            row.dataset.riapi != prevApi ||
-            row.dataset.rifamily != prevFamily
-          ) {
-            prevApi = ""
-            apiId++
-            apiCount = 1
-            row.insertAdjacentHTML(
-              "afterbegin",
-              '<td data-ins="' +
-                setId +
-                apiId +
-                '" rowspan="1"><span class="mb-badge">' +
-                row.dataset.riapi +
-                "</span></td>"
-            )
-          } else {
-            apiCount++
-            const apis = document.querySelectorAll(
-              '[data-ins="' + setId + apiId + '"]'
-            )
-            apis.forEach((api) => {
-              api.rowSpan = apiCount
-            })
-          }
-
-          if (row.dataset.rifamily != prevFamily) {
-            count = 1
-            row.insertAdjacentHTML(
-              "afterbegin",
-              '<td data-ins="' +
-                setId +
-                '" rowspan="1">' +
-                row.dataset.cntype +
-                "</td>"
-            )
-            row.insertAdjacentHTML(
-              "afterbegin",
-              '<th data-ins="' +
-                setId +
-                '" scope="row" rowspan="1" class="maxw20r">' +
-                row.dataset.rifamily +
-                "</th>"
-            )
-          } else {
-            count++
-            const sets = document.querySelectorAll(
-              '[data-ins="' + setId + '"]'
-            )
-            sets.forEach((set) => {
-              set.rowSpan = count
-            })
-          }
-
-          prevApi = row.dataset.riapi
-          prevFamily = row.dataset.rifamily
+      /*
+      // Check if row data matches at least one active filter in each active filterset
+      let matches = 0
+      for (const activeFilter in allFilters) {
+        if (allFilters[activeFilter].length > 0) {
+          const currentFilters = allFilters[activeFilter]
+          const rowDataAtt = '[data-filter="' + activeFilter + '"]'
+          currentFilters.forEach((currentFilter) => {
+            if (row.querySelector(rowDataAtt)) {
+              const currentRowData = row
+                .querySelector(rowDataAtt)
+                .textContent.toLowerCase()
+              if (currentRowData === currentFilter.toLowerCase()) {
+                matches++
+              }
+            }
+          })
         }
-      })
+      }
+      if (matches === activeFilterSets) {
+      */
+        queries.forEach((query) => {
+          if (row.dataset[filterKey].toLowerCase().includes(query)) {
+            row.hidden = false
+
+            if (row.dataset.rifamily != prevFamily) {
+              setId++
+            }
+
+            if (
+              row.dataset.riapi != prevApi ||
+              row.dataset.rifamily != prevFamily
+            ) {
+              prevApi = ""
+              apiId++
+              apiCount = 1
+              row.insertAdjacentHTML(
+                "afterbegin",
+                '<td data-ins="' +
+                  setId +
+                  apiId +
+                  '" rowspan="1"><span class="mb-badge">' +
+                  row.dataset.riapi +
+                  "</span></td>"
+              )
+            } else {
+              apiCount++
+              const apis = document.querySelectorAll(
+                '[data-ins="' + setId + apiId + '"]'
+              )
+              apis.forEach((api) => {
+                api.rowSpan = apiCount
+              })
+            }
+
+            if (row.dataset.rifamily != prevFamily) {
+              count = 1
+              row.insertAdjacentHTML(
+                "afterbegin",
+                '<td data-ins="' +
+                  setId +
+                  '" rowspan="1">' +
+                  row.dataset.cntype +
+                  "</td>"
+              )
+              row.insertAdjacentHTML(
+                "afterbegin",
+                '<th data-ins="' +
+                  setId +
+                  '" scope="row" rowspan="1" class="maxw20r">' +
+                  row.dataset.rifamily +
+                  "</th>"
+              )
+            } else {
+              count++
+              const sets = document.querySelectorAll(
+                '[data-ins="' + setId + '"]'
+              )
+              sets.forEach((set) => {
+                set.rowSpan = count
+              })
+            }
+
+            prevApi = row.dataset.riapi
+            prevFamily = row.dataset.rifamily
+          }
+        })
+      //}
     })
   }
 }
@@ -210,10 +321,10 @@ riFilterBtns.forEach((filterBtn) => {
     const filterKey = e.target.dataset.rifilterbtn
     removeInsCells()
     if (e.target.classList.contains("active")) {
-      riClearFilters()
+      riCloseFilter()
       return
     }
-    riClearFilters()
+    riCloseFilter()
     riClearBtn.classList.remove("dn")
 
     e.target.classList.add("active")
@@ -241,6 +352,23 @@ riFilterBtns.forEach((filterBtn) => {
       setCheck.addEventListener("click", function (e) {
         const filterKey = e.target.dataset.filter
 
+        // Store active filters
+        allFilters[filterKey] = []
+        riSetChecks.forEach((setCheck) => {
+          if (setCheck.checked === true) {
+            allFilters[filterKey].push(setCheck.value)
+          }
+        })
+
+        let activeFilterSets = 0
+        for (let activeFilter in allFilters) {
+          if (allFilters[activeFilter].length > 0) {
+            activeFilterSets++
+          }
+        }
+
+        comboFilter(allFilters)
+
         let showAllRows = true
         let queries = []
         riSetChecks.forEach((setCheck, i) => {
@@ -250,7 +378,9 @@ riFilterBtns.forEach((filterBtn) => {
           }
         })
 
-        renderResult(showAllRows, queries, filterKey)
+        renderResult(activeFilterSets, allFilters, showAllRows, queries, filterKey)
+
+        riEmptyCheck()
       })
     })
   })

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -83,7 +83,6 @@ function riCloseFilter() {
   if (clearFilters) {
     riClearFilters()
   }
-
 }
 
 // Clear all filters
@@ -113,6 +112,7 @@ riCutoffBtn.addEventListener("click", function () {
 })
 
 riClearBtn.addEventListener("click", function () {
+  riCloseFilter()
   riClearFilters()
 })
 

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -202,7 +202,6 @@ function renderResult(allFilters, showAllRows, filterKey) {
     // Always iterate in the same order
     const setOrder = ["rifamily", "riapi", "rireptype"]
 
-    console.log("helaftens")
     riRows.forEach((row) => {
       let setInd = 0
       let hideRow = true
@@ -236,6 +235,8 @@ function renderResult(allFilters, showAllRows, filterKey) {
         }
       })
 
+      // Insert additional cells
+      if (row.hidden === false) {
 
       //  queries.forEach((query) => {
         //  if (row.dataset[filterKey].toLowerCase().includes(query)) {
@@ -320,6 +321,7 @@ function renderResult(allFilters, showAllRows, filterKey) {
           // }
         // })
       //}
+      }
     })
   }
 }

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -385,14 +385,19 @@ riFilterBtns.forEach((filterBtn) => {
         const filterKey = e.target.dataset.filter
 
         // Store active filters
-        let showAllRows = true
         allFilters[filterKey] = []
         riSetChecks.forEach((setCheck) => {
           if (setCheck.checked === true) {
             allFilters[filterKey].push(setCheck.value)
-            showAllRows = false
           }
         })
+
+        let showAllRows = true
+        for (const [k, _] of Object.entries(allFilters)) {
+          if (allFilters[k].length > 0) {
+            showAllRows = false
+          }
+        }
 
         comboFilter(allFilters)
         renderResult(allFilters, showAllRows, filterKey)

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -206,6 +206,14 @@ function renderResult(allFilters, showAllRows, filterKey) {
       let setInd = 0
       let hideRow = true
 
+      if (filterKey === "rirepname") {
+        const query = allFilters
+        row.hidden = true
+        if (row.dataset[filterKey].toLowerCase().includes(query)) {
+            row.hidden = false
+        }
+
+      } else {
       setOrder.forEach((setName) => {
         const filterSet = allFilters[setName]
         if (filterSet) {
@@ -234,30 +242,10 @@ function renderResult(allFilters, showAllRows, filterKey) {
           setInd = setInd + 1
         }
       })
+    }
 
       // Insert additional cells
       if (row.hidden === false) {
-
-      //  queries.forEach((query) => {
-        //  if (row.dataset[filterKey].toLowerCase().includes(query)) {
-        //    row.hidden = false
-
-        //  riFilterSets.forEach((set) => {
-        //    if (allFilters[set.id] && set.id != filterKey) {
-        //      console.log(set.id)
-        //      allFilters[set.id].forEach((filtersetValue => {
-        //        if (row.dataset[set.id].includes(filtersetValue)) {
-        //          row.hidden = false
-        //        } else {
-        //          row.hidden = true
-        //        }
-        //      }
-        //    ))
-        //    }
-        //  })
-
-
-
             if (row.dataset.rifamily != prevFamily) {
               setId++
             }
@@ -318,33 +306,26 @@ function renderResult(allFilters, showAllRows, filterKey) {
 
             prevApi = row.dataset.riapi
             prevFamily = row.dataset.rifamily
-          // }
-        // })
-      //}
       }
     })
   }
 }
 
-// TODO: FIX this again, queries don’t work anymore
 // Input filter
 riFilterInput.addEventListener("keyup", function (e) {
   riHideCutoffs()
-  const query = e.target.value.toLowerCase()
+  let query = e.target.value.toLowerCase()
   const notEmpty = query.length >= 1 && query !== "-"
   const filterKey = "rirepname"
   let showAllRows = true
-  let queries = [""]
   if (notEmpty) {
     riClearBtn.classList.remove("dn")
     showAllRows = false
-    queries = [query]
   } else {
     riClearBtn.classList.add("dn")
   }
 
-  removeInsCells()
-  renderResult(showAllRows, queries, filterKey)
+  renderResult(query, showAllRows, filterKey)
   riEmptyCheck()
 })
 

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -319,7 +319,6 @@ riFilterInput.addEventListener("keyup", function (e) {
 riFilterBtns.forEach((filterBtn) => {
   filterBtn.addEventListener("click", function (e) {
     const filterKey = e.target.dataset.rifilterbtn
-    removeInsCells()
     if (e.target.classList.contains("active")) {
       riCloseFilter()
       return

--- a/js/servicefiltering-ri.js
+++ b/js/servicefiltering-ri.js
@@ -184,9 +184,9 @@ function toggleCheckbox(box) {
 }
 
 // Render result
-function renderResult(activeFilterSets, allFilters, showAllRows, queries, filterKey) {
+function renderResult(allFilters, showAllRows, filterKey) {
   removeInsCells()
-  if (/*activeFilterSets <= 0 ||*/ showAllRows) {
+  if (showAllRows) {
     riRows.forEach((row) => {
       hideOriginals(false)
       row.hidden = false
@@ -199,33 +199,63 @@ function renderResult(activeFilterSets, allFilters, showAllRows, queries, filter
     let prevApi = ""
     let apiId = 0
     let apiCount = 1
-    riRows.forEach((row) => {
-      row.hidden = true
+    // Always iterate in the same order
+    const setOrder = ["rifamily", "riapi", "rireptype"]
 
-      /*
-      // Check if row data matches at least one active filter in each active filterset
-      let matches = 0
-      for (const activeFilter in allFilters) {
-        if (allFilters[activeFilter].length > 0) {
-          const currentFilters = allFilters[activeFilter]
-          const rowDataAtt = '[data-filter="' + activeFilter + '"]'
-          currentFilters.forEach((currentFilter) => {
-            if (row.querySelector(rowDataAtt)) {
-              const currentRowData = row
-                .querySelector(rowDataAtt)
-                .textContent.toLowerCase()
-              if (currentRowData === currentFilter.toLowerCase()) {
-                matches++
-              }
-            }
-          })
-        }
-      }
-      if (matches === activeFilterSets) {
-      */
-        queries.forEach((query) => {
-          if (row.dataset[filterKey].toLowerCase().includes(query)) {
+    console.log("helaftens")
+    riRows.forEach((row) => {
+      let setInd = 0
+      let hideRow = true
+
+      setOrder.forEach((setName) => {
+        const filterSet = allFilters[setName]
+        if (filterSet) {
+
+          // Show all rows before applying filters
+          if (setInd === 0 ) {
             row.hidden = false
+          }
+
+          if (row.hidden === false ) {
+            let alreadyVisible = false
+            filterSet.forEach((filter => {
+              // Avoid re-checking already visible rows
+              if (!alreadyVisible) {
+                if (row.dataset[setName] === filter) {
+                  hideRow = false
+                  alreadyVisible = true
+                }
+                else {
+                  hideRow = true
+                }
+              }
+            }))
+          }
+          row.hidden = hideRow
+          setInd = setInd + 1
+        }
+      })
+
+
+      //  queries.forEach((query) => {
+        //  if (row.dataset[filterKey].toLowerCase().includes(query)) {
+        //    row.hidden = false
+
+        //  riFilterSets.forEach((set) => {
+        //    if (allFilters[set.id] && set.id != filterKey) {
+        //      console.log(set.id)
+        //      allFilters[set.id].forEach((filtersetValue => {
+        //        if (row.dataset[set.id].includes(filtersetValue)) {
+        //          row.hidden = false
+        //        } else {
+        //          row.hidden = true
+        //        }
+        //      }
+        //    ))
+        //    }
+        //  })
+
+
 
             if (row.dataset.rifamily != prevFamily) {
               setId++
@@ -287,13 +317,14 @@ function renderResult(activeFilterSets, allFilters, showAllRows, queries, filter
 
             prevApi = row.dataset.riapi
             prevFamily = row.dataset.rifamily
-          }
-        })
+          // }
+        // })
       //}
     })
   }
 }
 
+// TODO: FIX this again, queries don’t work anymore
 // Input filter
 riFilterInput.addEventListener("keyup", function (e) {
   riHideCutoffs()
@@ -352,33 +383,17 @@ riFilterBtns.forEach((filterBtn) => {
         const filterKey = e.target.dataset.filter
 
         // Store active filters
+        let showAllRows = true
         allFilters[filterKey] = []
         riSetChecks.forEach((setCheck) => {
           if (setCheck.checked === true) {
             allFilters[filterKey].push(setCheck.value)
+            showAllRows = false
           }
         })
-
-        let activeFilterSets = 0
-        for (let activeFilter in allFilters) {
-          if (allFilters[activeFilter].length > 0) {
-            activeFilterSets++
-          }
-        }
 
         comboFilter(allFilters)
-
-        let showAllRows = true
-        let queries = []
-        riSetChecks.forEach((setCheck, i) => {
-          if (setCheck.checked === true) {
-            showAllRows = false
-            queries[i] = setCheck.value.toLowerCase()
-          }
-        })
-
-        renderResult(activeFilterSets, allFilters, showAllRows, queries, filterKey)
-
+        renderResult(allFilters, showAllRows, filterKey)
         riEmptyCheck()
       })
     })

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -437,7 +437,10 @@
                 {{- partial "api/servicefilter.html" (dict "scratcher" ($.Scratch.Get "rireptype") "filter" "rireptype" ) -}}
               </div>
             </div>
-            <button type="button" id="ri-clearfilters" class="btn-link--dark mtl mrl dn">Clear all filters</button>
+            <div class="maxw100p">
+              <div id="ri-filtercombo" class="mtm mrm text-note"></div>
+              <button type="button" id="ri-clearfilters" class="btn-link--dark mtl mrl dn">Clear all filters</button>
+            </div>
           </div>
           <table id="services-ri">
             <thead>


### PR DESCRIPTION
Adds combination filtering to Reports and Invoice table similar to how the booking and shipping guide works.
Keeps track of the selected filters in an object, but has to loop through that object in a given order so the rendering works.
Had to redo/simplify the text input filtering as a result of this.

Will do a separate PR with some formatting – didn’t want to introduce a lot of extra whitespace changes now.