### PR TITLE
Param and schema details

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -151,20 +151,31 @@
 
                             {{- if $hasSchema -}}
                               {{- with .content -}}
+                              {{- $multiSchema := false -}}
+                              {{- if gt (len .) 1 -}}
+                                {{- $multiSchema = true -}}
+                              {{- end -}}
                               <details class="mbs">
                                 <summary class="{{ $responseColor }} pas" aria-label="Response {{$response}} {{$description}} details dropdown"><span class="fw600">{{ $response }}</span> {{ $description }}</summary>
 
                                 <div class="bg-gray1 pam">
-                                  <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Response schema:</label>
-                                  <select id="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib schema-type-select">
-                                    {{- $selected := "selected" -}}
+                                  <h4>Schema</h4>
+                                  {{- if $multiSchema -}}
+                                    <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Media type:</label>
+                                    <select id="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib schema-type-select hauto">
+                                      {{- $selected := "selected" -}}
+                                      {{- range $applicationType, $_ := . -}}
+                                        <option value='schemaType-{{$response}}-{{$endpointId}}-{{$applicationType}}' {{$selected | safeHTMLAttr}}>
+                                          {{ $applicationType }}
+                                        </option>
+                                        {{- $selected = "" -}}
+                                      {{- end -}}
+                                    </select>
+                                  {{- else -}}
                                     {{- range $applicationType, $_ := . -}}
-                                      <option value='schemaType-{{$response}}-{{$endpointId}}-{{$applicationType}}' {{$selected | safeHTMLAttr}}>
-                                        {{ $applicationType }}
-                                      </option>
-                                      {{$selected = ""}}
+                                      <p>Media type: {{ $applicationType }}</p>
                                     {{- end -}}
-                                  </select>
+                                  {{- end -}}
 
                                   {{- range $application, $_ := . -}}
                                     {{- $format := "" -}}
@@ -174,7 +185,7 @@
                                       {{- $format = printf "xml" -}}
                                     {{- end -}}
 
-                                    <dl class="schema-type-container desc-list pam bshadow bg-white dn" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
+                                    <dl class="schema-type-container desc-list pam bshadow bg-white {{ if $multiSchema }}dn{{ end }}" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
                                       {{/*  TODO: pass the entire .schema in for non-XML as well  */}}
                                       {{- if eq "xml" $format -}}
                                         {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}

--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -74,39 +74,45 @@
         <dd class="pls">
           {{- .description -}}
           {{- if gt (len $description) 0 -}}
-              <p class="text-note mb0">{{$description}}</p>
+            <p class="mb0">{{$description}}</p>
           {{- end -}}
-          <div class="text-note gray">
+          <div class="gray">
             {{- $type -}}
           </div>
 
           {{- if and (reflect.IsSlice $enum) ( gt (len $enum) 0 ) -}}
-              <div class="text-note">
-                {{- if gt (len $enum) 1 -}}
-                  Enum:
-                {{- else -}}
-                  Value:
-                {{- end -}}
-              </div>
-              {{- range $enum -}}
-                <code class="mbxs db maxwmaxc">{{.}}</code>
+            <div class="fw600 mtxs">
+              {{- if gt (len $enum) 1 -}}
+                Enum
+              {{- else -}}
+                Value
               {{- end -}}
+            </div>
+            {{- range $enum -}}
+              <code class="mbxs db maxwmaxc">{{.}}</code>
+            {{- end -}}
           {{- end -}}
 
           {{- if gt (len $default) 0 -}}
-              <div class="text-note">Default:</div>
-              <code class="mbxs db maxwmaxc">"{{$default}}"</code>
+            <div class="fw600 mtxs">Default</div>
+            <code class="mbxs db maxwmaxc">"{{$default}}"</code>
           {{- end -}}
 
           {{- if gt (len $example) 0 -}}
-              <div class="text-note">Example:</div>
-              <code class="mbxs db maxwmaxc">{{$example}}</code>
+            <div class="fw600 mtxs">Example</div>
+            <code class="mbxs db maxwmaxc">{{$example}}</code>
           {{- end -}}
 
           {{- if gt (len $examples) 0 -}}
-            <div class="text-note">Examples:</div>
+            <div class="fw600 mtxs">
+              {{- if gt (len $examples) 1 -}}
+                Examples
+              {{- else -}}
+                Example
+              {{- end -}}
+            </div>
             {{- range $key, $value := $examples -}}
-              <p class="text-note fwb mb0">{{$key}}</p>
+              <p class="text-note mb0">{{$key}}</p>
               {{- if ne $key $value.description -}}
                 <p class="text-note mb0">{{$value.description}}</p>
               {{- end -}}

--- a/layouts/partials/api/oas/response-schema-dd.html
+++ b/layouts/partials/api/oas/response-schema-dd.html
@@ -21,7 +21,7 @@
   </div>
   {{- with .enum -}}
     <div>
-      <span class="text-note">Enum:</span>
+      <span class="text-note fw600">Enum</span>
       {{- range . -}}
         <br><code class="wrap-text">{{- . -}}</code>
       {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -97,7 +97,7 @@
         </div>
         {{- with $schemaObj.enum -}}
         <div>
-          <span class="text-note">Enum:</span>
+          <span class="text-note fw600">Enum</span>
           {{- range . -}}
             <br><code class="wrap-text">{{ . }}</code>
           {{- end -}}


### PR DESCRIPTION
- Put "Schema" as header inside responses
- Use "Media type" as label instead
- Use a p element instead of select when there’s only one media type
- Use slightly bolder text instead of colon for example/enum/default
- Use plural s when there are more than one example
- Make the parameter text regular size, but keeping small size in schema.

I think some of these can be improved further, the example/enum/header looks a bit too important in some cases. Maybe background sectioning could be an option in the next round.

<img width="707" alt="Screenshot 2022-07-01 at 06 53 56" src="https://user-images.githubusercontent.com/9307503/176828771-0de838af-42ac-45d2-9e62-3c86442638a0.png">
<img width="694" alt="Screenshot 2022-07-01 at 07 08 23" src="https://user-images.githubusercontent.com/9307503/176828782-0249a735-7974-4c28-baed-a040e63bcda0.png">
