### PR TITLE
Check for schema content not just content

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -133,38 +133,53 @@
                           {{- end -}}
 
                           {{- $description := .description -}}
-                          {{- with .content -}}
-                          <details class="mbs">
-                            <summary class="{{ $responseColor }} pas" aria-label="Response {{$response}} {{$description}} details dropdown"><span class="fw600">{{ $response }}</span> {{ $description }}</summary>
-                          
-                            <div class="bg-gray1 pam">
-                              <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Response schema:</label>
-                              <select id="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib schema-type-select">
-                                {{- $selected := "selected" -}}
-                                {{- range $applicationType, $_ := . -}}
-                                  <option value='schemaType-{{$response}}-{{$endpointId}}-{{$applicationType}}' {{$selected | safeHTMLAttr}}>
-                                    {{ $applicationType }}
-                                  </option>
-                                  {{$selected = ""}}
-                                {{- end -}}
-                              </select>
 
-                              {{- range $application, $_ := . -}}
-                                <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
-                                {{/*  Finding the schemarefs and using those in the partial to recursively output the schema data  */}}
-                                {{- range $key, $_ := .schema -}}
-                                  {{- if reflect.IsMap . -}}
-                                    {{- range . -}}
-                                      {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
-                                    {{- end -}}
-                                  {{- else if eq $key "$ref" -}}
-                                      {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
-                                  {{- end -}}
+                          {{ $hasSchema := false }}
+                          {{- with .content -}}
+                            {{- range . -}}
+                              {{/*  since go template doesn’t have loop breaks  */}}
+                              {{- if not $hasSchema -}}
+                                {{- with .schema -}}
+                                  {{- $hasSchema = true -}}
                                 {{- end -}}
-                                </dl>
                               {{- end -}}
-                              </div>
-                          </details>
+                            {{- end -}}
+                          {{- end -}}
+
+                          {{- if $hasSchema -}}
+                            {{- with .content -}}
+                            <details class="mbs">
+                              <summary class="{{ $responseColor }} pas" aria-label="Response {{$response}} {{$description}} details dropdown"><span class="fw600">{{ $response }}</span> {{ $description }}</summary>
+
+                              <div class="bg-gray1 pam">
+                                <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Response schema:</label>
+                                <select id="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib schema-type-select">
+                                  {{- $selected := "selected" -}}
+                                  {{- range $applicationType, $_ := . -}}
+                                    <option value='schemaType-{{$response}}-{{$endpointId}}-{{$applicationType}}' {{$selected | safeHTMLAttr}}>
+                                      {{ $applicationType }}
+                                    </option>
+                                    {{$selected = ""}}
+                                  {{- end -}}
+                                </select>
+
+                                {{- range $application, $_ := . -}}
+                                  <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
+                                  {{/*  Finding the schemarefs and using those in the partial to recursively output the schema data  */}}
+                                  {{- range $key, $_ := .schema -}}
+                                    {{- if reflect.IsMap . -}}
+                                      {{- range . -}}
+                                        {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
+                                      {{- end -}}
+                                    {{- else if eq $key "$ref" -}}
+                                        {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
+                                    {{- end -}}
+                                  {{- end -}}
+                                  </dl>
+                                {{- end -}}
+                                </div>
+                            </details>
+                            {{- end -}}
                           {{- else -}}
                             <div class="{{ $responseColor }} pas mbs"><span class="fw600">{{ $response }}</span> {{ $description }}</div>
                           {{- end -}}


### PR DESCRIPTION
Makes it possible to have examples without having schemas
Extra special conditional used since go’s break tag doesn’t exist in go template https://github.com/golang/go/issues/20531