### PR TITLE
Fix dark mode on service portfolio page

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -111,11 +111,14 @@
   & .btn--white,
   & .btn--white:link,
   & .btn--white:visited,
-  & .btn-link--filter,
   & .btn-link--dark {
     background-color: var(--green-22);
     color: var(--green-86);
     border-color: var(--green-40);
+  }
+
+  & .btn-link {
+    color: var(--green-86);
   }
 
   & .btn-link svg,

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -111,6 +111,7 @@
   & .btn--white,
   & .btn--white:link,
   & .btn--white:visited,
+  & .btn-link--filter,
   & .btn-link--dark {
     background-color: var(--green-22);
     color: var(--green-86);

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -139,6 +139,11 @@
     background-color: var(--green-22);
   }
 
+  & .btn--white:hover,
+  & .btn--white.active {
+    background-color: var(--green-18);
+  }
+
   & .btn-link--dark {
     &.active,
     &:active,

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -107,6 +107,14 @@
     color: var(--gray-60);
   }
 
+  & #services-bsg .icon-ui--green-dark {
+    fill: var(--green);
+  }
+
+  & #services-bsg .icon-ui--lightgray {
+    fill: var(--gray-40);
+  }
+
   /* Buttons */
   & .btn--white,
   & .btn--white:link,

--- a/js/servicefiltering-vas.js
+++ b/js/servicefiltering-vas.js
@@ -172,19 +172,9 @@ if (container) {
         document.querySelector("[data-siteheader]").offsetHeight + 20,
       elementPosition = element.getBoundingClientRect().top,
       offsetPosition = elementPosition + window.pageYOffset - headerOffset,
-      vasBtnParent = element.parentElement,
-      vasBtnToggler = vasBtnParent.querySelector("[data-collapse]"),
-      vasItemContent = vasBtnParent.querySelector("[data-vas-element]")
-  
-    if (vasBtnToggler) {
-      vasBtnToggler.classList.remove("dev-collapsible__toggler--collapsed")
-      vasBtnToggler.classList.add("dev-collapsible__toggler--expanded")
-    }
-  
-    if (vasItemContent) {
-      vasItemContent.classList.remove("dev-collapsible__item--collapsed")
-      vasItemContent.classList.add("dev-collapsible__item--expanded")
-    }
+      vasBtnParent = element.parentElement
+      
+      vasBtnParent.setAttribute('open','')
   
     window.scrollTo({
       top: offsetPosition,

--- a/layouts/partials/services/vas.html
+++ b/layouts/partials/services/vas.html
@@ -41,25 +41,18 @@
   </div>
 </div>
 
-<div class="flex flex-dir-col" id="all-vas">
+<div class="flex flex-dir-col gas" id="all-vas">
   {{- range $index, $vas := (sort .data "vasName") -}}
-    <div class="vas-item bg-gray2 mbxs dev-collapsible">
-      <div class="dev-anchored" id="{{ .vasName|anchorize }}">
-        <button
-          type="button"
-          data-collapse="#vas-item{{ $index }}"
-          class="btn-link fw600 pv.75r phs w100p dev-collapsible__toggler--collapsed justify-cfs"
-        >
-          <span
-            data-mybicon="mybicon-arrow-right"
-            data-mybicon-class="dev-collapsible__toggler__icon"
-            data-mybicon-width="16"
-            data-mybicon-height="16"
-          ></span>
-          <span data-filter="name">{{ .vasName }}</span>
-        </button>
-      </div>
-      <div class="mhxs mbxs phm pbm bg-white flex flex-wrap dev-collapsible__item--collapsed" id="vas-item{{ $index }}" data-vas-element>
+    <details class="mb-disclosure mb-disclosure--arrow bg-gray1 vas-item">
+      <summary class="dev-anchored" id="{{ .vasName|anchorize }}">
+        <span
+          data-mybicon="mybicon-arrow-right"
+          data-mybicon-width="16"
+          data-mybicon-height="16"
+        ></span>
+        <span data-filter="name">{{ .vasName }}</span>
+      </summary>
+      <div class="mhxs mbxs phm pbm flex flex-wrap" id="vas-item{{ $index }}" data-vas-element>
         <div class="vas__codes mrm">
           <div class="mtm">
             <span class="text-note fw600">API request codes</span>
@@ -205,7 +198,7 @@
           {{- end -}}
         </div>
       </div>
-    </div>
+    </details>
   {{- end -}}
 </div>
 <div class="cutoff-overlay" id="vas-cutoff">

--- a/layouts/partials/services/vas.html
+++ b/layouts/partials/services/vas.html
@@ -52,9 +52,9 @@
         ></span>
         <span data-filter="name">{{ .vasName }}</span>
       </summary>
-      <div class="mhxs mbxs phm pbm flex flex-wrap" id="vas-item{{ $index }}" data-vas-element>
+      <div class="pam flex flex-wrap" id="vas-item{{ $index }}" data-vas-element>
         <div class="vas__codes mrm">
-          <div class="mtm">
+          <div>
             <span class="text-note fw600">API request codes</span>
             {{- if .orderedViaVasCodes -}}
               <dl class="text-note bl mb-border pls mtxs">
@@ -78,7 +78,7 @@
             {{- end -}}
           </div>
           {{- if .incompatibleVases -}}
-            <div class="mtm">
+            <div>
               <span class="text-note fw600">Incompatible with</span>
               <dl class="bl mb-border pls mtxs">
                 {{- range .incompatibleVases -}}
@@ -90,7 +90,7 @@
             </div>
           {{- end -}}
         </div>
-        <div class="vas__docs ptm">
+        <div class="vas__docs">
           <p>{{ .description }}</p>
           {{- if gt (len .vasFootNotes) 0 -}}
             {{- range .vasFootNotes -}}


### PR DESCRIPTION
Some elements needed some adjustments in dark mode. Along with that the VAS buttons are replaced by the disclosure element.

These are the changes done with this PR:
- Make buttons in the selected filter overview visible
- VAS buttons (with belonging content) are refactored to disclosure elements
- Make buttons inside VAS-es visible
- Improve icon visibility in the BSG tables
- Fix hover color on buttons