### PR TITLE
Check for existence of elements using VAS anchors

### DIFF
--- a/js/servicefiltering-vas.js
+++ b/js/servicefiltering-vas.js
@@ -183,14 +183,18 @@ function scrollToVasTarget(targetElement){
   const offsetPosition = elementPosition + window.pageYOffset - headerOffset
 
   const vasBtnParent = element.parentElement
-    
+
   const vasBtnToggler = vasBtnParent.querySelector('[data-collapse]')
-  vasBtnToggler.classList.remove('dev-collapsible__toggler--collapsed')
-  vasBtnToggler.classList.add('dev-collapsible__toggler--expanded')
+  if (vasBtnToggler) {
+    vasBtnToggler.classList.remove('dev-collapsible__toggler--collapsed')
+    vasBtnToggler.classList.add('dev-collapsible__toggler--expanded')
+  }
 
   const vasItemContent = vasBtnParent.querySelector('[data-vas-element]')
-  vasItemContent.classList.remove('dev-collapsible__item--collapsed')
-  vasItemContent.classList.add('dev-collapsible__item--expanded')
+  if (vasItemContent) {
+    vasItemContent.classList.remove('dev-collapsible__item--collapsed')
+    vasItemContent.classList.add('dev-collapsible__item--expanded')
+  }
 
   window.scrollTo({
        top: offsetPosition,


### PR DESCRIPTION
Got some complaints from the console when there wasn’t an anchor link to use when querying for the elements in the VAS overview.