### PR TITLE
Allow booleans as default param values

### DIFF
--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -48,8 +48,8 @@
           {{- with .enum -}}
             {{- $enum = . -}}
           {{- end -}}
-          {{- with .default -}}
-            {{- $default = . -}}
+          {{- if or .default (eq .default false) -}}
+            {{- $default = printf "%v" .default -}}
           {{- end -}}
         {{- else if eq $key "example" -}}
           {{- if eq $paramType "path" -}}


### PR DESCRIPTION
This checks for the existence of the value and displays it – even if the value itself is `false`
Ref: https://pkg.go.dev/fmt