### PR TITLE
Add info about deprecating v1 tracking in dev site

### DIFF
--- a/content/api/revision-history/2022-06-22.md
+++ b/content/api/revision-history/2022-06-22.md
@@ -1,6 +1,6 @@
 ---
 title: Tracking API
-publishDate: 2022-08-01
+publishDate: 2022-06-22
 layout: api
 ---
 

--- a/content/api/revision-history/2022-06-22.md
+++ b/content/api/revision-history/2022-06-22.md
@@ -4,5 +4,4 @@ publishDate: 2022-06-22
 layout: api
 ---
 
-Starting 1 August 2022, we will be deprecating the v1 version of Tracking API.
-It is not a breaking change. In the new version you will have access to many more fields.
+Starting 1 August 2022, Tracking API version v1 will be deprecated and the requests will be automatically forwarded to the latest version, v2.

--- a/content/api/revision-history/2022-08-01.md
+++ b/content/api/revision-history/2022-08-01.md
@@ -1,0 +1,8 @@
+---
+title: Tracking API
+publishDate: 2022-08-01
+layout: api
+---
+
+Starting 1 August 2022, we will be deprecating the v1 version of Tracking API.
+It is not a breaking change. In the new version you will have access to many more fields.

--- a/content/api/tracking/_index.md
+++ b/content/api/tracking/_index.md
@@ -12,6 +12,10 @@ weight: 31
  
 important:
   - type: warn
+    title: Deprecating v1 version of Tracking API - 01.08.2022
+    message: |
+     Starting 1 August 2022, we will be deprecating the v1 version of Tracking API. It is not a breaking change. In the new version you will have access to many more fields.
+  - type: warn
     title: Removed pickup code from open tracking - 04.02.2022
     message: |
      As an increased security measure, as of Feb. 4th 2022 we will hide the pickup code from open Tracking API. Logged in Tracking API will still contain the pickup code.

--- a/content/api/tracking/_index.md
+++ b/content/api/tracking/_index.md
@@ -76,7 +76,7 @@ documentation:
       ```
 
       ### Select version by URL
-      Use the normal URL, but add `{v1, v2}` to the URL. Example:
+      Use the normal URL, but add `{v2}` to the URL. Example:
 
       | Application | URL example |
       |:-------|:--------|

--- a/content/api/tracking/_index.md
+++ b/content/api/tracking/_index.md
@@ -14,7 +14,7 @@ important:
   - type: warn
     title: Deprecating v1 version of Tracking API - 01.08.2022
     message: |
-     Starting 1 August 2022, we will be deprecating the v1 version of Tracking API. It is not a breaking change. In the new version you will have access to many more fields.
+     Starting 1 August 2022, Tracking API version v1 will be deprecated and the requests will be automatically forwarded to the latest version, v2.
   - type: warn
     title: Removed pickup code from open tracking - 04.02.2022
     message: |

--- a/content/api/tracking/api.raml
+++ b/content/api/tracking/api.raml
@@ -285,8 +285,8 @@ types:
   description: Get information about an existing shipment based on a tracking number, shipment number or reference.
   uriParameters:
     version:
-      enum: [ v1, v2 ]
-      description: v1 is deprecated and will be removed soon. Use v2 when requesting the tracking API
+      enum: [ v2 ]
+      description: Use v2 when requesting the tracking API
     mediaTypeExtension:
       enum: [ .json, .xml ]
       description: Use .json to specify application/json or .xml to specify application/xml

--- a/content/api/tracking/new.md
+++ b/content/api/tracking/new.md
@@ -69,7 +69,7 @@ documentation:
       ```
 
       ### Select version by URL
-      Use the normal URL, but add `{v1, v2}` to the URL. Example:
+      Use the normal URL, but add `{v2}` to the URL. Example:
 
       | Application | URL example |
       |:-------|:--------|

--- a/content/api/tracking/new.md
+++ b/content/api/tracking/new.md
@@ -5,6 +5,10 @@ hidden: true
  
 important:
   - type: warn
+    title: Deprecating v1 version of Tracking API - 01.08.2022
+    message: |
+     Starting 1 August 2022, we will be deprecating the v1 version of Tracking API. It is not a breaking change. In the new version you will have access to many more fields.
+  - type: warn
     title: Removed pickup code from open tracking - 04.02.2022
     message: |
      As an increased security measure, as of Feb. 4th 2022 we will hide the pickup code from open Tracking API. Logged in Tracking API will still contain the pickup code.

--- a/content/api/tracking/new.md
+++ b/content/api/tracking/new.md
@@ -7,7 +7,7 @@ important:
   - type: warn
     title: Deprecating v1 version of Tracking API - 01.08.2022
     message: |
-     Starting 1 August 2022, we will be deprecating the v1 version of Tracking API. It is not a breaking change. In the new version you will have access to many more fields.
+     Starting 1 August 2022, Tracking API version v1 will be deprecated and the requests will be automatically forwarded to the latest version, v2.
   - type: warn
     title: Removed pickup code from open tracking - 04.02.2022
     message: |


### PR DESCRIPTION
We will be deprecating the v1 version of Tracking API starting 1 August 2022. 

Information about the change has been added to the revision history and a warning has been added to the Tracking API site.
Information about v1 have also been removed from the documentation.