### PR TITLE
Add aria attributes to the response schema param buttons

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -3,11 +3,13 @@ const paramToggleBtn = document.querySelectorAll(".param-toggle-btn")
 
 paramToggleBtn.forEach((btn) => {
   btn.addEventListener("click", function () {
-    const paramToggleBtnId = this.id
-    const paramSubLevel = document.querySelector(
-      '[data-sublevel-id="' + paramToggleBtnId + '"]'
-    )
+    const paramToggleBtnId = this.getAttribute('aria-controls')
+    const paramSubLevel = document.getElementById(paramToggleBtnId)
     const paramToggleIcon = this.querySelector(".param-toggle-icon")
+    let paramToggleBtnState = this.getAttribute('aria-expanded')
+    paramToggleBtnState = paramToggleBtnState === 'true' ? false : true
+
+    this.setAttribute('aria-expanded', paramToggleBtnState)
     paramSubLevel.classList.toggle("dn")
     paramToggleIcon.classList.toggle("rotate-icon-90")
   })

--- a/layouts/partials/api/oas/param-toggle-btn-xml.html
+++ b/layouts/partials/api/oas/param-toggle-btn-xml.html
@@ -1,9 +1,9 @@
-<button id="{{ .levelId }}" title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn">
+<button title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn" aria-expanded="{{ if lt .recLevel 3 }}true{{ else }}false{{ end }}" aria-controls="{{ .levelId }}">
   <span
     data-mybicon="mybicon-arrow-right"
     data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 3}}rotate-icon-90{{end}}"
     data-mybicon-width="16"
     data-mybicon-height="16">
   </span>
-    <code>{{ .name }}</code>
+  <code>{{ .name }}</code>
 </button>

--- a/layouts/partials/api/oas/param-toggle-btn.html
+++ b/layouts/partials/api/oas/param-toggle-btn.html
@@ -1,9 +1,9 @@
-<button id="{{ .levelId }}" title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn">
+<button title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn" aria-expanded="{{ if lt .recLevel 3 }}true{{ else }}false{{ end }}" aria-controls="{{ .levelId }}">
   <span
     data-mybicon="mybicon-arrow-right"
     data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 2}}rotate-icon-90{{end}}"
     data-mybicon-width="16"
     data-mybicon-height="16">
   </span>
-    <code>{{ .name }}</code>
+  <code>{{ .name }}</code>
 </button>

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -81,7 +81,7 @@
       </div>
       {{/*  object  */}}
       {{- with $schemaObj.properties -}}
-        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
               {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
@@ -91,7 +91,7 @@
       {{- end -}}
       {{/*  oneOf object  */}}
       {{- with $schemaObj.oneOf -}}
-        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <form>
             <fieldset class="mlxs mbs pls pbs">
               <legend class="fw600 pts mbxs">oneOf</legend>
@@ -112,7 +112,7 @@
       {{- end -}}
       {{/*  array  */}}
       {{- with $schemaObj.items -}}
-        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" "" "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
           </dl>

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -111,7 +111,7 @@
       </div>
 
       {{- with $schemaObj.properties -}}
-        <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
               {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
@@ -195,7 +195,7 @@
     </div>
 
     {{- with $schemaObj.items -}}
-      <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" data-sublevel-id="{{ $levelId }}">
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
         {{- $isItemRef := false -}}
         {{- $isItemOneOfRef := false -}}
         {{/*  Check for oneOf  */}}


### PR DESCRIPTION
Adding the `aria-expanded` and `aria-controls` attributes on the response schema param buttons, signifying the expanded (or not expanded) state of the button, and what element the button controls.
The `aria-controls` attribute targets the matching ID of the element that the button controls, so have to move the ID to the element itself.

The JS had to also be modified a bit to accommodate `aria-expanded` state on the buttons.