### PR TITLE
Improve solution for switching between media types

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -1,46 +1,4 @@
-// Responses
-const schemaTypeSelect = document.querySelectorAll(".schema-type-select")
-schemaTypeSelect.forEach(changeType)
-
-function changeType(type) {
-  type.addEventListener("change", function () {
-    const selectedOption = this.value
-    const schemaTypeParent = document.querySelector(
-      '[data-schematype-id="' + selectedOption + '"]'
-    ).parentNode
-    const schemaTypes = schemaTypeParent.querySelectorAll(
-      ".schema-type-container"
-    )
-
-    schemaTypes.forEach((schema) => {
-      schema.classList.add("dn")
-    })
-
-    showSelectedSchemaOption(this)
-  })
-}
-
-function showSelectedSchemaOption(sel) {
-  let opt
-  for (let i = 0; i < sel.options.length; i++) {
-    opt = sel.options[i]
-    if (opt.selected === true) {
-      const schemaType = opt.value
-      const schemaTypeContainer = document.querySelector(
-        '[data-schematype-id="' + schemaType + '"]'
-      )
-      schemaTypeContainer.classList.remove("dn")
-      return schemaType
-    }
-  }
-}
-
-function showInitialSchemaType() {
-  schemaTypeSelect.forEach(showSelectedSchemaOption)
-}
-
-showInitialSchemaType()
-
+//Param toggle buttons
 const paramToggleBtn = document.querySelectorAll(".param-toggle-btn")
 
 paramToggleBtn.forEach((btn) => {
@@ -112,27 +70,81 @@ responseExBtns.forEach((btn) => {
   })
 })
 
-// Format type selects
+// Data format selects
 const formatSelects = document.querySelectorAll('select[name="formats"]')
-formatSelects.forEach((select) => {
-  select.addEventListener("change", function (e){
-    const element = e.target
-    const formatId = element.value
+const dataTypes = document.querySelectorAll('[data-type]')
 
-    let exampleGroup
-    const parentId = element.dataset.subOf
-    const parentElement = document.querySelector('div[data-example="' + parentId + '"')
-    const exampleArr = parentElement.querySelectorAll('div[data-type]')
-    exampleArr.forEach((example) => {
-      if (example.dataset.type === formatId) {
-        exampleGroup = example
-        example.hidden = false
+const setSelectFormat = (e) => {
+  const storedFormat = localStorage.getItem("dataFormat")
+  let format = e.value;
+
+  formatSelects.forEach((f) => {
+    for(let i = 0; i < f.options.length; i++) {
+      //Set the format from local storage (if stored), with fallback to json or xml if something else
+      if(storedFormat && (storedFormat.includes("json") || storedFormat.includes("xml"))) {
+        format = storedFormat
+      } else if(f.options[i].value === storedFormat) {
+        format = storedFormat
+      }
+      //Set the selected option based on format
+      if(f.options[i].value === format) {
+        f.options[i].selected = true
       } else {
-        example.hidden = true
+        f.options[i].selected = false
+        //Fallback for json or xml if format don't entirely match with option values
+        if(format.includes("json") && f.options[i].value.includes("json") || format.includes("xml") && f.options[i].value.includes("xml")) {
+            f.options[i].selected = true
+        }
+      }
+    }
+  })
+  
+  dataTypes.forEach((dataType) => {
+    //Display response parameters and examples based on format
+    if(dataType.dataset.type === format) {
+      dataType.hidden = false
+    } else {
+      dataType.hidden = true
+      //Fallback for json or xml if format don't entirely match with example data-type
+      if(format.includes("json") && dataType.dataset.type.includes("json") || format.includes("xml") && dataType.dataset.type.includes("xml")) {
+        dataType.hidden = false
+      }
+    }
+  })
+
+  //Display chosen sub-example independently of chosen format
+  const exampleWrapper = e.closest("div[data-example]")
+
+  if(exampleWrapper) {
+    const exampleTypes = exampleWrapper.querySelectorAll("div[data-type]")
+    exampleTypes.forEach((type) => {
+      const selectSub = type.querySelector("select[data-example-sub]")
+      if(selectSub) {
+        const examplesSub = type.querySelectorAll("div[data-example-sub]")
+        switchExample(examplesSub, "exampleSub", selectSub.value)
       }
     })
+  }
+}
+
+//Set the format on page load
+formatSelects.forEach(setSelectFormat)
+
+formatSelects.forEach((select) => {
+  select.addEventListener("change", function(e) {
+    localStorage.setItem("dataFormat",e.target.value)
+    setSelectFormat(select)
 
     // If multiple examples
+    /*let exampleGroup
+
+    formatTypes.forEach((example) => {
+      if (example.dataset.type === e.target.value) {
+        console.log(example)
+        exampleGroup = example
+      }
+    })
+    
     const subSelect = exampleGroup.querySelector('select[data-example-sub]')
     if (subSelect) {
       const subExampleArr = exampleGroup.querySelectorAll('div[data-example-sub]')
@@ -143,9 +155,7 @@ formatSelects.forEach((select) => {
           subExample.hidden = true
         }
       })
-
-    }
-
+    }*/
   })
 })
 

--- a/js/api.js
+++ b/js/api.js
@@ -134,28 +134,6 @@ formatSelects.forEach((select) => {
   select.addEventListener("change", function(e) {
     localStorage.setItem("dataFormat",e.target.value)
     setSelectFormat(select)
-
-    // If multiple examples
-    /*let exampleGroup
-
-    formatTypes.forEach((example) => {
-      if (example.dataset.type === e.target.value) {
-        console.log(example)
-        exampleGroup = example
-      }
-    })
-    
-    const subSelect = exampleGroup.querySelector('select[data-example-sub]')
-    if (subSelect) {
-      const subExampleArr = exampleGroup.querySelectorAll('div[data-example-sub]')
-      subExampleArr.forEach((subExample) => {
-        if (subExample.dataset.exampleSub === subSelect.value) {
-          subExample.hidden = false
-        } else {
-          subExample.hidden = true
-        }
-      })
-    }*/
   })
 })
 

--- a/js/api.js
+++ b/js/api.js
@@ -89,12 +89,11 @@ const setSelectFormat = (e) => {
       //Set the selected option based on format
       if(f.options[i].value === format) {
         f.options[i].selected = true
+      } else if((format.includes("json") && f.options[i].value.includes("json")) || (format.includes("xml") && f.options[i].value.includes("xml"))) {
+        //Fallback for json or xml if format don't entirely match with option values
+        f.options[i].selected = true
       } else {
         f.options[i].selected = false
-        //Fallback for json or xml if format don't entirely match with option values
-        if(format.includes("json") && f.options[i].value.includes("json") || format.includes("xml") && f.options[i].value.includes("xml")) {
-            f.options[i].selected = true
-        }
       }
     }
   })
@@ -103,12 +102,11 @@ const setSelectFormat = (e) => {
     //Display response parameters and examples based on format
     if(dataType.dataset.type === format) {
       dataType.hidden = false
+    } else if((format.includes("json") && dataType.dataset.type.includes("json")) || (format.includes("xml") && dataType.dataset.type.includes("xml"))) {
+      //Fallback for json or xml if format don't entirely match with example data-type
+      dataType.hidden = false
     } else {
       dataType.hidden = true
-      //Fallback for json or xml if format don't entirely match with example data-type
-      if(format.includes("json") && dataType.dataset.type.includes("json") || format.includes("xml") && dataType.dataset.type.includes("xml")) {
-        dataType.hidden = false
-      }
     }
   })
 

--- a/js/api.js
+++ b/js/api.js
@@ -92,6 +92,9 @@ const setSelectFormat = (e) => {
       } else if((format.includes("json") && f.options[i].value.includes("json")) || (format.includes("xml") && f.options[i].value.includes("xml"))) {
         //Fallback for json or xml if format don't entirely match with option values
         f.options[i].selected = true
+      } else if((format.includes("javascript") && !f.value.includes("javascript"))) {
+        //Select none if javascript option is not present
+        f.selectedIndex = -1
       } else {
         f.options[i].selected = false
       }

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -121,13 +121,12 @@
                                 <h4>Schema</h4>
                                 {{- if $multiSchema -}}
                                   <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Media type:</label>
-                                  <select id="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib schema-type-select hauto">
-                                    {{- $selected := "selected" -}}
+                                  <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
                                     {{- range $applicationType, $_ := . -}}
-                                      <option value='schemaType-{{$response}}-{{$endpointId}}-{{$applicationType}}' {{$selected | safeHTMLAttr}}>
+                                      {{- $typeClean := lower (anchorize $applicationType) -}}
+                                      <option value='{{$typeClean}}'>
                                         {{ $applicationType }}
                                       </option>
-                                      {{- $selected = "" -}}
                                     {{- end -}}
                                   </select>
                                 {{- else -}}
@@ -138,13 +137,16 @@
 
                                 {{- range $application, $_ := . -}}
                                   {{- $format := "" -}}
-                                  {{- if in $application "json" -}}
-                                    {{- $format = "json" -}}
+                                  {{- $typeClean := "" -}}
+                                  {{- if or (in $application "json") (in $application "javascript") -}}
+                                    {{- $format = printf "json" -}}
+                                    {{- $typeClean = lower (anchorize $application) -}}
                                   {{- else if in $application "xml" -}}
                                     {{- $format = printf "xml" -}}
+                                    {{- $typeClean = lower (anchorize $application) -}}
                                   {{- end -}}
 
-                                  <dl class="schema-type-container desc-list pam bshadow bg-white {{ if $multiSchema }}dn{{ end }}" data-schematype-id='schemaType-{{$response}}-{{$endpointId}}-{{$application}}'>
+                                  <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{$typeClean}}">
                                     {{- if eq "xml" $format -}}
                                       {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
                                     {{- else -}}

--- a/layouts/partials/api/oas/responseexample-components.html
+++ b/layouts/partials/api/oas/responseexample-components.html
@@ -87,6 +87,7 @@
                           {{- else -}}
                             {{- partial "api/oas/example-json.html" (dict "key" $examplePath.File "ctx" . "schemas" $components.schemas) . -}}
                           {{- end -}}
+                          {{- partial "api/oas/copy-btn.html" -}}
                         </div>
                       {{- end -}}
                       {{- $exInd = add $exInd 1 -}}

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -77,6 +77,7 @@
                     {{- else -}}
                       {{- partial "api/oas/example-json.html" (dict "ctx" . "schemas" .) -}}
                     {{- end -}}
+                    {{- partial "api/oas/copy-btn.html" -}}
                     </div>
                     {{- $exInd = add $exInd 1 -}}
                   {{- end -}}


### PR DESCRIPTION
Currently the switching between data formats in responses section and examples section are two separate things. With this PR they are melting together, so the switching between data formats (usually JSON or XML) is becoming global. 
If you choose one data format in the responses section, the same format is chosen for all other response sections, but also in all the example sections, and vice versa.

The chosen format is also then stored in local storage, so we can make a (cautious) presumption that the user wants to see the same format across the other API pages or when revisiting the same page, and preselect the preferred data format globally for the user. 🙂