### PR TITLE
Add checkout request builder to API menu

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -72,6 +72,15 @@ title = "Checkout"
 weight = 1
 
 [[menu.apidocs]]
+parent = "checkout"
+title = "Checkout request builder"
+url = "https://www.mybring.com/shipping-guide/integration/checkout"
+weight = 15
+
+[menu.apidocs.params]
+blank = "target=\"_blank\" rel=\"noopener noreferrer\""
+
+[[menu.apidocs]]
 identifier = "book"
 title = "Booking"
 weight = 2

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -6,10 +6,18 @@
   {{- $oasData = getJSON . -}}
 {{- end -}}
 
+{{- $target := "" -}}
+{{- $iconEx := "" -}}
+{{- with $currentMenuItem.Params.blank -}}
+  {{- $target = . -}}
+  {{- $iconEx = "<span data-mybicon='mybicon-external-link' data-mybicon-class='mls dev-sidemenu__icon' data-mybicon-width='14' data-mybicon-height='14'></span>" -}}
+{{- end -}}
+{{ .Params }}
+
 <li
 class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $currentMenuItem }}active{{ end }}"
 >
-  <a href="{{ .url }}" class="dev-sidemenu__apititle">{{ .pageTitle }}</a>
+  <a href="{{ .url }}" class="dev-sidemenu__apititle" {{ $target | safeHTMLAttr }}>{{ .pageTitle }}{{ safeHTML $iconEx }}</a>
   {{- if $currentPage.IsMenuCurrent $currentMenu $currentMenuItem -}}
     <ul class="dev-sidemenu__sublist">
       {{- range $currentPage.Params.documentation -}}


### PR DESCRIPTION
A temporary exception for checkout request builder until we have some sort of checkout section that works as a getting started / resource.

Don’t merge until GO from Checkout team.