### PR TITLE
Add light mode css for examples

### DIFF
--- a/css/base.css
+++ b/css/base.css
@@ -82,7 +82,7 @@ samp {
 
 pre {
   background-color: var(--gray-95);
-  font-family: Monaco, Consolas, "Lucida Console", monospace;
+  font-family: Consolas, SF Mono, Menlo, 'Andale Mono', 'Ubuntu Mono', 'Courier New', Courier, monospace;
   font-size: 0.82rem;
   padding: 0.75rem;
   overflow: auto;

--- a/css/code.css
+++ b/css/code.css
@@ -11,8 +11,6 @@
 code,
 .filename {
   white-space: pre;
-  font-family: Consolas, Monaco, "Andale Mono", "Ubuntu Mono", "Courier New",
-    Courier, monospace;
   font-size: 0.82rem;
 }
 

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -167,6 +167,11 @@
     }
   }
 
+  & .btn-link--copy {
+    background-color: hsl(200, 17%, 30%);;
+    color: hsl(0, 0%, 85%);
+  }
+
   & input[type="submit"] {
     background-color: var(--green);
     border-color: var(--green-15);

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -168,8 +168,7 @@
   }
 
   & .btn-link--copy {
-    background-color: hsl(200, 17%, 30%);;
-    color: hsl(0, 0%, 85%);
+    background-color: var(--green-26);
   }
 
   & input[type="submit"] {

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -128,23 +128,6 @@
 .btn-link--copy {
   top: 0.5rem;
   right: 1.2rem;
-  background-color: var(--gray-90);
-  color: hsl(200, 17%, 30%);
-}
-
-.btn-link--copy svg {
-  color: hsl(200, 17%, 30%);
-}
-
-.btn-link--copy:hover,
-.btn-link--copy:focus-visible {
-  background-color: hsl(199, 17%, 36%);
-  color: hsl(0, 0%, 100%);
-}
-
-.btn-link--copy:hover svg,
-.btn-link--copy:focus-visible svg {
-  color: hsl(0, 0%, 100%);
 }
 
 .oas-endpoints > div:last-of-type {

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -128,8 +128,12 @@
 .btn-link--copy {
   top: 0.5rem;
   right: 1.2rem;
-  background-color: hsl(200, 17%, 30%);
-  color: hsl(0, 0%, 85%);
+  background-color: var(--gray-90);
+  color: hsl(200, 17%, 30%);
+}
+
+.btn-link--copy svg {
+  color: hsl(200, 17%, 30%);
 }
 
 .btn-link--copy:hover,

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -1,82 +1,169 @@
-/* Background */ .chroma { color: hsl(0, 0%, 93%); background-color: hsl(200, 17%, 17%); border-radius: 2px; }
+/* Background */ .chroma { background-color: var(--gray-98); }
 /* Other */ .chroma .x {  }
-/* Error */ .chroma .err { color: hsl(3, 77.5%, 69%); }
+/* Error */ .chroma .err { color: hsl(3, 43%, 49%); }
+/* CodeLine */ .chroma .cl {  }
 /* LineTableTD */ .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
-/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
-/* LineHighlight */ .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
-/* LineNumbersTable */ .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
-/* LineNumbers */ .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
-/* Keyword */ .chroma .k { color: hsl(288, 81%, 78%); }
-/* KeywordConstant */ .chroma .kc { color: hsl(288, 81%, 78%); }
-/* KeywordDeclaration */ .chroma .kd { color: hsl(288, 81%, 78%); }
-/* KeywordNamespace */ .chroma .kn { color: hsl(194, 100%, 65%); }
-/* KeywordPseudo */ .chroma .kp { color: hsl(288, 81%, 78%); }
-/* KeywordReserved */ .chroma .kr { color: hsl(288, 81%, 78%); }
-/* KeywordType */ .chroma .kt { color: hsl(41, 98%, 65%); }
+/* LineTable */ .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; }
+/* LineHighlight */ .chroma .hl { background-color: hsl(60, 100%, 83%) }
+/* LineNumbersTable */ .chroma .lnt { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: hsl(0, 0%, 50%) }
+/* LineNumbers */ .chroma .ln { white-space: pre; user-select: none; margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: hsl(0, 0%, 50%) }
+/* Line */ .chroma .line { display: flex; }
+/* Keyword */ .chroma .k { color: hsl(222, 67%, 35%); font-weight: bold }
+/* KeywordConstant */ .chroma .kc { color: hsl(330, 67%, 35%); font-weight: bold }
+/* KeywordDeclaration */ .chroma .kd { color: hsl(222, 67%, 35%); font-weight: bold }
+/* KeywordNamespace */ .chroma .kn { color: hsl(222, 67%, 35%); font-weight: bold }
+/* KeywordPseudo */ .chroma .kp { color: hsl(222, 67%, 35%) }
+/* KeywordReserved */ .chroma .kr { color: hsl(222, 67%, 35%); font-weight: bold }
+/* KeywordType */ .chroma .kt { color: hsl(264, 77%, 41%); font-weight: bold }
 /* Name */ .chroma .n {  }
-/* NameAttribute */ .chroma .na { color: hsl(93.5, 75%, 65%); }
-/* NameBuiltin */ .chroma .nb {  }
+/* NameAttribute */ .chroma .na { color: hsl(0, 47%, 45%); font-style: italic }
+/* NameBuiltin */ .chroma .nb { color: hsl(264, 77%, 41%); font-weight: bold }
 /* NameBuiltinPseudo */ .chroma .bp {  }
-/* NameClass */ .chroma .nc { color: hsl(41, 98%, 65%); }
-/* NameConstant */ .chroma .no { color: hsl(3, 77.5%, 69%); }
-/* NameDecorator */ .chroma .nd { color: hsl(194, 100%, 65%); }
-/* NameEntity */ .chroma .ni {  }
-/* NameException */ .chroma .ne { color: hsl(3, 77.5%, 69%); }
-/* NameFunction */ .chroma .nf { color: hsl(93.5, 75%, 65%); }
+/* NameClass */ .chroma .nc { text-decoration: underline }
+/* NameConstant */ .chroma .no { color: hsl(190, 51%, 39%) }
+/* NameDecorator */ .chroma .nd { color: hsl(30, 100%, 50%); font-weight: bold }
+/* NameEntity */ .chroma .ni { color: hsl(264, 77%, 41%); font-weight: bold }
+/* NameException */ .chroma .ne { color: hsl(264, 77%, 41%); font-weight: bold }
+/* NameFunction */ .chroma .nf { color: hsl(30, 100%, 50%); font-weight: bold }
 /* NameFunctionMagic */ .chroma .fm {  }
 /* NameLabel */ .chroma .nl {  }
-/* NameNamespace */ .chroma .nn { color: hsl(41, 98%, 65%); }
-/* NameOther */ .chroma .nx { color: hsl(93.5, 75%, 65%); }
+/* NameNamespace */ .chroma .nn {  }
+/* NameOther */ .chroma .nx {  }
 /* NameProperty */ .chroma .py {  }
-/* NameTag */ .chroma .nt { color: hsl(194, 100%, 65%); }
-/* NameVariable */ .chroma .nv { color: hsl(3, 77.5%, 69%); }
+/* NameTag */ .chroma .nt { color: hsl(222, 67%, 35%); font-weight: bold }
+/* NameVariable */ .chroma .nv {  }
 /* NameVariableClass */ .chroma .vc {  }
 /* NameVariableGlobal */ .chroma .vg {  }
 /* NameVariableInstance */ .chroma .vi {  }
 /* NameVariableMagic */ .chroma .vm {  }
-/* Literal */ .chroma .l { color: hsl(41, 98%, 65%); }
-/* LiteralDate */ .chroma .ld { color: hsl(152, 50%, 55%); }
-/* LiteralString */ .chroma .s { color: hsl(152, 50%, 55%); }
-/* LiteralStringAffix */ .chroma .sa { color: hsl(152, 50%, 55%); }
-/* LiteralStringBacktick */ .chroma .sb { color: hsl(152, 50%, 55%); }
-/* LiteralStringChar */ .chroma .sc {  }
-/* LiteralStringDelimiter */ .chroma .dl { color: hsl(152, 50%, 55%); }
-/* LiteralStringDoc */ .chroma .sd { color: hsl(75, 53%, 70.5%); }
-/* LiteralStringDouble */ .chroma .s2 { color: hsl(152, 50%, 55%); }
-/* LiteralStringEscape */ .chroma .se { color: hsl(41, 98%, 65%); }
-/* LiteralStringHeredoc */ .chroma .sh { color: hsl(152, 50%, 55%); }
-/* LiteralStringInterpol */ .chroma .si { color: hsl(41, 98%, 65%); }
-/* LiteralStringOther */ .chroma .sx { color: hsl(152, 50%, 55%); }
-/* LiteralStringRegex */ .chroma .sr { color: hsl(152, 50%, 55%); }
-/* LiteralStringSingle */ .chroma .s1 { color: hsl(152, 50%, 55%); }
-/* LiteralStringSymbol */ .chroma .ss { color: hsl(152, 50%, 55%); }
-/* LiteralNumber */ .chroma .m { color: hsl(41, 98%, 65%); }
-/* LiteralNumberBin */ .chroma .mb { color: hsl(41, 98%, 65%); }
-/* LiteralNumberFloat */ .chroma .mf { color: hsl(41, 98%, 65%); }
-/* LiteralNumberHex */ .chroma .mh { color: hsl(41, 98%, 65%); }
-/* LiteralNumberInteger */ .chroma .mi { color: hsl(41, 98%, 65%); }
-/* LiteralNumberIntegerLong */ .chroma .il { color: hsl(41, 98%, 65%); }
-/* LiteralNumberOct */ .chroma .mo { color: hsl(41, 98%, 65%); }
-/* Operator */ .chroma .o { color: hsl(194, 100%, 65%); }
-/* OperatorWord */ .chroma .ow { color: hsl(194, 100%, 65%); }
+/* Literal */ .chroma .l {  }
+/* LiteralDate */ .chroma .ld {  }
+/* LiteralString */ .chroma .s { color: hsl(155, 74%, 27%) }
+/* LiteralStringAffix */ .chroma .sa { color: hsl(155, 74%, 27%) }
+/* LiteralStringBacktick */ .chroma .sb { color: hsl(155, 74%, 27%) }
+/* LiteralStringChar */ .chroma .sc { color: hsl(155, 74%, 27%) }
+/* LiteralStringDelimiter */ .chroma .dl { color: hsl(155, 74%, 27%) }
+/* LiteralStringDoc */ .chroma .sd { color: hsl(155, 74%, 27%); font-style: italic }
+/* LiteralStringDouble */ .chroma .s2 { color: hsl(155, 74%, 27%) }
+/* LiteralStringEscape */ .chroma .se { color: hsl(358, 94%, 40%); font-weight: bold }
+/* LiteralStringHeredoc */ .chroma .sh { color: hsl(155, 74%, 27%) }
+/* LiteralStringInterpol */ .chroma .si { color: hsl(155, 74%, 27%) }
+/* LiteralStringOther */ .chroma .sx { color: hsl(190, 51%, 39%) }
+/* LiteralStringRegex */ .chroma .sr { color: hsl(155, 74%, 27%) }
+/* LiteralStringSingle */ .chroma .s1 { color: hsl(155, 74%, 27%) }
+/* LiteralStringSymbol */ .chroma .ss { color: hsl(358, 94%, 40%); font-weight: bold }
+/* LiteralNumber */ .chroma .m { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberBin */ .chroma .mb { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberFloat */ .chroma .mf { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberHex */ .chroma .mh { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberInteger */ .chroma .mi { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberIntegerLong */ .chroma .il { color: hsl(30, 85%, 34%); font-weight: bold }
+/* LiteralNumberOct */ .chroma .mo { color: hsl(30, 85%, 34%); font-weight: bold }
+/* Operator */ .chroma .o { color: hsl(222, 67%, 35%) }
+/* OperatorWord */ .chroma .ow { color: hsl(222, 67%, 35%); font-weight: bold }
 /* Punctuation */ .chroma .p {  }
-/* Comment */ .chroma .c { color: hsl(75, 53%, 70.5%); }
-/* CommentHashbang */ .chroma .ch { color: hsl(75, 53%, 70.5%); }
-/* CommentMultiline */ .chroma .cm { color: hsl(75, 53%, 70.5%); }
-/* CommentSingle */ .chroma .c1 { color: hsl(75, 53%, 70.5%); }
-/* CommentSpecial */ .chroma .cs { color: hsl(75, 53%, 70.5%); }
-/* CommentPreproc */ .chroma .cp { color: hsl(75, 53%, 70.5%); }
-/* CommentPreprocFile */ .chroma .cpf { color: hsl(75, 53%, 70.5%); }
+/* Comment */ .chroma .c { color: hsl(40, 36%, 37%); font-style: italic }
+/* CommentHashbang */ .chroma .ch { color: hsl(40, 36%, 37%); font-style: italic }
+/* CommentMultiline */ .chroma .cm { color: hsl(40, 36%, 37%); font-style: italic }
+/* CommentSingle */ .chroma .c1 { color: hsl(40, 36%, 37%); font-style: italic }
+/* CommentSpecial */ .chroma .cs { color: hsl(40, 36%, 37%); font-weight: bold; font-style: italic }
+/* CommentPreproc */ .chroma .cp { color: hsl(83, 40%, 35%) }
+/* CommentPreprocFile */ .chroma .cpf { color: hsl(83, 40%, 35%) }
 /* Generic */ .chroma .g {  }
-/* GenericDeleted */ .chroma .gd { color: hsl(3, 77.5%, 69%); }
+/* GenericDeleted */ .chroma .gd { background-color: hsl(0, 100%, 90%) }
 /* GenericEmph */ .chroma .ge { font-style: italic }
-/* GenericError */ .chroma .gr {  }
-/* GenericHeading */ .chroma .gh { font-weight: bold }
-/* GenericInserted */ .chroma .gi { color: hsl(152, 50%, 55%); }
-/* GenericOutput */ .chroma .go {  }
-/* GenericPrompt */ .chroma .gp { color: hsl(75, 53%, 70.5%); font-weight: bold }
+/* GenericError */ .chroma .gr { color: hsl(0, 100%, 50%) }
+/* GenericHeading */ .chroma .gh { color: hsl(222, 67%, 35%); font-weight: bold }
+/* GenericInserted */ .chroma .gi { background-color: hsl(120, 100%, 90%) }
+/* GenericOutput */ .chroma .go { color: hsl(0, 0%, 67%) }
+/* GenericPrompt */ .chroma .gp { color: hsl(222, 67%, 35%); font-weight: bold }
 /* GenericStrong */ .chroma .gs { font-weight: bold }
-/* GenericSubheading */ .chroma .gu { color: hsl(194, 100%, 65%); font-weight: bold }
-/* GenericTraceback */ .chroma .gt {  }
-/* GenericUnderline */ .chroma .gl {  }
-/* TextWhitespace */ .chroma .w {  }
+/* GenericSubheading */ .chroma .gu { color: hsl(222, 67%, 35%); font-weight: bold }
+/* GenericTraceback */ .chroma .gt { color: hsl(358, 94%, 40%) }
+/* GenericUnderline */ .chroma .gl { text-decoration: underline }
+/* TextWhitespace */ .chroma .w { color: hsl(0, 0%, 80%) }
+
+:root[data-theme='dark'] {
+/* Background */ & .chroma { color: hsl(0, 0%, 93%); background-color: var(--green-18); border-radius: 2px; }
+/* Other */ & .chroma .x {  }
+/* Error */ & .chroma .err { color: hsl(3, 77.5%, 69%); }
+/* LineTableTD */ & .chroma .lntd { vertical-align: top; padding: 0; margin: 0; border: 0; }
+/* LineTable */ & .chroma .lntable { border-spacing: 0; padding: 0; margin: 0; border: 0; width: auto; overflow: auto; display: block; }
+/* LineHighlight */ & .chroma .hl { display: block; width: 100%;background-color: #ffffcc }
+/* LineNumbersTable */ & .chroma .lnt { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* LineNumbers */ & .chroma .ln { margin-right: 0.4em; padding: 0 0.4em 0 0.4em;color: #7f7f7f }
+/* Keyword */ & .chroma .k { color: hsl(288, 81%, 78%); }
+/* KeywordConstant */ & .chroma .kc { color: hsl(288, 81%, 78%); }
+/* KeywordDeclaration */ & .chroma .kd { color: hsl(288, 81%, 78%); }
+/* KeywordNamespace */ & .chroma .kn { color: hsl(194, 100%, 65%); }
+/* KeywordPseudo */ & .chroma .kp { color: hsl(288, 81%, 78%); }
+/* KeywordReserved */ & .chroma .kr { color: hsl(288, 81%, 78%); }
+/* KeywordType */ & .chroma .kt { color: hsl(41, 98%, 65%); }
+/* Name */ & .chroma .n {  }
+/* NameAttribute */ & .chroma .na { color: hsl(93.5, 75%, 65%); }
+/* NameBuiltin */ & .chroma .nb {  }
+/* NameBuiltinPseudo */ & .chroma .bp {  }
+/* NameClass */ & .chroma .nc { color: hsl(41, 98%, 65%); }
+/* NameConstant */ & .chroma .no { color: hsl(3, 77.5%, 69%); }
+/* NameDecorator */ & .chroma .nd { color: hsl(194, 100%, 65%); }
+/* NameEntity */ & .chroma .ni {  }
+/* NameException */ & .chroma .ne { color: hsl(3, 77.5%, 69%); }
+/* NameFunction */ & .chroma .nf { color: hsl(93.5, 75%, 65%); }
+/* NameFunctionMagic */ & .chroma .fm {  }
+/* NameLabel */ & .chroma .nl {  }
+/* NameNamespace */ & .chroma .nn { color: hsl(41, 98%, 65%); }
+/* NameOther */ & .chroma .nx { color: hsl(93.5, 75%, 65%); }
+/* NameProperty */ & .chroma .py {  }
+/* NameTag */ & .chroma .nt { color: hsl(194, 100%, 65%); }
+/* NameVariable */ & .chroma .nv { color: hsl(3, 77.5%, 69%); }
+/* NameVariableClass */ & .chroma .vc {  }
+/* NameVariableGlobal */ & .chroma .vg {  }
+/* NameVariableInstance */ & .chroma .vi {  }
+/* NameVariableMagic */ & .chroma .vm {  }
+/* Literal */ & .chroma .l { color: hsl(41, 98%, 65%); }
+/* LiteralDate */ & .chroma .ld { color: hsl(152, 50%, 55%); }
+/* LiteralString */ & .chroma .s { color: hsl(152, 50%, 55%); }
+/* LiteralStringAffix */ & .chroma .sa { color: hsl(152, 50%, 55%); }
+/* LiteralStringBacktick */ & .chroma .sb { color: hsl(152, 50%, 55%); }
+/* LiteralStringChar */ & .chroma .sc {  }
+/* LiteralStringDelimiter */ & .chroma .dl { color: hsl(152, 50%, 55%); }
+/* LiteralStringDoc */ & .chroma .sd { color: hsl(75, 53%, 70.5%); }
+/* LiteralStringDouble */ & .chroma .s2 { color: hsl(152, 50%, 55%); }
+/* LiteralStringEscape */ & .chroma .se { color: hsl(41, 98%, 65%); }
+/* LiteralStringHeredoc */ & .chroma .sh { color: hsl(152, 50%, 55%); }
+/* LiteralStringInterpol */ & .chroma .si { color: hsl(41, 98%, 65%); }
+/* LiteralStringOther */ & .chroma .sx { color: hsl(152, 50%, 55%); }
+/* LiteralStringRegex */ & .chroma .sr { color: hsl(152, 50%, 55%); }
+/* LiteralStringSingle */ & .chroma .s1 { color: hsl(152, 50%, 55%); }
+/* LiteralStringSymbol */ & .chroma .ss { color: hsl(152, 50%, 55%); }
+/* LiteralNumber */ & .chroma .m { color: hsl(41, 98%, 65%); }
+/* LiteralNumberBin */ & .chroma .mb { color: hsl(41, 98%, 65%); }
+/* LiteralNumberFloat */ & .chroma .mf { color: hsl(41, 98%, 65%); }
+/* LiteralNumberHex */ & .chroma .mh { color: hsl(41, 98%, 65%); }
+/* LiteralNumberInteger */ & .chroma .mi { color: hsl(41, 98%, 65%); }
+/* LiteralNumberIntegerLong */ & .chroma .il { color: hsl(41, 98%, 65%); }
+/* LiteralNumberOct */ & .chroma .mo { color: hsl(41, 98%, 65%); }
+/* Operator */ & .chroma .o { color: hsl(194, 100%, 65%); }
+/* OperatorWord */ & .chroma .ow { color: hsl(194, 100%, 65%); }
+/* Punctuation */ & .chroma .p { color: hsl(0, 100%, 95%); }
+/* Comment */ & .chroma .c { color: hsl(75, 53%, 70.5%); }
+/* CommentHashbang */ & .chroma .ch { color: hsl(75, 53%, 70.5%); }
+/* CommentMultiline */ & .chroma .cm { color: hsl(75, 53%, 70.5%); }
+/* CommentSingle */ & .chroma .c1 { color: hsl(75, 53%, 70.5%); }
+/* CommentSpecial */ & .chroma .cs { color: hsl(75, 53%, 70.5%); }
+/* CommentPreproc */ & .chroma .cp { color: hsl(75, 53%, 70.5%); }
+/* CommentPreprocFile */ & .chroma .cpf { color: hsl(75, 53%, 70.5%); }
+/* Generic */ & .chroma .g {  }
+/* GenericDeleted */ & .chroma .gd { color: hsl(3, 77.5%, 69%); }
+/* GenericEmph */ & .chroma .ge { font-style: italic }
+/* GenericError */ & .chroma .gr {  }
+/* GenericHeading */ & .chroma .gh { font-weight: bold }
+/* GenericInserted */ & .chroma .gi { color: hsl(152, 50%, 55%); }
+/* GenericOutput */ & .chroma .go {  }
+/* GenericPrompt */ & .chroma .gp { color: hsl(75, 53%, 70.5%); font-weight: bold }
+/* GenericStrong */ & .chroma .gs { font-weight: bold }
+/* GenericSubheading */ & .chroma .gu { color: hsl(194, 100%, 65%); font-weight: bold }
+/* GenericTraceback */ & .chroma .gt {  }
+/* GenericUnderline */ & .chroma .gl {  }
+/* TextWhitespace */ & .chroma .w {  }
+}

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -16,7 +16,7 @@
 /* KeywordReserved */ .chroma .kr { color: hsl(222, 67%, 35%); font-weight: bold }
 /* KeywordType */ .chroma .kt { color: hsl(264, 77%, 41%); font-weight: bold }
 /* Name */ .chroma .n {  }
-/* NameAttribute */ .chroma .na { color: hsl(0, 47%, 45%); font-style: italic }
+/* NameAttribute */ .chroma .na { color: hsl(0, 47%, 45%); }
 /* NameBuiltin */ .chroma .nb { color: hsl(264, 77%, 41%); font-weight: bold }
 /* NameBuiltinPseudo */ .chroma .bp {  }
 /* NameClass */ .chroma .nc { text-decoration: underline }

--- a/layouts/partials/api/oas/copy-btn.html
+++ b/layouts/partials/api/oas/copy-btn.html
@@ -1,7 +1,7 @@
-<button class="btn-link btn-link--copy flex align-ic absolute copy-btn" aria-label="Copy example">
+<button class="btn-link--dark btn-link--copy flex align-ic absolute copy-btn" aria-label="Copy example">
   <span
     data-mybicon="mybicon-copy"
-    data-mybicon-class="icon-ui--s icon-ui--lightgray mrxs"
+    data-mybicon-class="icon-ui--s icon-ui mrxs"
     data-mybicon-width="18"
     data-mybicon-height="18"
   ></span>

--- a/layouts/partials/api/tabs.html
+++ b/layouts/partials/api/tabs.html
@@ -101,10 +101,10 @@
           {{- end -}}
           {{ highlight .value $highlightLang "" }}
           {{- if eq $formatType "Request" -}}
-          <button class="btn-link btn-link--copy flex align-ic absolute copy-btn">
+          <button class="btn-link--dark btn-link--copy flex align-ic absolute copy-btn">
             <span
               data-mybicon="mybicon-copy"
-              data-mybicon-class="icon-ui--s icon-ui--lightgray mrxs"
+              data-mybicon-class="icon-ui--s icon-ui mrxs"
               data-mybicon-width="18"
               data-mybicon-height="18"
             ></span>

--- a/layouts/partials/api/tabssoap.html
+++ b/layouts/partials/api/tabssoap.html
@@ -40,10 +40,10 @@
               {{- end -}}
             {{- end -}}
             {{ highlight .value $format "" }}
-            <button class="btn-link btn-link--copy flex align-ic absolute copy-btn">
+            <button class="btn-link--dark btn-link--copy flex align-ic absolute copy-btn">
               <span
                 data-mybicon="mybicon-copy"
-                data-mybicon-class="icon-ui--s icon-ui--lightgray mrxs"
+                data-mybicon-class="icon-ui--s icon-ui mrxs"
                 data-mybicon-width="18"
                 data-mybicon-height="18"
               ></span>


### PR DESCRIPTION
Adding light mode CSS in the syntax.css, following the same logic as we have in place for the dark theme. So, when a user have dark mode enabled or selected, the original dark mode syntax highlighting CSS is in use, otherwise the newly added light mode CSS will be in use.

We can generate a syntax highlighting CSS with Hugo. In order to do so, we need to install Hugo locally.

Quick start:
https://gohugo.io/getting-started/quick-start/

Then we can generate one base on the available styles:

`hugo gen chromastyles --style=monokai > syntax.css`

Gallery of available styles.
https://xyproto.github.io/splash/docs/longer/all.html

I chose **rainbow_dash**, but modified it so the colours don't pop too much and have some balance between dark mode and light mode.

Chosen theme:
https://xyproto.github.io/splash/docs/longer/rainbow_dash.html

JSON example:
![Skjermbilde 2022-10-13 kl  10 30 04](https://user-images.githubusercontent.com/65193388/195544631-fc36e095-7951-4034-a35d-d882f65695c1.png)

XML example:
![Skjermbilde 2022-10-13 kl  10 33 31](https://user-images.githubusercontent.com/65193388/195545470-b8425574-1a11-4560-9dfd-593124ab2fac.png)
