### PR TITLE
Only render $ref examples once

### DIFF
--- a/layouts/partials/api/oas/responseexample-components.html
+++ b/layouts/partials/api/oas/responseexample-components.html
@@ -24,11 +24,16 @@
               {{- if gt (len .examples) 1 -}}
               <div class="phm pvm bg-gray4">
                 <select class="form__control w100p mb0" name="{{$responseId}}" data-example-sub aria-label="Response code {{$response}} example">
-                  {{- range $name, $_ := .examples -}}
-                    {{- range . -}}
-                      {{- $exPath := path.Split . -}}
-                      {{- $exId := print $responseId "-" $exPath.File -}}
-                      <option value="{{$exId}}">{{$name}}</option>
+                  {{- range $name, $val := .examples -}}
+                    {{- with $val.description -}}
+                      {{- $name = . -}}
+                    {{- end -}}
+                    {{- range $k, $_ := . -}}
+                      {{- if eq $k "$ref" -}}
+                        {{- $exPath := path.Split . -}}
+                        {{- $exId := print $responseId "-" $exPath.File -}}
+                        <option value="{{ $exId }}">{{ $name }}</option>
+                      {{- end -}}
                     {{- end -}}
                   {{- end -}}
                 </select>
@@ -38,19 +43,21 @@
               {{- $exInd := 0 -}}
 
               {{- range .examples -}}
-                {{- range . -}}
-                  {{- $exPath := path.Split . -}}
-                  {{- $exId := print $responseId "-" $exPath.File -}}
-                  <div class="relative" data-example-sub="{{$exId}}" {{if ne $exInd 0}}hidden{{end}}>
-                    {{- range index $components.examples $exPath.File -}}
-                      {{- $codeExample = . | jsonify (dict "indent" "  ") -}}
-                      {{- $codeExample = replace $codeExample "\\u0026" "&" -}}
-                      {{- highlight $codeExample "json" -}}
-                    {{- end -}}
-                    {{- partial "api/oas/copy-btn.html" -}}
-                  </div>
+                {{- range $k, $_ := . -}}
+                  {{- if eq $k "$ref" -}}
+                    {{- $exPath := path.Split . -}}
+                    {{- $exId := print $responseId "-" $exPath.File -}}
+                    <div class="relative" data-example-sub="{{ $exId }}" {{ if ne $exInd 0 }}hidden{{ end }}>
+                      {{- range index $components.examples $exPath.File -}}
+                        {{- $codeExample = . | jsonify (dict "indent" "  ") -}}
+                        {{- $codeExample = replace $codeExample "\\u0026" "&" -}}
+                        {{- highlight $codeExample "json" -}}
+                      {{- end -}}
+                      {{- partial "api/oas/copy-btn.html" -}}
+                    </div>
+                    {{- $exInd = add $exInd 1 -}}
+                  {{- end -}}
                 {{- end -}}
-                {{- $exInd = add $exInd 1 -}}
               {{- end -}}
             {{- end -}}
           {{- end -}}

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -30,17 +30,23 @@
                 {{- if gt (len .examples) 1 -}}
                   <div class="phm pvm bg-gray4">
                     <select class="form__control w100p mb0" name="{{$responseId}}" data-example-sub aria-label="Response code {{$response}} example">
-                      {{- range $name, $_ := .examples -}}
+                      {{- range $name, $val := .examples -}}
+                        {{- with $val.description -}}
+                          {{- $name = . -}}
+                        {{- end -}}
                         {{- $exId := print $responseId "-" $name -}}
-                        <option value="{{$exId}}">{{$name}}</option>
+                        <option value="{{ $exId }}">{{ $name }}</option>
                       {{- end -}}
                     </select>
                   </div>
                 {{- end -}}
                 {{- $exInd := 0 -}}
-                {{- range $name,$_ := .examples -}}
+                {{- range $name, $val := .examples -}}
+                  {{- with $val.description -}}
+                    {{- $name = . -}}
+                  {{- end -}}
                   {{- $exId := print $responseId "-" $name -}}
-                  <div class="relative" data-example-sub="{{$exId}}" {{if ne $exInd 0}}hidden{{end}}>
+                  <div class="relative" data-example-sub="{{ $exId }}" {{ if ne $exInd 0 }}hidden{{ end }}>
                     {{- $codeExample = .value | jsonify (dict "indent" "  ") -}}
                     {{- highlight $codeExample "json" -}}
                     {{- partial "api/oas/copy-btn.html" -}}


### PR DESCRIPTION
- Prevent additional values inside example objects with $ref to render as separate examples
- Use description as name if it exists, instead of the key even though they usually are the same