### PR TITLE
Add XML schema

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -221,7 +221,7 @@ summary.error-code:hover {
 .schema__sublist {
   border-left-style: dashed;
   border-width: 1px;
-  margin: 0 0.75rem;
+  margin: 0 0.25rem 0 0.75rem;
 }
 
 .desc-list > div {

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -167,21 +167,32 @@
                                   </select>
 
                                   {{- range $application, $_ := . -}}
-                                    <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
-                                    {{/*  Finding the schemarefs and using those in the partial to recursively output the schema data  */}}
-                                    {{- range $key, $_ := .schema -}}
-                                      {{- if reflect.IsMap . -}}
-                                        {{- range . -}}
-                                          {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
-                                        {{- end -}}
-                                      {{- else if eq $key "$ref" -}}
-                                          {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId) -}}
-                                      {{- end -}}
+                                    {{- $format := "" -}}
+                                    {{- if in $application "json" -}}
+                                      {{- $format = "json" -}}
+                                    {{- else if in $application "xml" -}}
+                                      {{- $format = printf "xml" -}}
                                     {{- end -}}
+
+                                    <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
+                                      {{/*  TODO: pass the entire .schema in for non-XML as well  */}}
+                                      {{- if eq "xml" $format -}}
+                                        {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
+                                      {{- else -}}
+                                        {{- range $key, $_ := .schema -}}
+                                          {{- if reflect.IsMap . -}}
+                                            {{- range . -}}
+                                              {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId "application" $application) -}}
+                                            {{- end -}}
+                                          {{- else if eq $key "$ref" -}}
+                                            {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId "application" $application) -}}
+                                          {{- end -}}
+                                        {{- end -}}
+                                      {{- end -}}
                                     </dl>
                                   {{- end -}}
                                   </div>
-                              </details>
+                                </details>
                               {{- end -}}
                             {{- else -}}
                               <div class="{{ $responseColor }} pas mbs"><span class="fw600">{{ $response }}</span> {{ $description }}</div>

--- a/layouts/partials/api/oas/param-toggle-btn-xml.html
+++ b/layouts/partials/api/oas/param-toggle-btn-xml.html
@@ -1,0 +1,9 @@
+<button id="{{ .levelId }}" title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn">
+  <span
+    data-mybicon="mybicon-arrow-right"
+    data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 3}}rotate-icon-90{{end}}"
+    data-mybicon-width="16"
+    data-mybicon-height="16">
+  </span>
+    <code>{{ .name }}</code>
+</button>

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -7,56 +7,18 @@
 {{- $recLevel := add .recLevel 1 -}}
 
 {{/*  If there’s a ref, pass the destination data again  */}}
-{{ $isRef := "false" }}
-{{ range $key, $_ := $schemaObj }}
-{{ if eq $key "$ref" }}
-  {{ $isRef = true }}
+{{- $isRef := "false" -}}
+{{- range $key, $_ := $schemaObj -}}
+{{- if eq $key "$ref" -}}
+  {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
     {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
-  {{ end }}
-{{ end }}
+  {{- end -}}
+{{- end -}}
 
-{{/*  If object, render and pass properties again  */}}
-{{ if eq $schemaObj.type "object" }}
-  {{ with $schemaObj.xml.name }}
-    {{ $name = . }}
-  {{ end }}
-  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
-  {{- $uniqueId = slicestr $generateId 0 15 -}}
-  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
-  <div class="mb-border bb bw1 mbs">
-    <div class="flex flex-wrap align-ifs pbs">
-      <dt>
-        {{ with $schemaObj.properties }}
-          {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
-        {{ else }}
-          <code class="mls">{{ $name }}</code>
-        {{ end }}
-        {{- if $required -}}
-          <div class="plm mls lh-solid param-required text-note">Required</div>
-        {{ end }}
-      </dt>
-      <dd class="ptxs pls">
-        {{ with $schemaObj.description }}
-          {{ . }}
-        {{ end }}
-        <div class="gray text-note">{{ $schemaObj.type }}</div>
-      </dd>
-    </div>
-    {{ with $schemaObj.properties }}
-      <dd class="schema__sublist mb-border {{if gt $recLevel 2}}dn{{end}}" data-sublevel-id="{{$levelId}}">
-        <dl class="pls">
-          {{ range $key, $_ := . }}
-            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
-          {{ end }}
-        </dl>
-      </dd>
-    {{ end }}
-  </div>
-
-{{/*  If array, render and pass the items again  */}}
-{{ else if eq $schemaObj.type "array" }}
+{{/*  If object or array, render and pass properties or items again  */}}
+{{- if or (eq $schemaObj.type "object") (eq $schemaObj.type "array") -}}
   {{- with $schemaObj.xml.name -}}
     {{- $name = . -}}
   {{- end -}}
@@ -66,19 +28,19 @@
   <div class="mb-border bb bw1 mbs">
     <div class="flex flex-wrap align-ifs pbs">
       <dt>
-        {{ with $schemaObj.items }}
+        {{- if or ($schemaObj.properties) ($schemaObj.items) -}}
           {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
-        {{ else }}
+        {{- else -}}
           <code class="mls">{{ $name }}</code>
-        {{ end }}
+        {{- end -}}
         {{- if $required -}}
           <div class="plm mls lh-solid param-required text-note">Required</div>
         {{- end -}}
       </dt>
       <dd class="ptxs pls">
-        {{ with $schemaObj.description }}
+        {{- with $schemaObj.description -}}
           {{ . }}
-        {{ end }}
+        {{- end -}}
         <div class="gray text-note">
           {{- $schemaObj.type -}}
           {{- if $schemaObj.xml.wrapped -}}
@@ -87,20 +49,31 @@
         </div>
       </dd>
     </div>
-    {{ with $schemaObj.items }}
-      <dd class="schema__sublist mb-border {{if gt $recLevel 2}}dn{{end}}" data-sublevel-id="{{$levelId}}">
+    {{/*  object  */}}
+    {{- with $schemaObj.properties -}}
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dl class="pls">
+          {{- range $key, $_ := . -}}
+            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- end -}}
+        </dl>
+      </dd>
+    {{- end -}}
+    {{/*  array  */}}
+    {{- with $schemaObj.items -}}
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
         <dl class="pls">
           {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" "" "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
         </dl>
       </dd>
-    {{ end }}
+    {{- end -}}
   </div>
 
 {{/*  If neither obj, arr or ref, render the item */}}
-{{ else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) }}
-  {{ with $schemaObj.xml.name }}
-    {{ $name = . }}
-  {{ end }}
+{{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}
+  {{- with $schemaObj.xml.name -}}
+    {{- $name = . -}}
+  {{- end -}}
   <div class="mb-border bb bw1 mbs pbs pls">
     <div class="flex flex-wrap align-ifs">
       <dt>
@@ -110,9 +83,9 @@
         {{- end -}}
       </dt>
       <dd class="pls">
-        {{ with $schemaObj.description }}
+        {{- with $schemaObj.description -}}
           {{ . }}
-        {{ end }}
+        {{- end -}}
         <div class="gray text-note">
           {{- $schemaObj.type -}}
           {{- with $schemaObj.format -}}
@@ -126,11 +99,11 @@
         <div>
           <span class="text-note">Enum:</span>
           {{- range . -}}
-            <br><code class="wrap-text">{{- . -}}</code>
+            <br><code class="wrap-text">{{ . }}</code>
           {{- end -}}
         </div>
         {{- end -}}
       </dd>
     </div>
   </div>
-{{ end }}
+{{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -1,0 +1,136 @@
+{{- $schemaObj := .schemaObj -}}
+{{- $name := .name -}}
+{{- $required := .required -}}
+{{- $components := .components -}}
+{{- $endpointId := .endpointId -}}
+{{- $uniqueId := "" -}}
+{{- $recLevel := add .recLevel 1 -}}
+
+{{/*  If there’s a ref, pass the destination data again  */}}
+{{ $isRef := "false" }}
+{{ range $key, $_ := $schemaObj }}
+{{ if eq $key "$ref" }}
+  {{ $isRef = true }}
+    {{- $schemaPath := path.Split . -}}
+    {{- $schema := index $components.schemas $schemaPath.File -}}
+    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+  {{ end }}
+{{ end }}
+
+{{/*  If object, render and pass properties again  */}}
+{{ if eq $schemaObj.type "object" }}
+  {{ with $schemaObj.xml.name }}
+    {{ $name = . }}
+  {{ end }}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
+  <div class="mb-border bb bw1 mbs">
+    <div class="flex flex-wrap align-ifs pbs">
+      <dt>
+        {{ with $schemaObj.properties }}
+          {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+        {{ else }}
+          <code class="mls">{{ $name }}</code>
+        {{ end }}
+        {{- if $required -}}
+          <div class="plm mls lh-solid param-required text-note">Required</div>
+        {{ end }}
+      </dt>
+      <dd class="ptxs pls">
+        {{ with $schemaObj.description }}
+          {{ . }}
+        {{ end }}
+        <div class="gray text-note">{{ $schemaObj.type }}</div>
+      </dd>
+    </div>
+    {{ with $schemaObj.properties }}
+      <dd class="schema__sublist mb-border {{if gt $recLevel 2}}dn{{end}}" data-sublevel-id="{{$levelId}}">
+        <dl class="pls">
+          {{ range $key, $_ := . }}
+            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{ end }}
+        </dl>
+      </dd>
+    {{ end }}
+  </div>
+
+{{/*  If array, render and pass the items again  */}}
+{{ else if eq $schemaObj.type "array" }}
+  {{- with $schemaObj.xml.name -}}
+    {{- $name = . -}}
+  {{- end -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
+  <div class="mb-border bb bw1 mbs">
+    <div class="flex flex-wrap align-ifs pbs">
+      <dt>
+        {{ with $schemaObj.items }}
+          {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+        {{ else }}
+          <code class="mls">{{ $name }}</code>
+        {{ end }}
+        {{- if $required -}}
+          <div class="plm mls lh-solid param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="ptxs pls">
+        {{ with $schemaObj.description }}
+          {{ . }}
+        {{ end }}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+          {{- if $schemaObj.xml.wrapped -}}
+            {{- print " wrapped" -}}
+          {{- end -}}
+        </div>
+      </dd>
+    </div>
+    {{ with $schemaObj.items }}
+      <dd class="schema__sublist mb-border {{if gt $recLevel 2}}dn{{end}}" data-sublevel-id="{{$levelId}}">
+        <dl class="pls">
+          {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" "" "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+        </dl>
+      </dd>
+    {{ end }}
+  </div>
+
+{{/*  If neither obj, arr or ref, render the item */}}
+{{ else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) }}
+  {{ with $schemaObj.xml.name }}
+    {{ $name = . }}
+  {{ end }}
+  <div class="mb-border bb bw1 mbs pbs pls">
+    <div class="flex flex-wrap align-ifs">
+      <dt>
+        <code>{{ $name }}</code>
+        {{- if $required -}}
+          <div class="lh-tight param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="pls">
+        {{ with $schemaObj.description }}
+          {{ . }}
+        {{ end }}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+          {{- with $schemaObj.format -}}
+            {{- printf " <%s>" . -}}
+          {{- end -}}
+          {{- if $schemaObj.xml.attribute -}}
+            {{- print " attribute" -}}
+          {{- end -}}
+        </div>
+        {{- with $schemaObj.enum -}}
+        <div>
+          <span class="text-note">Enum:</span>
+          {{- range . -}}
+            <br><code class="wrap-text">{{- . -}}</code>
+          {{- end -}}
+        </div>
+        {{- end -}}
+      </dd>
+    </div>
+  </div>
+{{ end }}


### PR DESCRIPTION
- Renders XML specific schema
- Keeps the root level open by default
- Some visual details are different from the JSON render, but that will be fixed in an upcoming task to improve how that is rendered. 
- The major difference in this new template is that the entire .schema is passed to it before looping. And we check the given type in the data source instead of checking the type of the actual data structure. We trust that an object is an object if it says so – but we’re instead being more defensive about what it might contain. The basic structure is easier to follow:
  - If it’s a ref to a different place in .schema, go find the data for it and pass it in again
  - If it’s an object or an array (with descendants), start a new level and iterate/pass in the descendants one by one.
  - If it’s none of the above, it can just be shown, no need to iterate further.

Note that examples are still only JSON.