### PR TITLE
Add endpoint method to anchor links

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -125,7 +125,7 @@
                 {{- $components := .components -}}
                 {{- range $path, $_ := .paths -}}
                   {{- range $type, $_ := . -}}
-                    {{- $endpointId := .summary | anchorize -}}
+                    {{- $endpointId := (print .summary "-" $type | anchorize ) -}}
                     <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
                     <div class="flex flex-wrap mbxl pbxl mb-border bb gal">
                       <div class="param-response-area">

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -102,13 +102,20 @@
         {{- range .resources -}}
           {{- $resources := . -}}
           {{- $displayName := .displayName -}}
+          {{- $method := "" -}}
+          {{- range .methods -}}
+            {{- with .method -}}
+              {{- $method = . -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $endpointId := (print $displayName "-" $method | anchorize) -}}
           <section class="dev-docscontent__section maxw64r">
-            <h2 class="dev-anchored mbm" id="{{ $displayName | anchorize }}">
+            <h2 class="dev-anchored mbm" id="{{ $endpointId }}">
               {{- $displayName -}}
             </h2>
             {{- with .description -}}
               {{- if in (string .) "\n\n" -}}
-                {{ .| markdownify }}
+                {{ . | markdownify }}
                 {{- else -}}
                 <p>{{ . | markdownify }}</p>
               {{- end -}}

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -40,9 +40,11 @@ class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $curre
 
       {{- with $oasData -}}
         {{- range .paths -}}
-          {{- range . -}}
+          {{- range $k, $v := . -}}
+            {{- $method := $k -}}
+            {{- $endpointId := (print .summary "-" $method | anchorize) -}}
             <li>
-              <a href="#{{ .summary | anchorize }}" data-list-item="{{ .summary | anchorize }}">
+              <a href="#{{ $endpointId }}" data-list-item="{{ $endpointId }}">
                 <span data-hover="{{ .summary }}">
                   {{- .summary -}}
                 </span>
@@ -54,8 +56,15 @@ class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $curre
 
       {{- with (and (.apiData) (index .apiData .identifier)) -}}
         {{- range .resources -}}
+          {{- $method := "" -}}
+          {{- range .methods -}}
+            {{- with .method -}}
+              {{- $method = . -}}
+            {{- end -}}
+          {{- end -}}
+          {{- $endpointId := (print .displayName "-" $method | anchorize) -}}
           <li>
-            <a href="#{{ .displayName | anchorize }}" data-list-item="{{ .displayName | anchorize }}">
+            <a href="#{{ $endpointId }}" data-list-item="{{ $endpointId }}">
               <span data-hover="{{ .displayName }}">
                 {{- .displayName -}}
               </span>


### PR DESCRIPTION
Adding endpoint method to anchor links and id's, in order to solve potentially duplicate id's if the endpoint name is the same for different methods (ie. POST, GET, DELETE etc.).
