### PR TITLE
Remove post-css-variables config and CSS custom props

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -23,7 +23,7 @@
     .dev-siteheader__nav a,
     .dev-sidemenu a,
     a.dev-codetabs__link):hover {
-      color: var(--blue);
+      color: var(--blue-link);
   }
 
   & .color-theme-icon {
@@ -219,7 +219,7 @@
 
   & .mb-badge--blue {
     background-color: var(--blue-lighter);
-    color: var(--blue);
+    color: var(--blue-link);
   }
 
   & .mb-badge--red {

--- a/css/variables.css
+++ b/css/variables.css
@@ -1,25 +1,6 @@
 /* Subset of variables from Mybring design system */
 
 :root {
---gray-98: hsl(0, 0%, 98%); /* #fafafa */
---gray-95: hsl(0, 0%, 95%); /* #f2f2f2 */
---gray-90: hsl(0, 0%, 90%);
---gray-86: hsl(0, 0%, 86%);
---gray-80: hsl(0, 0%, 80%); /* #cccccc */
---gray-60: hsl(0, 0%, 60%); /* #999999 */
---gray-40: hsl(0, 0%, 40%); /* #666666 */
---gray-26: hsl(0, 0%, 26.5%); /* #444444 */
---gray-13: hsl(0, 0%, 13%); /* #222222 */
-
---green: hsl(93.5, 50%, 51%); /* #7bc144 */
---green-hover: hsl(93, 56%, 57%);
---green-light: hsl(75, 53%, 70.5%); /* #c8dc8c */
---green-lighter: hsl(86, 47%, 94%); /* #f1f7e9 */
---green-lighter-hover: hsl(86, 40%, 96%);
---green-lighter-active: hsl(86, 40%, 92%);
---green-dark: hsl(155, 100%, 19.6%); /* #00643a */
---green-darker: hsl(152, 100%, 9%);
---green-darkest: hsl(152, 15%, 10%);
 --green-86: hsl(152, 5%, 86%);
 --green-60: hsl(152, 5%, 60%);
 --green-40: hsl(152, 6%, 40%);
@@ -28,22 +9,13 @@
 --green-18: hsl(152, 8%, 18%);
 --green-15: hsl(152, 8%, 15%);
 
---yellow: hsl(41, 98%, 58.5%); /* #fdbb2f */
---yellow-dark: hsl(41, 58%,55%);
+--green-darkest: hsl(152, 15%, 10%);
+
 --yellow-darker: hsl(48, 40%, 20%);
 
---red: hsl(3, 77.5%, 51.5%); /* #e32d22 */
---red-light: hsl(3, 77.5%, 65%);
---red-lighter: hsl(3, 77.5%, 96%);
 --red-lighter-hover: hsl(3, 77.5%, 93%);
 --red-lighter-active: hsl(3, 77.5%, 91%);
---red-dark: hsl(0, 100%, 30%); /* #980000 */
 
---blue: hsl(212, 100%, 43%);
 --blue-light: hsl(211, 100%, 64%);
 --blue-lighter: hsl(211, 83%, 84%);
-
---shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.14);
-
---easeout-15: 0.15s ease-out;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,6 @@
         "cssnano": "^5.1.13",
         "hugo-bin": "^0.91.1",
         "postcss": "^8.4.16",
-        "postcss-css-variables": "^0.18.0",
         "postcss-import": "^15.0.0",
         "postcss-nesting": "^10.2.0",
         "raml-1-parser": "^1.1.67",
@@ -4339,12 +4338,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "node_modules/fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -5784,20 +5777,6 @@
       },
       "peerDependencies": {
         "postcss": "^8.2.15"
-      }
-    },
-    "node_modules/postcss-css-variables": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz",
-      "integrity": "sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==",
-      "dev": true,
-      "dependencies": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1"
-      },
-      "peerDependencies": {
-        "postcss": "^8.2.6"
       }
     },
     "node_modules/postcss-discard-comments": {
@@ -10778,12 +10757,6 @@
         "sort-keys-length": "^1.0.0"
       }
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
-    },
     "fd-slicer": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
@@ -11880,17 +11853,6 @@
       "requires": {
         "browserslist": "^4.20.3",
         "postcss-value-parser": "^4.2.0"
-      }
-    },
-    "postcss-css-variables": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/postcss-css-variables/-/postcss-css-variables-0.18.0.tgz",
-      "integrity": "sha512-lYS802gHbzn1GI+lXvy9MYIYDuGnl1WB4FTKoqMQqJ3Mab09A7a/1wZvGTkCEZJTM8mSbIyb1mJYn8f0aPye0Q==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "^1.0.0",
-        "escape-string-regexp": "^1.0.3",
-        "extend": "^3.0.1"
       }
     },
     "postcss-discard-comments": {

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "cssnano": "^5.1.13",
     "hugo-bin": "^0.91.1",
     "postcss": "^8.4.16",
-    "postcss-css-variables": "^0.18.0",
     "postcss-import": "^15.0.0",
     "postcss-nesting": "^10.2.0",
     "raml-1-parser": "^1.1.67",

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,7 +1,6 @@
 module.exports = {
   plugins: {
     "postcss-import": {},
-    "postcss-css-variables": {},
     "postcss-nesting": {},
     autoprefixer: { grid: "autoplace" },
     cssnano: {},


### PR DESCRIPTION
Removing post-css-variables config and several CSS custom properties (CSS variables) as custom properties are now globally available from the [Mybring Design System](https://github.com/bring/mybring-design-system).

You will find all of them listed here:
[Mybring Design System - Custom Properties](https://www.mybring.com/design-system/custom-properties/)