### PR TITLE
Improve front page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -102,7 +102,7 @@ important:
     </div>
     <p class="mhxs pll">
       Generate status, quality and deviation, economy and environment reports to
-      analyse your logistics with Bring.
+      analyse your logistics with Bring. List and retrieve invoices in PDF format.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/reports/">Reports API</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -24,6 +24,12 @@ important:
       Look up available services, delivery times, prices and environmental data,
       and use our recommended service descriptions in your checkout.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/shipping-guide_2/">Shipping Guide API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/pickup-point/">Pickup Point API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/address/">Address API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/postal-code/">Postal Code API</a>
+    </div>
   </div>
 
   <div class="bg-green1 flex flex-dir-col start__col pam">
@@ -39,6 +45,11 @@ important:
     <p class="mhxs pll">
       Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Order pickups.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/booking/">Booking API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/shipment/">Shipment API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/modify-delivery/">Modify Delivery API</a>
+    </div>
   </div>
 
   <div class="bg-green1 flex flex-dir-col start__col pam">
@@ -54,6 +65,10 @@ important:
     <p class="mhxs pll">
       Look up tracking events of your shipments, or subscribe to them, and make them available to your customers.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/tracking/">Tracking API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/event-cast/">Event Cast API</a>
+    </div>
   </div>
 
   <div class="bg-green1 flex flex-dir-col start__col pam">
@@ -69,6 +84,11 @@ important:
     <p class="mhxs pll">
       A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing/">Send order/article update</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing3/">Receive order/article update</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing4/">Pull order/article</a>
+    </div>
   </div>
 
   <div class="bg-green1 flex flex-dir-col start__col pam">
@@ -85,6 +105,10 @@ important:
       Generate status, quality and deviation, economy and environment reports to
       analyse your logistics with Bring.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/reports/">Reports API</a>
+      <a class="btn-link--dark mrxs mbxs" href="/api/invoice/">Invoice API</a>
+    </div>
   </div>
 
   <div class="bg-green1 flex flex-dir-col start__col pam">
@@ -100,6 +124,9 @@ important:
     <p class="mhxs pll">
       A solution that lets integrated customers, their suppliers and Bring exchange order level information across the life cycle of customers' orders.
     </p>
+    <div class="flex flex-wrap gas pll mlxs">
+      <a class="btn-link--dark mrxs mbxs" href="/api/order-management/">Order Management API</a>
+    </div>
   </div>
 </div>
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -9,11 +9,8 @@ important:
 ---
 
 <h2 class="mbs">Explore our APIs</h2>
-<div class="flex flex-wrap mbxl">
-  <a
-    href='{{< relref "api/shipping-guide_2" >}}'
-    class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs"
-  >
+<div class="flex flex-wrap gaxs mbxl">
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-list"
@@ -21,18 +18,15 @@ important:
         data-mybicon-width="19"
         data-mybicon-height="19"
       ></span>
-      <h3 class="mlxs fwn">Shipping Guide API</h3>
+      <h3 class="mlxs fwn">Checkout</h3>
     </div>
     <p class="mhxs pll">
       Look up available services, delivery times, prices and environmental data,
       and use our recommended service descriptions in your checkout.
     </p>
-  </a>
+  </div>
 
-  <a
-    href='{{< relref "api/booking" >}}'
-    class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs"
-  >
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-box"
@@ -40,32 +34,14 @@ important:
         data-mybicon-width="19"
         data-mybicon-height="19"
       ></span>
-      <h3 class="mlxs fwn">Booking API</h3>
+      <h3 class="mlxs fwn">Booking</h3>
     </div>
     <p class="mhxs pll">
       Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Order pickups.
     </p>
-  </a>
+  </div>
 
-  <a
-    href='{{< relref "api/pickup-point" >}}'
-    class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs"
-  >
-    <div class="flex align-ic mlxs">
-      <span
-        data-mybicon="mybicon-location"
-        data-mybicon-class="icon-ui--green-dark mrs"
-        data-mybicon-width="19"
-        data-mybicon-height="19"
-      ></span>
-      <h3 class="mlxs fwn">Pickup Point API</h3>
-    </div>
-    <p class="mhxs pll">
-      Let your customers choose their preferred pickup point in your checkout.
-    </p>
-  </a>
-
-  <a href='{{< relref "tracking" >}}' class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs">
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-search"
@@ -73,31 +49,29 @@ important:
         data-mybicon-width="19"
         data-mybicon-height="19"
       ></span>
-      <h3 class="mlxs fwn">Tracking API</h3>
+      <h3 class="mlxs fwn">Tracking</h3>
     </div>
     <p class="mhxs pll">
-      Look up tracking events of your shipments, and make them available to your
-      customers.
+      Look up tracking events of your shipments, or subscribe to them, and make them available to your customers.
     </p>
-  </a>
+  </div>
 
-  <a href='{{< relref "event-cast" >}}' class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs">
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
     <div class="flex align-ic mlxs">
       <span
-        data-mybicon="mybicon-alert"
+        data-mybicon="mybicon-warehouse"
         data-mybicon-class="icon-ui--green-dark mrs"
         data-mybicon-width="19"
         data-mybicon-height="19"
       ></span>
-      <h3 class="mlxs fwn">Event Cast API</h3>
+      <h3 class="mlxs fwn">Warehousing</h3>
     </div>
     <p class="mhxs pll">
-      Subscribe to tracking events through webhooks, and get notified
-      proactively.
+      A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics.
     </p>
-  </a>
+  </div>
 
-  <a href='{{< relref "reports" >}}' class="mb-card flex flex-dir-col flex-1-1-20r pam mrxs mbxs">
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-chart-bar"
@@ -105,16 +79,27 @@ important:
         data-mybicon-width="19"
         data-mybicon-height="19"
       ></span>
-      <h3 class="mlxs fwn">Reports API</h3>
+      <h3 class="mlxs fwn">Reports and invoices</h3>
     </div>
     <p class="mhxs pll">
       Generate status, quality and deviation, economy and environment reports to
       analyse your logistics with Bring.
     </p>
-  </a>
+  </div>
 
-  <div class="w100p mtm text-heading">
-    <a href='{{< relref "api" >}}'>View all our APIs &RightArrow;</a>
+  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+    <div class="flex align-ic mlxs">
+      <span
+        data-mybicon="mybicon-tasks"
+        data-mybicon-class="icon-ui--green-dark mrs"
+        data-mybicon-width="19"
+        data-mybicon-height="19"
+      ></span>
+      <h3 class="mlxs fwn">Order Management</h3>
+    </div>
+    <p class="mhxs pll">
+      A solution that lets integrated customers, their suppliers and Bring exchange order level information across the life cycle of customers' orders.
+    </p>
   </div>
 </div>
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -24,10 +24,10 @@ important:
       Look up available services, delivery times, prices and environmental data. Verify addresses and let users pick the closest pickup point. And use our recommended service descriptions in your checkout.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/shipping-guide_2/">Shipping Guide API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/pickup-point/">Pickup Point API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/address/">Address API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/postal-code/">Postal Code API</a>
+      <a class="btn-link--dark" href="/api/shipping-guide_2/">Shipping Guide API</a>
+      <a class="btn-link--dark" href="/api/pickup-point/">Pickup Point API</a>
+      <a class="btn-link--dark" href="/api/address/">Address API</a>
+      <a class="btn-link--dark" href="/api/postal-code/">Postal Code API</a>
     </div>
   </div>
 
@@ -45,9 +45,9 @@ important:
       Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Modify certain shipments that are on their way, and order pickup.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/booking/">Booking API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/shipment/">Shipment API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/modify-delivery/">Modify Delivery API</a>
+      <a class="btn-link--dark" href="/api/booking/">Booking API</a>
+      <a class="btn-link--dark" href="/api/shipment/">Shipment API</a>
+      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 
@@ -65,8 +65,8 @@ important:
       Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/tracking/">Tracking API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/event-cast/">Event Cast API</a>
+      <a class="btn-link--dark" href="/api/tracking/">Tracking API</a>
+      <a class="btn-link--dark" href="/api/event-cast/">Event Cast API</a>
     </div>
   </div>
 
@@ -84,9 +84,9 @@ important:
       A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics. Submit order and article information to Bring’s warehouses. Retrieve information about orders and inventory down to single items.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing/">Send order/article update</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing3/">Receive order/article update</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/warehousing4/">Pull order/article</a>
+      <a class="btn-link--dark" href="/api/warehousing/">Send order/article update</a>
+      <a class="btn-link--dark" href="/api/warehousing3/">Receive order/article update</a>
+      <a class="btn-link--dark" href="/api/warehousing4/">Pull order/article</a>
     </div>
   </div>
 
@@ -105,8 +105,8 @@ important:
       analyse your logistics with Bring. List and retrieve invoices in PDF format.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/reports/">Reports API</a>
-      <a class="btn-link--dark mrxs mbxs" href="/api/invoice/">Invoice API</a>
+      <a class="btn-link--dark" href="/api/reports/">Reports API</a>
+      <a class="btn-link--dark" href="/api/invoice/">Invoice API</a>
     </div>
   </div>
 
@@ -124,7 +124,7 @@ important:
       For integrated customers, their suppliers and Bring to exchange order level information across the life cycle of customers' orders.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark mrxs mbxs" href="/api/order-management/">Order Management API</a>
+      <a class="btn-link--dark" href="/api/order-management/">Order Management API</a>
     </div>
   </div>
 </div>

--- a/content/_index.html
+++ b/content/_index.html
@@ -81,7 +81,7 @@ important:
       <h3 class="mlxs fwn">Warehousing</h3>
     </div>
     <p class="mhxs pll">
-      A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics.
+      A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics. Submit order and article information to Bring’s warehouses. Retrieve information about orders and inventory down to single items.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/warehousing/">Send order/article update</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -10,7 +10,7 @@ important:
 
 <h2 class="mbs">Explore our APIs</h2>
 <div class="flex flex-wrap gaxs mbxl">
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-list"
@@ -26,7 +26,7 @@ important:
     </p>
   </div>
 
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-box"
@@ -41,7 +41,7 @@ important:
     </p>
   </div>
 
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-search"
@@ -56,7 +56,7 @@ important:
     </p>
   </div>
 
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-warehouse"
@@ -71,7 +71,7 @@ important:
     </p>
   </div>
 
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-chart-bar"
@@ -87,7 +87,7 @@ important:
     </p>
   </div>
 
-  <div class="bg-green1 flex flex-dir-col flex-1-1-20r pam">
+  <div class="bg-green1 flex flex-dir-col start__col pam">
     <div class="flex align-ic mlxs">
       <span
         data-mybicon="mybicon-tasks"
@@ -104,7 +104,7 @@ important:
 </div>
 
 <div class="flex flex-wrap">
-  <div class="flex-1-1-20r mrl mbxl">
+  <div class="start__col mrl mbxl">
     <h2>Checkout guide Norway</h2>
     <p>
       Recommendations and guide, based on user research and testing, to get the
@@ -114,7 +114,7 @@ important:
       >Checkout guide &RightArrow;</a
     >
   </div>
-  <div class="flex-1-1-20r mbxl">
+  <div class="start__col mbxl">
     <h2>EDI documentation</h2>
     <p>
       Guidelines and specifications for vendors of TA/EDI solutions and

--- a/content/_index.html
+++ b/content/_index.html
@@ -42,7 +42,7 @@ important:
       <h3 class="mlxs fwn">Booking</h3>
     </div>
     <p class="mhxs pll">
-      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Order pickups.
+      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Modify certain shipments that are on their way, and order pickup.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/booking/">Booking API</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -121,7 +121,7 @@ important:
       <h3 class="mlxs fwn">Order Management</h3>
     </div>
     <p class="mhxs pll">
-      A solution that lets integrated customers, their suppliers and Bring exchange order level information across the life cycle of customers' orders.
+      For integrated customers, their suppliers and Bring to exchange order level information across the life cycle of customers' orders.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/order-management/">Order Management API</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -21,8 +21,7 @@ important:
       <h3 class="mlxs fwn">Checkout</h3>
     </div>
     <p class="mhxs pll">
-      Look up available services, delivery times, prices and environmental data,
-      and use our recommended service descriptions in your checkout.
+      Look up available services, delivery times, prices and environmental data. Verify addresses and let users pick the closest pickup point. And use our recommended service descriptions in your checkout.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/shipping-guide_2/">Shipping Guide API</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -84,8 +84,8 @@ important:
       E-commerce customers in Norway and Sweden, for whom we handle storage and logistics, can submit and retrieve order and article information in Bring’s warehouses.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
-      <a class="btn-link--dark" href="/api/warehousing/">Send order/article update</a>
-      <a class="btn-link--dark" href="/api/warehousing3/">Receive order/article update</a>
+      <a class="btn-link--dark" href="/api/warehousing/">Send updates</a>
+      <a class="btn-link--dark" href="/api/warehousing3/">Receive updates</a>
       <a class="btn-link--dark" href="/api/warehousing4/">Pull order/article</a>
     </div>
   </div>

--- a/content/_index.html
+++ b/content/_index.html
@@ -81,7 +81,7 @@ important:
       <h3 class="mlxs fwn">Warehousing</h3>
     </div>
     <p class="mhxs pll">
-      A complete solution for online stores with customers in Norway and Sweden, where we handle the storage and logistics. Submit order and article information to Bring’s warehouses. Retrieve information about orders and inventory down to single items.
+      E-commerce customers in Norway and Sweden, for whom we handle storage and logistics, can submit and retrieve order and article information in Bring’s warehouses.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/warehousing/">Send order/article update</a>

--- a/content/_index.html
+++ b/content/_index.html
@@ -62,7 +62,7 @@ important:
       <h3 class="mlxs fwn">Tracking</h3>
     </div>
     <p class="mhxs pll">
-      Look up tracking events of your shipments, or subscribe to them, and make them available to your customers.
+      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark mrxs mbxs" href="/api/tracking/">Tracking API</a>

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -82,7 +82,7 @@
     border-color: var(--gray-40);
   }
 
-  & .flex-1-1-20r {
+  & .start__col {
     & svg {
       fill: var(--green);
     }

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -7,7 +7,6 @@
   & a:not(
     .btn,
     .btn-link--dark,
-    .mb-card,
     .sitefooter a,
     .dev-siteheader__nav a,
     .dev-sidemenu a,
@@ -18,7 +17,6 @@
   & a:not(
     .btn,
     .btn-link--dark,
-    .mb-card,
     .sitefooter a,
     .dev-siteheader__nav a,
     .dev-sidemenu a,
@@ -84,12 +82,7 @@
     border-color: var(--gray-40);
   }
 
-  & .mb-card {
-    background-color: var(--green-22);
-    border-color: transparent;
-    &:hover {
-      background-color: var(--green-18);
-    }
+  & .flex-1-1-20r {
     & svg {
       fill: var(--green);
     }
@@ -184,8 +177,7 @@
   & .param-toggle-icon,
   & .form__label,
   & .dev-docscontent__info summary,
-  & .dev-docscontent__info details p,
-  & .mb-card {
+  & .dev-docscontent__info details p {
     color: var(--green-86);
   }
 

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -71,7 +71,7 @@
 }
 
 .dev-docs__menu {
-  background-color: var(--gray-95);
+  background-color: var(--gray-93);
   display: flex;
   justify-content: flex-end;
   align-items: stretch;

--- a/css/footer.css
+++ b/css/footer.css
@@ -17,6 +17,7 @@
 
 .sitefooter__terms {
   display: flex;
+  justify-content: space-between;
   flex-flow: row wrap;
   font-size: 0.83rem;
 }

--- a/css/footer.css
+++ b/css/footer.css
@@ -5,30 +5,6 @@
   color: #fff;
 }
 
-.sitefooter__wrapper {
-  padding: 2rem 0;
-  display: flex;
-  flex-flow: row wrap;
-  border-bottom: 1px solid var(--green-dark);
-  margin-bottom: 0.5rem;
-}
-
-.sitefooter__logo {
-  width: 9rem;
-  height: auto;
-  margin-right: 3rem;
-  margin-bottom: 1rem;
-}
-
-.sitefooter__nav {
-  margin-right: 2rem;
-  margin-bottom: 1rem;
-  display: flex;
-  flex-flow: column nowrap;
-  align-items: flex-start;
-  min-width: 8rem;
-}
-
 .sitefooter a {
   color: var(--green-lighter);
   text-decoration: underline;

--- a/css/frontpage.css
+++ b/css/frontpage.css
@@ -10,12 +10,12 @@
 
 .dev-intro-l {
   flex: 1 1 40rem;
-  max-width: 50rem;
+  max-width: 58rem;
 }
 
 .dev-intro-m {
   flex: 1 1 20rem;
-  max-width: 30rem;
+  max-width: 36rem;
 }
 
 @media screen and (min-width: 50em) {

--- a/css/frontpage.css
+++ b/css/frontpage.css
@@ -26,6 +26,6 @@
   }
 }
 
-.flex-1-1-20r {
+.start__col {
   flex: 1 1 20rem;
 }

--- a/css/frontpage.css
+++ b/css/frontpage.css
@@ -21,8 +21,8 @@
 @media screen and (min-width: 50em) {
   .dev-intro-l,
   .dev-intro-m {
-    margin-right: 3rem;
-    margin-left: 3rem;
+    margin-right: 2rem;
+    margin-left: 2rem;
   }
 }
 

--- a/css/page.css
+++ b/css/page.css
@@ -6,8 +6,6 @@
 }
 
 .dev-container {
-  margin-left: auto;
-  margin-right: auto;
   width: 100%;
   max-width: 100rem;
   padding-left: 1rem;

--- a/css/siteheader.css
+++ b/css/siteheader.css
@@ -113,9 +113,10 @@
 }
 
 .theme-switch-container {
-  position:absolute;
-  top:100%;
-  right:0;
+  position: absolute;
+  top: 100%;
+  right: 0;
+  z-index: 1;
 }
 
 .themes-btn:hover {

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -5,196 +5,188 @@
     {{- $maxwidth = "maxw108r" -}}
   {{- end -}}
 
-  <div class="dev-docs__menu" data-drawer data-drawer-event>
-    {{- partial "sidemenu.html" . -}}
-  </div>
-  {{- partial "drawmenu.html" . -}}
-  <div class="dev-docs__page">
-    {{- if (eq $notAnApi true) -}}
-      <main id="main" class="dev-docscontent w100p {{ $maxwidth }}">
-        <article>
-          <h1>
-            {{- .Title -}}
-            {{- with .Params.titlesub -}}
-              <span class="db text-title mts">{{ . }}</span>
-            {{- end -}}
-          </h1>
-          {{- if or (isset .Params "services") (isset .Params "examples") -}}
-            {{- partial "api/guide.html" . -}}
+  {{- if (eq $notAnApi true) -}}
+    <main id="main" class="dev-docscontent w100p {{ $maxwidth }}">
+      <article>
+        <h1>
+          {{- .Title -}}
+          {{- with .Params.titlesub -}}
+            <span class="db text-title mts">{{ . }}</span>
           {{- end -}}
-          {{- if and (isset .Params "apidoc") (isset .Params "apiresources") -}}
-            {{- partial "api/guideapi.html" . -}}
-          {{- end -}}
-          {{- if and (isset .Params "apidoc") (isset .Params "apiresource") -}}
-            {{- partial "api/guideapiresource.html" . -}}
-          {{- end -}}
-          {{- .Content -}}
-          {{- if (in .CurrentSection "revision-history") -}}
-            {{- partial "api/changelog.html" . -}}
-          {{- end -}}
-          {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
-            <section class="dev-docscontent__section">
-              {{ template "_internal/disqus.html" $ }}
-            </section>
-          {{- end -}}
-        </article>
-      </main>
+        </h1>
+        {{- if or (isset .Params "services") (isset .Params "examples") -}}
+          {{- partial "api/guide.html" . -}}
+        {{- end -}}
+        {{- if and (isset .Params "apidoc") (isset .Params "apiresources") -}}
+          {{- partial "api/guideapi.html" . -}}
+        {{- end -}}
+        {{- if and (isset .Params "apidoc") (isset .Params "apiresource") -}}
+          {{- partial "api/guideapiresource.html" . -}}
+        {{- end -}}
+        {{- .Content -}}
+        {{- if (in .CurrentSection "revision-history") -}}
+          {{- partial "api/changelog.html" . -}}
+        {{- end -}}
+        {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
+          <section class="dev-docscontent__section">
+            {{ template "_internal/disqus.html" $ }}
+          </section>
+        {{- end -}}
+      </article>
+    </main>
 
-    {{- else if in .Title "Order Management" -}}
-      {{- partial "api/oas/restsoap.html" . -}}
-    {{- else if isset $.Params "oas" -}}
-      <main id="main" class="dev-docscontent w100p {{ replace .Title "API" "" | urlize }}">
-        <article>
-          {{- partial "api/oas/section-intro.html" . -}}
+  {{- else if in .Title "Order Management" -}}
+    {{- partial "api/oas/restsoap.html" . -}}
+  {{- else if isset $.Params "oas" -}}
+    <main id="main" class="dev-docscontent w100p {{ replace .Title "API" "" | urlize }}">
+      <article>
+        {{- partial "api/oas/section-intro.html" . -}}
 
-          {{- $oasData := getJSON $.Params.oas -}}
-          {{- partial "api/oas/endpoints.html" (dict "oas" $oasData) -}}
+        {{- $oasData := getJSON $.Params.oas -}}
+        {{- partial "api/oas/endpoints.html" (dict "oas" $oasData) -}}
 
-          <section class="dev-docscontent__section oas-endpoints maxw96r">
-            {{- with $oasData -}}
-              {{ $baseUrl := "" }}
-              {{- range .servers -}}
-                {{- $baseUrl = replace .url "qa." "" -}}
-                {{- $last := substr $baseUrl -1 -}}
-                {{- if eq $last "/" -}}
-                  {{- $baseUrl = substr $baseUrl 0 -1 -}}
-                {{- end -}}
+        <section class="dev-docscontent__section oas-endpoints maxw96r">
+          {{- with $oasData -}}
+            {{ $baseUrl := "" }}
+            {{- range .servers -}}
+              {{- $baseUrl = replace .url "qa." "" -}}
+              {{- $last := substr $baseUrl -1 -}}
+              {{- if eq $last "/" -}}
+                {{- $baseUrl = substr $baseUrl 0 -1 -}}
               {{- end -}}
-              {{- $components := .components -}}
-              {{- range $path, $_ := .paths -}}
-                {{- range $type, $_ := . -}}
-                  {{- $endpointId := (print .summary "-" $type | anchorize ) -}}
-                  <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
-                  <div class="flex flex-wrap mbxl pbxl mb-border bb gal">
-                    <div class="param-response-area">
-                      <div class="flex align-ic mbl mts">
-                        {{- partial "api/oas/endpoint-type" (dict "type" $type) -}}
-                        <span class="flex-auto">
-                          <pre class="flex align-ic pas mb0 wrap-text">
-                            <span>{{ $baseUrl }}{{ $path }}</span>
-                          </pre>
-                        </span>
-                      </div>
-                      <p class="mbl text-heading">{{ .description | safeHTML }}</p>
+            {{- end -}}
+            {{- $components := .components -}}
+            {{- range $path, $_ := .paths -}}
+              {{- range $type, $_ := . -}}
+                {{- $endpointId := (print .summary "-" $type | anchorize ) -}}
+                <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
+                <div class="flex flex-wrap mbxl pbxl mb-border bb gal">
+                  <div class="param-response-area">
+                    <div class="flex align-ic mbl mts">
+                      {{- partial "api/oas/endpoint-type" (dict "type" $type) -}}
+                      <span class="flex-auto">
+                        <pre class="flex align-ic pas mb0 wrap-text">
+                          <span>{{ $baseUrl }}{{ $path }}</span>
+                        </pre>
+                      </span>
+                    </div>
+                    <p class="mbl text-heading">{{ .description | safeHTML }}</p>
 
-                      {{- with .parameters -}}
-                        {{- partial "api/oas/request-params.html" (dict "parameters" .) -}}
-                      {{- end -}}
+                    {{- with .parameters -}}
+                      {{- partial "api/oas/request-params.html" (dict "parameters" .) -}}
+                    {{- end -}}
 
-                      {{- with .responses -}}
-                        <h3 class="mbm">Responses</h3>
-                        {{- range $response, $_ := . -}}
-                          {{- $responseColorBg := "bg-gray1" -}}
-                          {{- $responseColorTxt := "" -}}
-                          {{- if and (ge $response 200) (lt $response 300) -}}
-                            {{- $responseColorBg = "bg-green1" -}}
-                            {{- $responseColorTxt = "green-dark" -}}
-                          {{- else if ge $response 300 -}}
-                            {{- $responseColorBg = "bg-red1" -}}
-                            {{- $responseColorTxt = "red-dark" -}}
-                          {{- end -}}
+                    {{- with .responses -}}
+                      <h3 class="mbm">Responses</h3>
+                      {{- range $response, $_ := . -}}
+                        {{- $responseColorBg := "bg-gray1" -}}
+                        {{- $responseColorTxt := "" -}}
+                        {{- if and (ge $response 200) (lt $response 300) -}}
+                          {{- $responseColorBg = "bg-green1" -}}
+                          {{- $responseColorTxt = "green-dark" -}}
+                        {{- else if ge $response 300 -}}
+                          {{- $responseColorBg = "bg-red1" -}}
+                          {{- $responseColorTxt = "red-dark" -}}
+                        {{- end -}}
 
-                          {{- $description := .description -}}
+                        {{- $description := .description -}}
 
-                          {{ $hasSchema := false }}
-                          {{- with .content -}}
-                            {{- range . -}}
-                              {{/*  since go template doesn’t have loop breaks  */}}
-                              {{- if not $hasSchema -}}
-                                {{- with .schema -}}
-                                  {{- $hasSchema = true -}}
-                                {{- end -}}
+                        {{ $hasSchema := false }}
+                        {{- with .content -}}
+                          {{- range . -}}
+                            {{/*  since go template doesn’t have loop breaks  */}}
+                            {{- if not $hasSchema -}}
+                              {{- with .schema -}}
+                                {{- $hasSchema = true -}}
                               {{- end -}}
                             {{- end -}}
                           {{- end -}}
+                        {{- end -}}
 
-                          {{- if $hasSchema -}}
-                            {{- with .content -}}
-                            {{- $multiSchema := false -}}
-                            {{- if gt (len .) 1 -}}
-                              {{- $multiSchema = true -}}
-                            {{- end -}}
-                            <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
-                              <summary class="{{ $responseColorTxt }}" aria-label="Disclose response {{$response}} {{$description}} details">
-                                <span
-                                data-mybicon="mybicon-arrow-right"
-                                data-mybicon-width="16"
-                                data-mybicon-height="16"
-                                ></span>
-                                <span class="fw600">{{ $response }}</span> {{ $description }}
-                              </summary>
-                              <div class="bg-gray1 pam">
-                                <h4>Schema</h4>
-                                {{- if $multiSchema -}}
-                                  <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Media type:</label>
-                                  <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
-                                    {{- range $applicationType, $_ := . -}}
-                                      {{- $typeClean := lower (anchorize $applicationType) -}}
-                                      <option value='{{$typeClean}}'>
-                                        {{ $applicationType }}
-                                      </option>
-                                    {{- end -}}
-                                  </select>
-                                {{- else -}}
-                                  {{- range $applicationType, $_ := . -}}
-                                    <p>Media type: {{ $applicationType }}</p>
-                                  {{- end -}}
-                                {{- end -}}
-
-                                {{- range $application, $_ := . -}}
-                                  {{- $format := "" -}}
-                                  {{- $typeClean := "" -}}
-                                  {{- if or (in $application "json") (in $application "javascript") -}}
-                                    {{- $format = printf "json" -}}
-                                    {{- $typeClean = lower (anchorize $application) -}}
-                                  {{- else if in $application "xml" -}}
-                                    {{- $format = printf "xml" -}}
-                                    {{- $typeClean = lower (anchorize $application) -}}
-                                  {{- end -}}
-
-                                  <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{$typeClean}}">
-                                    {{- if eq "xml" $format -}}
-                                      {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
-                                    {{- else -}}
-                                      {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
-                                    {{- end -}}
-                                  </dl>
-                                {{- end -}}
-                                </div>
-                              </details>
-                            {{- end -}}
-                          {{- else -}}
-                            <div class="{{ $responseColorBg }} {{ $responseColorTxt }} response mbxs"><span class="fw600">{{ $response }}</span> {{ $description }}</div>
+                        {{- if $hasSchema -}}
+                          {{- with .content -}}
+                          {{- $multiSchema := false -}}
+                          {{- if gt (len .) 1 -}}
+                            {{- $multiSchema = true -}}
                           {{- end -}}
+                          <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
+                            <summary class="{{ $responseColorTxt }}" aria-label="Disclose response {{$response}} {{$description}} details">
+                              <span
+                              data-mybicon="mybicon-arrow-right"
+                              data-mybicon-width="16"
+                              data-mybicon-height="16"
+                              ></span>
+                              <span class="fw600">{{ $response }}</span> {{ $description }}
+                            </summary>
+                            <div class="bg-gray1 pam">
+                              <h4>Schema</h4>
+                              {{- if $multiSchema -}}
+                                <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Media type:</label>
+                                <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
+                                  {{- range $applicationType, $_ := . -}}
+                                    {{- $typeClean := lower (anchorize $applicationType) -}}
+                                    <option value='{{$typeClean}}'>
+                                      {{ $applicationType }}
+                                    </option>
+                                  {{- end -}}
+                                </select>
+                              {{- else -}}
+                                {{- range $applicationType, $_ := . -}}
+                                  <p>Media type: {{ $applicationType }}</p>
+                                {{- end -}}
+                              {{- end -}}
+
+                              {{- range $application, $_ := . -}}
+                                {{- $format := "" -}}
+                                {{- $typeClean := "" -}}
+                                {{- if or (in $application "json") (in $application "javascript") -}}
+                                  {{- $format = printf "json" -}}
+                                  {{- $typeClean = lower (anchorize $application) -}}
+                                {{- else if in $application "xml" -}}
+                                  {{- $format = printf "xml" -}}
+                                  {{- $typeClean = lower (anchorize $application) -}}
+                                {{- end -}}
+
+                                <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{$typeClean}}">
+                                  {{- if eq "xml" $format -}}
+                                    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                                  {{- else -}}
+                                    {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                                  {{- end -}}
+                                </dl>
+                              {{- end -}}
+                              </div>
+                            </details>
+                          {{- end -}}
+                        {{- else -}}
+                          <div class="{{ $responseColorBg }} {{ $responseColorTxt }} response mbxs"><span class="fw600">{{ $response }}</span> {{ $description }}</div>
                         {{- end -}}
                       {{- end -}}
-                    </div>
-                    <div class="example-area">
-                      {{- if .requestBody -}}
-                        {{- partial "api/oas/requestexample.html" (dict "requestBody" .requestBody "endpointId" $endpointId) -}}
-                      {{- end -}}
-                      {{- if $components.examples -}}
-                        {{- partial "api/oas/responseexample-components.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}
-                      {{- else -}}
-                        {{- partial "api/oas/responseexample.html" (dict "responses" .responses "endpointId" $endpointId) -}}
-                      {{- end -}}
-                    </div>
+                    {{- end -}}
                   </div>
-                  {{- end -}}
-              {{- end -}}
+                  <div class="example-area">
+                    {{- if .requestBody -}}
+                      {{- partial "api/oas/requestexample.html" (dict "requestBody" .requestBody "endpointId" $endpointId) -}}
+                    {{- end -}}
+                    {{- if $components.examples -}}
+                      {{- partial "api/oas/responseexample-components.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}
+                    {{- else -}}
+                      {{- partial "api/oas/responseexample.html" (dict "responses" .responses "endpointId" $endpointId) -}}
+                    {{- end -}}
+                  </div>
+                </div>
+                {{- end -}}
             {{- end -}}
-          </section>
-          {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
-            <section id="api-support" class="dev-docscontent__section maxw64r">
-              {{- template "_internal/disqus.html" $ -}}
-            </section>
           {{- end -}}
-        </article>
-      </main>
-    {{- else -}}
-      {{- partial "api/docs.html" . -}}
-    {{- end -}}
-    {{- partial "footer.html" . -}}
-    <div class="dev-obfuscator" data-drawer data-drawer-event></div>
-  </div>
+        </section>
+        {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
+          <section id="api-support" class="dev-docscontent__section maxw64r">
+            {{- template "_internal/disqus.html" $ -}}
+          </section>
+        {{- end -}}
+      </article>
+    </main>
+  {{- else -}}
+    {{- partial "api/docs.html" . -}}
+  {{- end -}}
 {{- end -}}

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,17 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
   {{ partial "head.html" . }}
-    <body class="dev-docslayout">
-      {{ partial "header.html" . }}
-      <div class="dev-docs__menu" data-drawer data-drawer-event>
-        {{- partial "sidemenu.html" . -}}
-      </div>
-      {{- partial "drawmenu.html" . -}}
-      <div class="dev-docs__page">
-        {{ block "main" . }} {{ end }}
-        <div class="dev-obfuscator" data-drawer data-drawer-event></div>
-        {{ partial "footer.html" . }}
-      </div>
-      {{- partial "scripts.html" . -}}
-    </body>
+  <body class="dev-docslayout">
+    {{ partial "header.html" . }}
+    <div class="dev-docs__menu" data-drawer data-drawer-event>
+      {{- partial "sidemenu.html" . -}}
+    </div>
+    {{- partial "drawmenu.html" . -}}
+    <div class="dev-docs__page">
+      {{ block "main" . }} {{ end }}
+      <div class="dev-obfuscator" data-drawer data-drawer-event></div>
+      {{ partial "footer.html" . }}
+    </div>
+    {{- partial "scripts.html" . -}}
+  </body>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,18 +1,17 @@
 <!DOCTYPE html>
 <html lang="en">
   {{ partial "head.html" . }}
-  {{- if (or (in .Section "api" ) (in .Section "edi")) -}}
     <body class="dev-docslayout">
       {{ partial "header.html" . }}
-      {{ block "main" . }} {{ end }}
+      <div class="dev-docs__menu" data-drawer data-drawer-event>
+        {{- partial "sidemenu.html" . -}}
+      </div>
+      {{- partial "drawmenu.html" . -}}
+      <div class="dev-docs__page">
+        {{ block "main" . }} {{ end }}
+        <div class="dev-obfuscator" data-drawer data-drawer-event></div>
+        {{ partial "footer.html" . }}
+      </div>
       {{- partial "scripts.html" . -}}
     </body>
-  {{- else -}}
-    <body class="dev-pagelayout">
-      {{ partial "header.html" . }}
-      {{ block "main" . }} {{ end }}
-      {{ partial "footer.html" . }}
-      {{- partial "scripts.html" . -}}
-    </body>
-  {{- end -}}
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,17 +1,26 @@
 <!DOCTYPE html>
 <html lang="en">
   {{ partial "head.html" . }}
-  <body class="dev-docslayout">
-    {{ partial "header.html" . }}
-    <div class="dev-docs__menu" data-drawer data-drawer-event>
-      {{- partial "sidemenu.html" . -}}
-    </div>
-    {{- partial "drawmenu.html" . -}}
-    <div class="dev-docs__page">
+  {{- if (or (.IsHome) (in .Section "api" ) (in .Section "edi")) -}}
+    <body class="dev-docslayout">
+      {{ partial "header.html" . }}
+      <div class="dev-docs__menu" data-drawer data-drawer-event>
+        {{- partial "sidemenu.html" . -}}
+      </div>
+      {{- partial "drawmenu.html" . -}}
+      <div class="dev-docs__page">
+        {{ block "main" . }} {{ end }}
+        <div class="dev-obfuscator" data-drawer data-drawer-event></div>
+        {{ partial "footer.html" . }}
+      </div>
+      {{- partial "scripts.html" . -}}
+    </body>
+  {{- else -}}
+    <body class="dev-pagelayout">
+      {{ partial "header.html" . }}
       {{ block "main" . }} {{ end }}
-      <div class="dev-obfuscator" data-drawer data-drawer-event></div>
       {{ partial "footer.html" . }}
-    </div>
-    {{- partial "scripts.html" . -}}
-  </body>
+      {{- partial "scripts.html" . -}}
+    </body>
+  {{- end -}}
 </html>

--- a/layouts/_default/edi.html
+++ b/layouts/_default/edi.html
@@ -1,22 +1,12 @@
 {{- define "main" -}}
-
-  <div class="dev-docs__menu" data-drawer>
-    {{- partial "sidemenu.html" . -}}
-  </div>
-  {{- partial "drawmenu.html" . -}}
-  <div class="dev-docs__page">
-    <main id="main">
-      <article class="dev-docscontent maxw64r">
-        {{ .Content }}
-        {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
-          <section class="dev-docscontent__section">
-            {{ template "_internal/disqus.html" $ }}
-          </section>
-        {{- end -}}
-      </article>
-    </main>
-    {{ partial "footer.html" . }}
-    <div class="dev-obfuscator" data-drawer data-drawer-event></div>
-  </div>
-
+  <main id="main">
+    <article class="dev-docscontent maxw64r">
+      {{ .Content }}
+      {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
+        <section class="dev-docscontent__section">
+          {{ template "_internal/disqus.html" $ }}
+        </section>
+      {{- end -}}
+    </article>
+  </main>
 {{- end -}}

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -3,12 +3,6 @@
 {{- if (eq ($.Param "widelayout") true) -}}
   {{- $maxwidth = "" -}}
 {{- end -}}
-
-<div class="dev-docs__menu" data-drawer data-drawer-event>
-  {{- partial "sidemenu.html" . -}}
-</div>
-{{- partial "drawmenu.html" . -}}
-<div class="dev-docs__page">
   <main id="main" class="dev-docscontent w100p {{ $maxwidth }}">
     <article>
       <h1>
@@ -33,7 +27,4 @@
       {{- end -}}
     </article>
   </main>
-  {{- partial "footer.html" . -}}
-  <div class="dev-obfuscator" data-drawer data-drawer-event></div>
-</div>
 {{- end -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -33,21 +33,25 @@
           {{- end -}}
           <div class="mbxl">
             <h2 class="mbs">API updates</h2>
-            {{- range where .Site.Pages "Section" "api" -}}
-              {{- if (in .CurrentSection "revision-history") -}}
-                {{- range first 3 .Pages -}}
-                  <h3 class="text-basic">
-                    <time
-                      datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
-                      >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
-                    >: {{ .Title }}
-                  </h3>
-                  {{ .Content }}
+            <div class="owls mbl rad-a2px">
+              {{- range where .Site.Pages "Section" "api" -}}
+                {{- if (in .CurrentSection "revision-history") -}}
+                  {{- range first 3 .Pages -}}
+                    <div class="bg-gray1 bshadow pal rad-a2px">
+                      <h3 class="text-basic">
+                        <time
+                          datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                          >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
+                        >: {{ .Title }}
+                      </h3>
+                      {{ .Content }}
+                    </div>
+                  {{- end -}}
                 {{- end -}}
               {{- end -}}
-            {{- end -}}
-            <div class="w100p mtm mbl">
-              <a class="text-heading" href="./api/revision-history/">Show all updates &RightArrow;</a>
+              <div class="w100p">
+                <a class="text-heading" href="./api/revision-history/">Show all updates &RightArrow;</a>
+              </div>
             </div>
             <div class="bg-gray2 pal rad-a2px">
               <h3>Subscribe to updates</h3>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="sitefooter">
-    <div class="sitefooter__terms">
+    <div class="sitefooter__terms pvs">
       <span class="mrm"
         >&copy;
         <script type="text/javascript">
@@ -7,16 +7,14 @@
         </script>
         Posten Norge AS
       </span>
-      <a class="mrm" href="http://www.bring.com/privacy-policy"
-        >Privacy policy</a
-      >
-      <a class="mrm" href="http://www.bring.com/use-of-cookies">Cookies</a>
-      <p class="mrm mb0">Download&nbsp;
-        <a href="{{ "/General_Terms_and_Conditions_for_Self_Service_Solutions.pdf" | relURL }}">
+      <div>
+        <a class="mrm" href="http://www.bring.com/privacy-policy">Privacy policy</a>
+        <a class="mrm" href="http://www.bring.com/use-of-cookies">Cookies</a>
+        <a class="mrm" href="{{ "/General_Terms_and_Conditions_for_Self_Service_Solutions.pdf" | relURL }}">
           General Terms and Conditions for Self Service Solutions
         </a>
-      </p>
-      <a href="{{ "/subcontractors/" | relURL }}">Subcontractors</a>
+        <a href="{{ "/subcontractors/" | relURL }}">Subcontractors</a>
+      </div>
     </div>
 </footer>
 <script defer src="https://www.mybring.com/design-system/js/iconsystem-vanilla.js?ts={{ now.Unix }}"></script>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,68 +1,4 @@
-{{- $footClass := "" -}}
-{{- if (and (not (in .Section "api")) (not (in .Section "edi"))) -}}
-  {{- $footClass = "dev-container" -}}
-{{- end -}}
 <footer class="sitefooter">
-  <div class="{{ $footClass }}">
-    {{- if (and (not (in .Section "api")) (not (in .Section "edi"))) -}}
-      <div class="sitefooter__wrapper">
-        <a
-          class="sitefooter__logo"
-          href="https://bring.no/"
-          rel="noopener"
-          title="Bring"
-          aria-label="bring.no"
-        >
-          <svg
-            xmlns="http://www.w3.org/2000/svg"
-            width="150"
-            height="60"
-            viewBox="0 0 500 200"
-          >
-            <path
-              fill="#7bc144"
-              d="M41.2 95.2C42.6 77 57.9 62.6 76.5 62.6s33.9 14.4 35.3 32.6H177c-1.5-37.8-32.6-68-70.8-68-38.2 0-69.3 30.2-70.8 68h5.8z"
-            ></path>
-            <path
-              fill="#c1c1c1"
-              d="M111.8 100.8c-1.4 18.2-16.7 32.6-35.3 32.6S42.6 119 41.2 100.8h-5.7c1.5 37.8 32.6 68 70.8 68 38.2 0 69.3-30.2 70.8-68h-65.3z"
-            ></path>
-            <path
-              fill="#7bc144"
-              d="M228.3 99.7c-6.8 0-14.2.8-18.9 5.6V80.7h-14.5v82.5h13v-5c3.8 3.5 9.7 6 18 6 24.9 0 26.6-16.9 26.6-32.1.1-18.9-2.9-32.4-24.2-32.4zm-3.2 51.5c-12.4 0-16-3.5-16-19.1 0-15.6 3.6-19.1 16-19.1 10.7 0 13 4.5 13 19.1 0 14.6-2.3 19.1-13 19.1zm64.7-51.5c-7.3 0-13.1 2.3-17.1 6.7v-5.6h-12.5v62.4h14.5v-27.1c0-4.9-.3-11.8 1.4-16.2 1.5-4.2 5.2-7.4 11.3-7.4 6 0 8.4 1.3 8.4 7H310c0-13.7-6.8-19.8-20.2-19.8zm81.5 0c-8.8 0-14.5 2.8-18 6v-4.9h-12.5v62.4h14.5v-29c0-10.9-1.1-21.6 14.5-21.6 12.5 0 11.4 5.8 11.4 17.8v32.9h14.5v-34c-.2-13.7.8-29.6-24.4-29.6zm76.3 1.1v4.9c-4.9-4.3-12.8-6-19.4-6-21.5 0-24.9 12.9-24.9 31.9 0 15 1.4 31.6 25.1 31.6 6 0 13.4-1.4 17.9-5.5 0 3.2.1 7.7-.3 10.9-.8 5.9-6.8 8.4-15.1 8.4-8.1 0-10.6-2.3-10.6-6.8h-15.7c0 15.9 14.2 19 26.7 19 11.5 0 26.6-3.1 28.9-17.9.5-3.5.5-9.1.5-14.9v-55.7h-13.1v.1zm-17 49.3c-10.7 0-12.9-4-12.9-18.6s2.2-19.1 12.9-19.1c12.4 0 15.7 3.5 15.7 19.1 0 15.7-3.3 18.6-15.7 18.6zm-113.7 13.1h14.5v-62.4h-14.5v62.4zm0-68h14.5V80.7h-14.5v14.5z"
-            ></path>
-          </svg>
-        </a>
-        <div class="sitefooter__nav">
-          <a class="mbxs" href="{{ "/" | relURL }}">Bring Developer</a>
-          <a class="mbxs" href="{{ "/api/" | relURL }}">API docs</a>
-          <a class="mbxs" href="{{ "/edi/" | relURL }}">EDI docs</a>
-        </div>
-        <div class="sitefooter__nav">
-          <a
-            class="mbxs"
-            href="{{ "/blog/" | relURL }}"
-            title="Bring Developer Blog"
-            >Blog</a
-          >
-          <a class="mbxs" href="{{ "/jobs/" | relURL }}">Jobs</a>
-          <a
-            class="mbxs"
-            href="https://github.com/bring/developer-site"
-            title="The source code for this site"
-            >GitHub</a
-          >
-        </div>
-        <div>
-          <p class="mbxs">Download&nbsp;
-            <a href="{{ "/General_Terms_and_Conditions_for_Self_Service_Solutions.pdf" | relURL }}">
-              General Terms and Conditions for Self Service Solutions
-            </a>
-          </p>
-          <a href="{{ "/subcontractors/" | relURL }}">Subcontractors</a>
-        </div>
-      </div>
-    {{- end -}}
     <div class="sitefooter__terms">
       <span class="mrm"
         >&copy;
@@ -74,8 +10,13 @@
       <a class="mrm" href="http://www.bring.com/privacy-policy"
         >Privacy policy</a
       >
-      <a href="http://www.bring.com/use-of-cookies">Cookies</a>
+      <a class="mrm" href="http://www.bring.com/use-of-cookies">Cookies</a>
+      <p class="mrm mb0">Download&nbsp;
+        <a href="{{ "/General_Terms_and_Conditions_for_Self_Service_Solutions.pdf" | relURL }}">
+          General Terms and Conditions for Self Service Solutions
+        </a>
+      </p>
+      <a href="{{ "/subcontractors/" | relURL }}">Subcontractors</a>
     </div>
-  </div>
 </footer>
 <script defer src="https://www.mybring.com/design-system/js/iconsystem-vanilla.js?ts={{ now.Unix }}"></script>

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -1,7 +1,7 @@
 {{- $currentPage := . -}}
 
 <nav class="dev-sidemenu" aria-label="Section">
-  {{- if or (eq .Section "api") (eq .Section "") -}}
+  {{- if or (eq .Section "api") (eq .Section "subcontractors") (eq .Section "") -}}
     <ul class="dev-sidemenu__list">
       {{- $len := (len .Site.Menus.api) -}}
       {{- range $index, $element := .Site.Menus.api -}}

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -1,7 +1,7 @@
 {{- $currentPage := . -}}
 
 <nav class="dev-sidemenu" aria-label="Section">
-  {{- if or (eq .Section "api") (eq .Section "subcontractors") (eq .Section "") -}}
+  {{- if or (eq .Section "api") (.IsHome) -}}
     <ul class="dev-sidemenu__list">
       {{- $len := (len .Site.Menus.api) -}}
       {{- range $index, $element := .Site.Menus.api -}}

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -1,7 +1,7 @@
 {{- $currentPage := . -}}
 
 <nav class="dev-sidemenu" aria-label="Section">
-  {{- if eq .Section "api" -}}
+  {{- if or (eq .Section "api") (eq .Section "") -}}
     <ul class="dev-sidemenu__list">
       {{- $len := (len .Site.Menus.api) -}}
       {{- range $index, $element := .Site.Menus.api -}}

--- a/static/svg/systems.svg
+++ b/static/svg/systems.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1200 400" class="mbm maxw44r" height="234">
+<svg xmlns="http://www.w3.org/2000/svg" viewbox="0 0 1200 400" class="mbm w100p" height="234">
   <rect fill="#EEE" width="1200" height="390"/>
 
   <g id="systems">


### PR DESCRIPTION
We are improving the home page of the developer site with this PR. The changes that are done here will help visitors find the proper documentation right away, without having to go via a button - "Get started". The menu is available right away on the home page for new and existing visitors.

The changes done are mainly:
- Add the left menu to the home page.
- Disable links on the API descriptive cards, and rather focus on and describe the different API "sections".
- Add a small facelift to the "API updates" entries in the right column

The texts describing the different API sections need some adjustments, and further there will be changes done to a new Checkout area. EDI documentation will also be changed, but I'm not touching those in this PR.

![Skjermbilde 2022-10-24 kl  13 42 24](https://user-images.githubusercontent.com/65193388/197517898-a43586e1-976d-422a-a5e0-43f858fdfcaf.png)