### PR TITLE
Make copy button content visible on keyboard focus

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -81,7 +81,7 @@
 
 summary {
   padding-left: 0.25em;
-  padding-bottom: .05em;
+  padding-bottom: 0.05em;
   border-radius: 2px;
 }
 
@@ -159,8 +159,8 @@ summary:hover {
 }
 
 .btn-link--copy {
-  top:.5rem;
-  right:1.2rem;
+  top: 0.5rem;
+  right: 1.2rem;
   background-color: hsl(200, 17%, 30%);
   color: hsl(0, 0%, 85%);
 }
@@ -229,7 +229,7 @@ summary.error-code:hover {
 }
 
 .schema-type-select {
-  height:auto;
+  height: auto;
 }
 
 .schema__sublist {
@@ -258,9 +258,9 @@ summary.error-code:hover {
 }
 
 .param-collapsed-btn {
-  box-sizing:border-box;
-  width:100%;
-  justify-content:flex-start;
+  box-sizing: border-box;
+  width: 100%;
+  justify-content: flex-start;
 }
 
 .param-toggle-icon {
@@ -289,7 +289,7 @@ summary.error-code:hover {
 }
 
 .minw0 {
-  min-width:0;
+  min-width: 0;
 }
 
 .wrap-text {

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -164,11 +164,15 @@ summary:hover {
   background-color: hsl(200, 17%, 30%);
   color: hsl(0, 0%, 85%);
 }
-.btn-link--copy:hover {
+
+.btn-link--copy:hover,
+.btn-link--copy:focus-visible {
   background-color: hsl(199, 17%, 36%);
   color: hsl(0, 0%, 100%);
 }
-.btn-link--copy:hover svg {
+
+.btn-link--copy:hover svg,
+.btn-link--copy:focus-visible svg {
   color: hsl(0, 0%, 100%);
 }
 


### PR DESCRIPTION
Just a quick fix for the below issue:
<img width="535" alt="Screenshot 2022-04-04 at 12 41 39" src="https://user-images.githubusercontent.com/9307503/161534641-31a6a3f6-a524-41f5-a498-5ec23585810b.png">
