### PR TITLE
adding text in the guide section as per recommendation

### DIFF
--- a/content/api/pickup-point/index.md
+++ b/content/api/pickup-point/index.md
@@ -13,7 +13,12 @@ aliases:
   - checkout-guide-norway/api/pickup-point/
 
 introduction: |
-  The Pickup Point API provides a list of pickup points that are nearest to a given location, in order for end customers to choose their preferred pickup point in your checkout. The API supports both manned pickup points and parcel lockers in Norway, Sweden, Denmark and Finland. Pickup points are sorted by driving time by car (source: Google). When driving times are unavailable (e.g. due to separation by sea), they are sorted by aerial distance. For precise results, we strongly recommend to use the end customer’s complete address (not only their postal code) when using the API.
+  The Pickup Point API provides a list of pickup points that are nearest to a given location, in order for end customers to choose their preferred pickup point in your checkout. The API supports both manned pickup points and parcel lockers in Norway, Sweden, Denmark and Finland. Pickup points are sorted by driving time by car (source: Google). When driving times are unavailable (e.g. due to separation by sea), they are sorted by aerial distance.
+
+guides:
+  - title: Smart Pickup point
+    content: |
+      For precise results, we strongly recommend to use the end customer’s complete address (not only their postal code) when using the API.
 
 information:
   - title: Authentication

--- a/content/api/pickup-point/index.md
+++ b/content/api/pickup-point/index.md
@@ -16,10 +16,20 @@ introduction: |
   The Pickup Point API provides a list of pickup points that are nearest to a given location, in order for end customers to choose their preferred pickup point in your checkout. The API supports both manned pickup points and parcel lockers in Norway, Sweden, Denmark and Finland. Pickup points are sorted by driving time by car (source: Google). When driving times are unavailable (e.g. due to separation by sea), they are sorted by aerial distance.
 
 guides:
-  - title: Smart Pickup point
-    content: |
-      For precise results, we strongly recommend to use the end customer’s complete address (not only their postal code) when using the API.
+- title: Smart pickup point usage
+  content: |
+    For precise results, we strongly recommend to use the end customer’s complete address (not only their postal code) when using the API.
 
+- title: Max parcel dimensions for Pakkeboks pickup points
+  content: |
+    Max parcel dimensions for Pakkeboks (parcel lockers in Norway) pickup points can now be used to filter out pickup points based on parcel size on the client side, and thus preventing failed bookings during checkout. JSON field:
+    ```json
+      "maxParcelDimensions": {
+        "length": 44.5,
+        "width": 50.5,
+        "height": 60.0
+      }
+    ```
 information:
   - title: Authentication
     content: |
@@ -32,18 +42,6 @@ information:
   - title: Formats
     content: |
       REST XML/JSON over HTTP.
-
-guides:
-  - title: Max parcel dimensions for Pakkeboks pickup points
-    content: |
-      Max parcel dimensions for Pakkeboks (parcel lockers in Norway) pickup points can now be used to filter out pickup points based on parcel size on the client side, and thus preventing failed bookings during checkout. JSON field:
-      ```json
-        "maxParcelDimensions": {
-          "length": 44.5,
-          "width": 50.5,
-          "height": 60.0
-        }
-      ```
 
 documentation:
   - title: Filtering results
@@ -80,6 +78,5 @@ documentation:
         - Type Posti: Finland Posti Pickup Point
         - Type Noutopiste: Finland Pickup Point
         - Type LOCKER: Finland Locker Pickup Point **_(These lockers are placed inside buildings only accessible to the residents and workers in the building)_**
-
 oas: https://api.qa.bring.com/pickuppoint/openapi.json
 ---


### PR DESCRIPTION
We are adding the text :

For precise results, we strongly recommend to use the end customer’s complete address (not only their postal code) when using the API.

in the newly created guide section in the developers website for smart usage of Pickup point.
