### PR TITLE
Make json template code more like the xml version

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -208,15 +208,7 @@
                                       {{- if eq "xml" $format -}}
                                         {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
                                       {{- else -}}
-                                        {{- range $key, $_ := .schema -}}
-                                          {{- if reflect.IsMap . -}}
-                                            {{- range . -}}
-                                              {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId "application" $application) -}}
-                                            {{- end -}}
-                                          {{- else if eq $key "$ref" -}}
-                                            {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" false "endpointId" $endpointId "application" $application) -}}
-                                          {{- end -}}
-                                        {{- end -}}
+                                      {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
                                       {{- end -}}
                                     </dl>
                                   {{- end -}}

--- a/layouts/partials/api/oas/param-toggle-btn.html
+++ b/layouts/partials/api/oas/param-toggle-btn.html
@@ -1,13 +1,9 @@
-{{- $endpointId := .endpointId -}}
-{{- $param := .param -}}
-{{- $uniqueId := .uniqueId -}}
-
-<button id="{{$endpointId}}-{{$param}}-{{$uniqueId}}" class="btn-link param-collapsed-btn param-toggle-btn">
+<button id="{{ .levelId }}" title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn">
   <span
     data-mybicon="mybicon-arrow-right"
-    data-mybicon-class="icon-ui mrxs param-toggle-icon"
+    data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 2}}rotate-icon-90{{end}}"
     data-mybicon-width="16"
     data-mybicon-height="16">
   </span>
-  <code>{{ $param }}</code>
+    <code>{{ .name }}</code>
 </button>

--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -2,7 +2,9 @@
 {{- $name := "" -}}
 {{- $paramArr := slice -}}
 {{- range .parameters -}}
-  {{- $paramArr = $paramArr | append .in -}}
+  {{- with .in -}}
+    {{- $paramArr = $paramArr | append . -}}
+  {{- end -}}
 {{- end -}}
 {{- $paramArr = uniq $paramArr -}}
 

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -13,7 +13,7 @@
   {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel) -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -1,128 +1,189 @@
+{{- $schemaObj := .schemaObj -}}
+{{- $name := .name -}}
 {{- $components := .components -}}
-{{- $schemaPath := path.Split .ctx -}}
-{{- $responseObject := index $components.schemas $schemaPath.File -}}
+{{- $required := .required -}}
 {{- $endpointId := .endpointId -}}
-{{- $nested := .nested -}}
-{{- $required := slice -}}
-{{- $requiredParam := "" -}}
 {{- $uniqueId := "" -}}
+{{- $recLevel := add .recLevel 1 -}}
 
-    {{- range $key, $value := $responseObject -}}
-      {{- if eq $key "required" -}}
-        {{- $required = $value -}}
+{{/*  If there’s a ref, pass the destination data again  */}}
+{{- $isRef := "false" -}}
+{{- range $key, $_ := $schemaObj -}}
+  {{- if eq $key "$ref" -}}
+    {{- $isRef = true -}}
+    {{- $schemaPath := path.Split . -}}
+    {{- $schema := index $components.schemas $schemaPath.File -}}
+    {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  If object and first level, skip  */}}
+{{- if and (eq $schemaObj.type "object") (lt $recLevel 3) -}}
+  {{- with $schemaObj.properties -}}
+    {{- range $key, $_ := . -}}
+      {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+    {{- end -}}
+  {{- end -}}
+
+{{/*  If object, render and pass properties  */}}
+{{- else if eq $schemaObj.type "object" -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
+  <div class="mb-border bb bw1 mbs">
+    <div class="flex flex-wrap align-ifs pbs">
+      <dt>
+        {{- if or ($schemaObj.properties) -}}
+          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+        {{- else -}}
+          <code class="mls">{{ $name }}</code>
+        {{- end -}}
+        {{- if $required -}}
+          <div class="plm mls lh-solid param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="ptxs pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+        </div>
+      </dd>
+    </div>
+
+    {{- with $schemaObj.properties -}}
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dl class="pls">
+          {{- range $key, $_ := . -}}
+            {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- end -}}
+        </dl>
+      </dd>
+    {{- end -}}
+  </div>
+
+{{/*  If array, render and pass items  */}}
+{{- else if eq $schemaObj.type "array" -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
+
+  {{/*  If items have children or ref has properties  */}}
+  {{- $hasChildren := false -}}
+  {{- with $schemaObj.items -}}
+    {{- $hasChildren = true -}}
+    {{- range $key, $_ := . -}}
+      {{- if or (eq $key "type") (eq $key "format") -}}
+        {{- $hasChildren = false -}}
+      {{- end -}}
+      {{- if eq $key "$ref" -}}
+        {{- $hasChildren = false -}}
+        {{- $schemaPath := path.Split . -}}
+        {{- $schema := index $components.schemas $schemaPath.File -}}
+        {{- with $schema.properties -}}
+          {{- $hasChildren = true -}}
+        {{- end -}}
       {{- end -}}
     {{- end -}}
+  {{- end -}}
 
-    {{- range $key, $value := $responseObject -}}
-      {{- if reflect.IsMap . -}}
-        {{- $isParent := false -}}
-        {{- range $param, $_ := . -}}
+  <div class="mb-border bb bw1 mbs">
+    <div class="flex flex-wrap align-ifs pbs">
+      <dt>
+        {{- if $hasChildren -}}
+          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+        {{- else -}}
+          <code class="mls">{{ $name }}</code>
+        {{- end -}}
+        {{- if $required -}}
+          <div class="plm mls lh-solid param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="ptxs pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
 
-          {{- range $required -}}
-            {{- if eq . $param -}}
-              {{- $requiredParam = . -}}
-            {{- end -}}
-          {{- end -}}
-
-          {{- $typeArrObj := false -}}
-          {{- if reflect.IsMap . -}}
-            {{- range $k, $v := . -}}
-              {{- if or (eq $v "array") (eq $v "object") (eq $k "$ref") -}}
-                {{- $typeArrObj = true -}}
+        {{/*  See what it’s an array of */}}
+        {{- $schemaType := $schemaObj.type -}}
+        {{- $schemaFormat := "" -}}
+        {{- with $schemaObj.items -}}
+          {{- range $key, $_ := . -}}
+            {{- if eq $key "$ref" -}}
+              {{- $schemaPath := path.Split . -}}
+              {{- $schema := index $components.schemas $schemaPath.File -}}
+              {{- with $schema.type -}}
+                {{- $schemaType = printf "array of %ss" . -}}
+              {{- end -}}
+            {{- else -}}
+              {{- if eq $key "format" -}}
+                {{- $schemaFormat = printf " <%s>" . -}}
+              {{- end -}}
+              {{- if eq $key "type" -}}
+                {{- $schemaType = printf "array of %ss%s" . $schemaFormat -}}
               {{- end -}}
             {{- end -}}
           {{- end -}}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaType -}}
+        </div>
+      </dd>
+    </div>
 
-          {{- if reflect.IsMap . -}}
-            {{- if or (isset . "items") (isset . "properties") -}}
-              {{- $nested = false -}}
-            {{- end -}}
-          {{- end -}}
-          
-          {{- if and (eq $nested true) (reflect.IsMap .) -}}
-            <div class="flex flex-wrap mb-border bb bw1 mbs pbs">
-              <dt class="pls">
-                <code>{{- $param -}}</code>
-                {{- if eq $param $requiredParam -}}
-                  {{- partial "api/oas/required.html" -}}
-                {{- end -}}
-              </dt>
-              <dd class="pls">
-                {{- partial "api/oas/response-schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
-              </dd>
-
-          {{- else if $typeArrObj -}}
-            {{- $isParent = true -}}
-            {{- $generateId := delimit (shuffle (split (md5 $param) "" )) "" -}}
-            {{- $uniqueId = slicestr $generateId 0 15 -}}
-            <div class="mbs mb-border bb bw1">
-              <div class="flex flex-wrap align-ifs pbs">
-                <dt>
-                  {{- partial "api/oas/param-toggle-btn.html" ( dict "endpointId" $endpointId "param" $param "uniqueId" $uniqueId ) -}}
-                  {{- if eq $param $requiredParam -}}
-                    <div class="plm mls">
-                    {{- partial "api/oas/required.html" -}}
-                    </div>
-                  {{- end -}}
-                </dt>
-                <dd class="ptxs pls">
-                  {{- partial "api/oas/response-schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
-                </dd>
-              </div>
-
-          {{- else -}}
-            {{- $isParent = false -}}
-            {{- if reflect.IsMap $_ -}}
-            <div class="flex flex-wrap mb-border bb bw1 mbs pbs">
-              <dt>
-                <code class="mls">{{- $param -}}</code>
-                {{- if eq $param $requiredParam}}
-                  <div class="mls">{{- partial "api/oas/required.html" -}}</div>
-                {{- end -}}
-              </dt>
-              <dd class="pls minw0">
-                {{- partial "api/oas/response-schema-dd" ( dict "ctx" . "isParent" $isParent ) -}}
-              </dd>
-            </div>
-            {{- end -}}
-          {{- end -}}
-
-        {{- if $isParent -}}
-          <dd data-sublevel-id="{{$endpointId}}-{{$param}}-{{$uniqueId}}" class="schema__sublist mb-border dn">
-            {{- if eq $nested false -}}
-              <dl class="desc-list mbm pts">
-            {{- end -}}
-            {{- if reflect.IsMap . -}}
-              {{- range $i, $_ := . -}}
-                {{- if reflect.IsMap . -}}
-                  {{- range $k,$v := . -}}
-                    {{- if eq $k "$ref" -}}
-                      {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" true "endpointId" $endpointId) -}}
-                    {{- else if reflect.IsMap . -}}
-                      <div class="flex flex-wrap mb-border bb bw1 mbs pbs">
-                        <dt>
-                          <code class="mls">{{- $k -}}</code>
-                        </dt>
-                        <dd class="pls minw0">
-                          {{- partial "api/oas/response-schema-dd" ( dict "ctx" . "isParent" false ) -}}
-                        </dd>
-                      </div>
-                    {{- end -}}
-                  {{- end -}}
-                {{- else if eq $i "$ref" -}}
-                  {{- partial "api/oas/response-schema.html" (dict "ctx" . "components" $components "nested" true "endpointId" $endpointId) -}}
-                {{- end -}}
+    {{- with $schemaObj.items -}}
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dl class="pls">
+          {{- $isItemRef := false -}}
+          {{- range $key, $_ := . -}}
+            {{- if eq $key "$ref" -}}
+              {{- $isItemRef = true -}}
+              {{- $schemaPath := path.Split . -}}
+              {{- $schema := index $components.schemas $schemaPath.File -}}
+              {{- $items := $schema.properties -}}
+              {{- range $key, $_ := $items -}}
+                {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
               {{- end -}}
             {{- end -}}
-            {{- if eq $nested false -}}
-              </dl>
-            {{- end -}}
-          </dd>
+          {{- end -}}
+          {{- if not $isItemRef -}}
+            {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" "" "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- end -}}
+        </dl>
+      </dd>
+    {{- end -}}
+  </div>
+
+{{/*  If neither obj, arr or ref, render the item */}}
+{{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}
+  <div class="mb-border bb bw1 mbs pbs pls">
+    <div class="flex flex-wrap align-ifs">
+      <dt>
+        <code>{{ $name }}</code>
+        {{- if $required -}}
+          <div class="lh-tight param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+          {{- with $schemaObj.format -}}
+            {{- printf " <%s>" . -}}
+          {{- end -}}
+        </div>
+        {{- with $schemaObj.enum -}}
+        <div>
+          <span class="text-note fw600">Enum</span>
+          {{- range . -}}
+            <br><code class="wrap-text">{{ . }}</code>
+          {{- end -}}
         </div>
         {{- end -}}
-        {{- if and (eq $nested true) (reflect.IsMap $_) -}}
-          </div>
-        {{- end -}}
-        {{- end -}}
-      {{- end -}}
-    {{- end -}}
+      </dd>
+    </div>
+  </div>
+{{- end -}}


### PR DESCRIPTION
Not necessarily fewer lines of code. Although it’s possible to eliminate some of the repetition, that will make it less readable. Compared to the XML template which just takes everything and shows it, the JSON version has fewer levels. I guess smaller output requires bigger templates.

The styling is slightly different (similar to the XML now) and I’ve added "array of …" instead of just "array". Arrays that doesn’t have any items are no longer able to be opened (no need to open empty boxes).

### before
<img width="639" alt="Screenshot 2022-08-05 at 16 38 11" src="https://user-images.githubusercontent.com/9307503/183100165-49196e08-d4fa-4969-8cee-f1be2a4c3b7e.png">


### after
<img width="643" alt="Screenshot 2022-08-05 at 16 37 22" src="https://user-images.githubusercontent.com/9307503/183100200-243b4c12-d011-42be-b6e0-5a486461f9be.png">