### PR TITLE
Warehousing-related template adjustments

### DIFF
--- a/content/api/warehousing/index.html
+++ b/content/api/warehousing/index.html
@@ -10,6 +10,9 @@ menu:
     parent: warehouse
 weight: 1
 
+introduction:
+  The Warehousing API is used to submit order and article information to Bring’s warehouses. Users are also able to extract/subscribe for detailed order information from our warehouses while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.
+
 information:
   - title: Authentication
     content: |
@@ -20,10 +23,6 @@ information:
       REST XML/JSON over HTTPS. This API doesn't support JSON for all methods yet. Look in the example section to see which are supported.
 
 documentation:
-  - title: Introduction
-    content: |
-      The Warehousing API is used to submit order and article information to Bring’s warehouses. Users are also able to extract/subscribe for detailed order information from our warehouses while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.
-
   - title: Endpoints
     content: |
 

--- a/content/api/warehousing/index.html
+++ b/content/api/warehousing/index.html
@@ -32,12 +32,19 @@ documentation:
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
       </head>
       <body>
-      <table class="codeBox"><tr><td><a href="https://bapi.bring.com/wh/api/v1">https://bapi.bring.com/wh/api/v1</a></td></tr></table>
-        <table>
-          <tr><th>Usage</th><th>Method</th><th>Endpoint</th></tr>
-          <tr><td><a href="#send-an-order">Send an Order</a></td><td>POST</td><td>/order</td></tr>
-          <tr><td><a href="#post-item-data">Post item data</a></td><td>POST</td><td>/itemdata</td></tr>
-          <tr><td><a href="#list-error-codes">List error codes</a></td><td>GET</td><td>/errorCodes</td></tr>
+        <div class="flex align-ifs mbl mts">
+          <span class="mb-badge text-note mrxs pas">Base URL</span>
+          <span class="flex-auto maxw40r">
+            <pre class="flex align-ic pas mb0 wrap-text"><span>https://bapi.bring.com/wh/api/v1</span></pre>
+          </span>
+        </div>
+        <table class="mb-table">
+          <thead><tr><th>Usage</th><th>Method</th><th>Endpoint</th></tr></thead>
+          <tbody>
+            <tr><td><a href="#send-an-order">Send an Order</a></td><td>POST</td><td>/order</td></tr>
+            <tr><td><a href="#post-item-data">Post item data</a></td><td>POST</td><td>/itemdata</td></tr>
+            <tr><td><a href="#list-error-codes">List error codes</a></td><td>GET</td><td>/errorCodes</td></tr>
+          </tbody>
         </table>
 
   - title: Send an Order
@@ -46,12 +53,18 @@ documentation:
         <p>This endpoint is used to submit orders to Bring Warehousing. There are two different types of order you can submit.</p>
         <p>&bull; Order / SalesOrder<br>&bull; PurchaseOrder<br></p>
         <p>To send information to Bring, the following base endpoint URL must be used:</p>
-        <table class="codeBox"><tr><td class="dark">POST</td><td>https://bapi.bring.com/wh/api/v1/order</td></tr></table>
+        <div class="flex align-ifs mbl mts"><span class="mb-badge mb-badge--blue text-note ttu mrxs pas">post</span>
+          <span class="flex-auto">
+            <pre class="flex align-ic pas mb0 wrap-text">
+              <span>https://bapi.bring.com/wh/api/v1/order</span>
+            </pre>
+          </span>
+        </div>
         <h3>Request parameters</h3>
-        <table>
+        <table class="mb-table">
           <tr><th>HTTP header</th><th>Type</th><th>Description</th></tr>
-          <tr><td>Accept</td><td>string</td><td><span class="req">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
-          <tr><td>Content-Type</td><td>string</td><td><span class="req">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
+          <tr><td>Accept</td><td>string</td><td><span class="mb-badge mb-badge--red">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
+          <tr><td>Content-Type</td><td>string</td><td><span class="mb-badge mb-badge--red">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
         </table>
         <h3>Request body</h3>
         <table>
@@ -65,9 +78,9 @@ documentation:
         </div>
         <button onclick="expandCollapseAll('createOrder1',true)">Expand all</button><button onclick="expandCollapseAll('createOrder1',false)">Collapse all</button>
         <ul id="createOrder1" class="maketree">
-          <li class="last"><a href="#createOrder1" onclick="compactMenu('createOrder1',true,'&plusmn; ')"></a><span class="name">CreateOrderRequest</span><span class="type">object</span><span class="req">Required</span><span class="desc">Create Order Request</span>
+          <li class="last"><a href="#createOrder1" onclick="compactMenu('createOrder1',true,'&plusmn; ')"></a><span class="name">CreateOrderRequest</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Create Order Request</span>
             <ul>
-              <li><a href="#createOrder1"></a><span class="name">version</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Version of Request.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">version</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Version of Request.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -76,7 +89,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">definedBy</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Defined By.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">definedBy</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Defined By.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -85,7 +98,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">domain</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Domain.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">domain</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Domain.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -94,7 +107,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">collaboration</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Collaboration.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">collaboration</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Collaboration.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -103,7 +116,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">messageFunction</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Type of order.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">messageFunction</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Type of order.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -112,7 +125,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">profile</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Profile.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">profile</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Profile.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -121,7 +134,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">messageId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Unique id for this message.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">messageId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Unique id for this message.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -130,7 +143,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Update Indicator.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Update Indicator.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -139,7 +152,7 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">testIndicator</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Whether this is a test message.</span><br>
+              <li><a href="#createOrder1"></a><span class="name">testIndicator</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Whether this is a test message.</span><br>
                 <ul>
                   <li class="last">
                     <table>
@@ -148,9 +161,9 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li><a href="#createOrder1"></a><span class="name">MessageDetails</span><span class="type">object</span><span class="req">Required</span><span class="desc">Message Details</span><br>
+              <li><a href="#createOrder1"></a><span class="name">MessageDetails</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Message Details</span><br>
                 <ul>
-                  <li><a href="#createOrder1"></a><span class="name">MessageDate</span><span class="type">datetime</span><span class="req">Required</span><span class="desc">The date on which the message was sent.</span><br>
+                  <li><a href="#createOrder1"></a><span class="name">MessageDate</span><span class="type">datetime</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">The date on which the message was sent.</span><br>
                     <ul>
                       <li class="last">
                         <table>
@@ -159,9 +172,9 @@ documentation:
                       </li>
                     </ul>
                   </li>
-                  <li><a href="#createOrder1"></a><span class="name">MessageRecipient</span><span class="type">object</span><span class="req">Required</span><span class="desc">Message Recipient</span><br>
+                  <li><a href="#createOrder1"></a><span class="name">MessageRecipient</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Message Recipient</span><br>
                     <ul>
-                      <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
+                      <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
                         <ul>
                           <li class="last">
                             <table>
@@ -170,7 +183,7 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">partyId type.</span><br>
+                      <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">partyId type.</span><br>
                         <ul>
                           <li class="last">
                             <table>
@@ -181,9 +194,9 @@ documentation:
                       </li>
                     </ul>
                   </li>
-                  <li class="last"><a href="#createOrder1"></a><span class="name">MessageSender</span><span class="type">object</span><span class="req">Required</span><span class="desc">Message Sender</span>
+                  <li class="last"><a href="#createOrder1"></a><span class="name">MessageSender</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Message Sender</span>
                     <ul>
-                      <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
+                      <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
                         <ul>
                           <li class="last">
                             <table>
@@ -192,7 +205,7 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">partyId type.</span><br>
+                      <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">partyId type.</span><br>
                         <ul>
                           <li class="last">
                             <table>
@@ -205,11 +218,11 @@ documentation:
                   </li>
                 </ul>
               </li>
-              <li class="last"><a href="#createOrder1"></a><span class="name">SupplyStructure</span><span class="type">object</span><span class="req">Required</span><span class="desc">Supply Structure</span>
+              <li class="last"><a href="#createOrder1"></a><span class="name">SupplyStructure</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Supply Structure</span>
                 <ul>
-                  <li class="last"><a href="#createOrder1"></a><span class="name">ORDERSET</span><span class="type">object</span><span class="req">Required</span><span class="desc">Order Set</span>
+                  <li class="last"><a href="#createOrder1"></a><span class="name">ORDERSET</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Order Set</span>
                     <ul>
-                      <li><a href="#createOrder1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Update Indicator.</span><br>
+                      <li><a href="#createOrder1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Update Indicator.</span><br>
                         <ul>
                           <li class="last">
                             <table>
@@ -218,9 +231,9 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li><a href="#createOrder1"></a><span class="name">ORDER</span><span class="type">object</span><span class="req">Required</span><span class="desc">Order</span>
+                      <li><a href="#createOrder1"></a><span class="name">ORDER</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Order</span>
                         <ul>
-                          <li><a href="#createOrder1"></a><span class="name">orderId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Unique ID for this order.</span><br>
+                          <li><a href="#createOrder1"></a><span class="name">orderId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Unique ID for this order.</span><br>
                             <ul>
                               <li class="last">
                                 <table>
@@ -229,7 +242,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">ExternalOrderType</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Type of Order.</span><br>
+                          <li><a href="#createOrder1"></a><span class="name">ExternalOrderType</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Type of Order.</span><br>
                             <ul>
                               <li class="last">
                                 <table>
@@ -238,7 +251,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                         <li><a href="#createOrder1"></a><span class="name">Reference</span><span class="type">array</span><span class="req">Required</span><span class="desc">Order Reference.</span>
+                         <li><a href="#createOrder1"></a><span class="name">Reference</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Order Reference.</span>
                             <ul>
                               <li>
                                 <table>
@@ -247,24 +260,24 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">referenceType</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Type of reference used in order</td></tr>
+                                  <tr class="trwh"><td class="name">referenceType</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Type of reference used in order</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Reference Number</td></tr>
+                                  <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Reference Number</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="req">Required</span><span class="desc">Date and time of the order.</span>
+                          <li><a href="#createOrder1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Date and time of the order.</span>
                             <ul>
                               <li>
                                 <table>
                                   <tr><td class="descParent">There are many different options for date and time, but the most frequently used subClasses are&#58;<br>&bull;<b>DocumentDate</b> The date on which the order is booked.<br>&bull;<b>DeliveryDateRequested</b> The date on which the order is requested to be delivered<br>&bull;<b>ExpirationDate</b><br><br>Example&#58;<br>&lt;DateAndTimes subClass=&quot;DocumentDate&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Date&gt;2021-02-12&lt;/Date&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Time&gt;13:29:45&lt;/Time&gt;<br>&lt;/DateAndTimes&gt;<br><br>&lt;DateAndTimes subClass=&quot;DeliveryDateRequested&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Date&gt;2021-02-15&lt;/Date&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Time&gt;00:00:00&lt;/Time&gt;<br>&lt;/DateAndTimes&gt;</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">subClass.</span><br>
+                              <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">subClass.</span><br>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -275,24 +288,24 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Date.</td></tr>
+                                  <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Date.</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Time.</td></tr>
+                                  <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Time.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">TermsOfDelivery</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Terms of Delivery</span>
+                          <li><a href="#createOrder1"></a><span class="name">TermsOfDelivery</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Terms of Delivery</span>
                             <ul>
                               <li>
                                 <table>
                                   <tr><td class="descParent">The regulations are used to clarify the distribution of obligations between seller and buyer when shipping goods / Incoterms<br><br>Example&#58;<br>&lt;TermsOfDelivery&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;TODConditionCode&gt;DDP&lt;/TODConditionCode&gt;<br>&lt;/TermsOfDelivery&gt;</td></tr>
                                 </table>
                               </li>
-                              <li class="last"><a href="#createOrder1"></a><span class="name">TODConditionCode</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Terms of Delivery Condition Code.</span><br>
+                              <li class="last"><a href="#createOrder1"></a><span class="name">TODConditionCode</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Terms of Delivery Condition Code.</span><br>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -303,7 +316,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">FreeText</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Reference on an order.</span>
+                          <li><a href="#createOrder1"></a><span class="name">FreeText</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Reference on an order.</span>
                             <ul>
                               <li>
                                 <table>
@@ -312,62 +325,62 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">usage Code.</td></tr>
+                                  <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">usage Code.</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">FreeText text.</td></tr>
+                                  <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">FreeText text.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">COD</span><span class="type">array</span><span class="req">Optional</span><span class="desc">If goods are to be paid on delivery.</span>
+                          <li><a href="#createOrder1"></a><span class="name">COD</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">If goods are to be paid on delivery.</span>
                             <ul>
                               <li>
                                 <table>
                                   <tr><td class="descParent"><br><br>Example&#58;<br>&lt;COD&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;AccountNo idType=&quot;idType_0&quot;&gt;AccountNo_0&lt;/AccountNo&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;CodAmount&gt;10&lt;/CodAmount&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;ControlDigit&gt;10&lt;/ControlDigit&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Kid&gt;Kid_0&lt;/Kid&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Message&gt;Message_0&lt;/Message&gt;<br>&lt;/COD&gt;</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">AccountNo</span><span class="type">Object</span><span class="req">Optional</span><span class="desc">Account No.</span>
+                              <li><a href="#createOrder1"></a><span class="name">AccountNo</span><span class="type">Object</span><span class="mb-badge">Optional</span><span class="desc">Account No.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">idType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">ID Type.</td></tr>
+                                      <tr class="trwh"><td class="name">idType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">ID Type.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">CODAmount</td><td class="type">Number (float)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">COD Amount</td></tr>
+                                  <tr class="trwh"><td class="name">CODAmount</td><td class="type">Number (float)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">COD Amount</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">ControlDigit</td><td class="type">Number (int)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Control Digit</td></tr>
+                                  <tr class="trwh"><td class="name">ControlDigit</td><td class="type">Number (int)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Control Digit</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">Kid</td><td class="type">String</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Kid</td></tr>
+                                  <tr class="trwh"><td class="name">Kid</td><td class="type">String</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Kid</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">Message</td><td class="type">String</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Message</td></tr>
+                                  <tr class="trwh"><td class="name">Message</td><td class="type">String</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Message</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">TermsOfPayment</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Payment for the order.</span>
+                          <li><a href="#createOrder1"></a><span class="name">TermsOfPayment</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Payment for the order.</span>
                             <ul>
                               <li>
                                 <table>
                                   <tr><td class="descParent"><br>Example&#58;<br>&lt;TermsOfPayment otherDesc=&quot;Vipps&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;TOPConditionCode&gt;Vipps&lt;/TOPConditionCode&gt;<br>&lt; /TermsOfPayment&gt;</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">otherDesc</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Other Description.</span>
+                              <li><a href="#createOrder1"></a><span class="name">otherDesc</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Other Description.</span>
                                 <ul>
                                   <li>
                                     <table>
@@ -376,7 +389,7 @@ documentation:
                                   </li>
                                 </ul>
                               </li>
-                              <li class="last"><a href="#createOrder1"></a><span class="name">TOPConditionCode</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Condition Code.</span>
+                              <li class="last"><a href="#createOrder1"></a><span class="name">TOPConditionCode</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Condition Code.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -387,7 +400,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li class="last"><a href="#createOrder1"></a><span class="name">PriorityCode</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Priority Code.</span>
+                          <li class="last"><a href="#createOrder1"></a><span class="name">PriorityCode</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Priority Code.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -398,14 +411,14 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li><a href="#createOrder1"></a><span class="name">TransportService</span><span class="type">object</span><span class="req">Required</span><span class="desc">Transport service for shipment to customer.</span>
+                      <li><a href="#createOrder1"></a><span class="name">TransportService</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Transport service for shipment to customer.</span>
                         <ul>
                           <li>
                             <table>
                               <tr><td class="descParent"><br>Example&#58;<br>&lt;TransportService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;BasicServiceCode&gt;Servicepakke&lt;/BasicServiceCode&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalServiceCode&gt;EVARSLING&lt;/AdditionalServiceCode&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;/AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalServiceCode&gt;PickUpPoint&lt;/AdditionalServiceCode&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;/AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;TariffReference&gt;TariffReference_0&lt;/TariffReference&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;NatureOfCargo&gt;NatureOfCargo_0&lt;/NatureOfCargo&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Priority&gt;Priority_0&lt;/Priority&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Utility usageCode=&quot;&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;Value sequence=&quot;&quot; valueType=&quot;&quot; valueCode=&quot;&quot;&gt;Value_0&lt;/Value&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;/Utility&gt;<br>&lt;/TransportService&gt;</td></tr>
                             </table>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">BasicServiceCode</span><span class="type">string</span><span class="req">Required</span><span class="desc">Basic Service Code.</span>
+                          <li><a href="#createOrder1"></a><span class="name">BasicServiceCode</span><span class="type">string</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Basic Service Code.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -414,14 +427,14 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">AdditionalService</span><span class="type">array</span><span class="req">Required</span><span class="desc">Additional Service.</span>
+                          <li><a href="#createOrder1"></a><span class="name">AdditionalService</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Additional Service.</span>
                             <ul>
                               <li>
                                 <table>
                                   <tr><td class="descParent"><br>If Recipient notification is over SMS or E-Mail, a value must be added for either email and/or cellphone number within Contact in Party [subClass=&quot;Buyer&quot;]<br><br>You will find information on all outgoing Services for Posten Norge and Bring <a href=&quot;https://developer.bring.com/api/services/&quot;>here</a><br><br>And more information about PickUpPoint (PuP) <a href=&quot;https://developer.bring.com/api/pickup-point/&quot;>here</a>.<br><br>Example&#58;<br>&lt;AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalServiceCode&gt;EVARSLING&lt;/AdditionalServiceCode&gt;<br>&lt;/AdditionalService&gt;<br>&lt;AdditionalService&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;AdditionalServiceCode&gt;PickUpPoint&lt;/AdditionalServiceCode&gt;<br>&lt;/AdditionalService&gt;</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">PriorityCode</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Priority Code.</span>
+                              <li><a href="#createOrder1"></a><span class="name">PriorityCode</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Priority Code.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -432,48 +445,48 @@ documentation:
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">AdditionalServiceCode</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Additional Service Code.</td></tr>
+                                  <tr class="trwh"><td class="name">AdditionalServiceCode</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Additional Service Code.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
                           <li>
                             <table>
-                              <tr class="trwh"><td class="name">TariffReference</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Tariff Reference.</td></tr>
+                              <tr class="trwh"><td class="name">TariffReference</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Tariff Reference.</td></tr>
                             </table>
                           </li>
                           <li>
                             <table>
-                              <tr class="trwh"><td class="name">NatureOfCargo</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Nature of Cargo.</td></tr>
+                              <tr class="trwh"><td class="name">NatureOfCargo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Nature of Cargo.</td></tr>
                             </table>
                           </li>
                           <li>
                             <table>
-                              <tr class="trwh"><td class="name">Priority</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Nature of Cargo.</td></tr>
+                              <tr class="trwh"><td class="name">Priority</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Nature of Cargo.</td></tr>
                             </table>
                           </li>
-                          <li class="last"><a href="#createOrder1"></a><span class="name">Utility</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Utility</span>
+                          <li class="last"><a href="#createOrder1"></a><span class="name">Utility</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Utility</span>
                             <ul>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">usage Code.</td></tr>
+                                  <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">usage Code.</td></tr>
                                 </table>
                               </li>
-                              <li class="last"><a href="#createOrder1"></a><span class="name">Value</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Utility Value.</span>
+                              <li class="last"><a href="#createOrder1"></a><span class="name">Value</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Utility Value.</span>
                                 <ul>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Priority Code.</td></tr>
+                                      <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Priority Code.</td></tr>
                                     </table>
                                   </li>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">valueType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">value Type.</td></tr>
+                                      <tr class="trwh"><td class="name">valueType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">value Type.</td></tr>
                                     </table>
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Service Utility Value.</td></tr>
+                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Service Utility Value.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
@@ -549,14 +562,14 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li><a href="#createOrder1"></a><span class="name">Party</span><span class="type">object</span><span class="req">Required</span><span class="desc">Party</span>
+                      <li><a href="#createOrder1"></a><span class="name">Party</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Party</span>
                         <ul>
                           <li>
                             <table>
                               <tr><td class="descParent"><br>An order consists of several Parties&#59; a supplier, a sender, a receiver, etc.<br>The subClass code defines each type of party.<br>Must have Name, Street, City, CountryCode<br><br>Example&#58;<br>&lt;Party subClass=&quot;OrderingParty&quot; partyId=&quot;11223&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Name&gt;Testcompany&lt;/Name&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Address subClass=&quot;PhysicalAddress&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;PostalCode&gt;0123&lt;/PostalCode&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;City&gt;OSLO&lt;/City&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;CountryCode&gt;NO&lt;/CountryCode&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;Street&gt;Teststreet 2&lt;/Street&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;/Address&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Contact&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;CellPhoneNo&gt;99010100&lt;/CellPhoneNo&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;EMailAddress&gt;john.doe@posten.no&lt;/EMailAddress&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;ContactName&gt;John Doe&lt;/ContactName&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;/Contact&gt;<br>&lt;/Party&gt;</td></tr>
                             </table>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Defines the type of Party.</span>
+                          <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Defines the type of Party.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -565,7 +578,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Party id for the <b>subClass</b>.</span>
+                          <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Party id for the <b>subClass</b>.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -574,7 +587,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">subPartyId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">The value of the actual Pick up point site.</span>
+                          <li><a href="#createOrder1"></a><span class="name">subPartyId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">The value of the actual Pick up point site.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -583,7 +596,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">Name</span><span class="type">string</span><span class="req">Required</span><span class="desc">Name of the Supplier/Sender/Receiver.</span>
+                          <li><a href="#createOrder1"></a><span class="name">Name</span><span class="type">string</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Name of the Supplier/Sender/Receiver.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -592,7 +605,7 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li><a href="#createOrder1"></a><span class="name">Address</span><span class="type">object</span><span class="req">Required</span><span class="desc">Address of the Supplier/Sender/Receiver</span>
+                          <li><a href="#createOrder1"></a><span class="name">Address</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Address of the Supplier/Sender/Receiver</span>
                             <ul>
                               <li>
                                 <table>
@@ -601,32 +614,32 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">subClass</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">sub Class.</td></tr>
+                                  <tr class="trwh"><td class="name">subClass</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">sub Class.</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">PostalCode</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Postal Code.</td></tr>
+                                  <tr class="trwh"><td class="name">PostalCode</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Postal Code.</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">City</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">City.</td></tr>
+                                  <tr class="trwh"><td class="name">City</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">City.</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">Countycode</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Country Code.</td></tr>
+                                  <tr class="trwh"><td class="name">Countycode</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Country Code.</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">Street</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Street.</td></tr>
+                                  <tr class="trwh"><td class="name">Street</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Street.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li class="last"><a href="#createOrder1"></a><span class="name">Contact</span><span class="type">object</span><span class="req">Req/Opt</span><span class="desc">Contact.</span>
+                          <li class="last"><a href="#createOrder1"></a><span class="name">Contact</span><span class="type">object</span><span class="mb-badge mb-badge--red">Req/Opt</span><span class="desc">Contact.</span>
                             <ul>
                               <li>
                                 <table>
@@ -635,26 +648,26 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">CellPhoneNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Cell Phone Number.</td></tr>
+                                  <tr class="trwh"><td class="name">CellPhoneNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Cell Phone Number.</td></tr>
                                 </table>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">EMailAddress</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Email address.</td></tr>
+                                  <tr class="trwh"><td class="name">EMailAddress</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Email address.</td></tr>
                                 </table>
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">ContactName</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Contact Name.</td></tr>
+                                  <tr class="trwh"><td class="name">ContactName</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Contact Name.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
                         </ul>
                       </li>
-                      <li><a href="#createOrder1"></a><span class="name">OrderLineSet</span><span class="type">object</span><span class="req">Required</span><span class="desc">Order Line Set</span>
+                      <li><a href="#createOrder1"></a><span class="name">OrderLineSet</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Order Line Set</span>
                         <ul>
-                          <li><a href="#createOrder1"></a><span class="name">OrderItem</span><span class="type">array</span><span class="req">Required</span><span class="desc">Details of the order lines.</span>
+                          <li><a href="#createOrder1"></a><span class="name">OrderItem</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Details of the order lines.</span>
                             <ul>
                               <li>
                                 <table>
@@ -663,31 +676,31 @@ documentation:
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">articleLineID</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Line Id.</td></tr>
+                                  <tr class="trwh"><td class="name">articleLineID</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Line Id.</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleId</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Numbers</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleId</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Numbers</span>
                                 <ul>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sets type of Article number/id.</td></tr>
+                                      <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sets type of Article number/id.</td></tr>
                                     </table>
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Id Value</td></tr>
+                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Id Value</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleQuantity</span><span class="type">array</span><span class="req">Required</span><span class="desc">Quantity Ordered.</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleQuantity</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Quantity Ordered.</span>
                                 <ul>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sets type of Article quantity/id.</td></tr>
+                                      <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sets type of Article quantity/id.</td></tr>
                                     </table>
                                   </li>
-                                  <li><a href="#createOrder1"></a><span class="name">unitCode</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Unit Code for quantity ordered.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">unitCode</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Unit Code for quantity ordered.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -698,14 +711,14 @@ documentation:
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Quantity.</td></tr>
+                                      <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Quantity.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleReference</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Article Reference.</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleReference</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Article Reference.</span>
                                 <ul>
-                                  <li><a href="#createOrder1"></a><span class="name">referenceType</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Type of references used in orderline.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">referenceType</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Type of references used in orderline.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -716,19 +729,19 @@ documentation:
                                   </li>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Quantity.</td></tr>
+                                      <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Quantity.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">Description</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Description.</span>
+                              <li><a href="#createOrder1"></a><span class="name">Description</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Description.</span>
                                 <ul>
                                   <li>
                                     <table>
                                       <tr><td class="descParent"><br>Example&#58;<br>&lt;Description usageCode=&quot;AAA&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Text&gt;White, electric table fan&lt;/Text&gt;<br>&lt;/Description&gt;</td></tr>
                                     </table>
                                   </li>
-                                  <li><a href="#createOrder1"></a><span class="name">usageCode</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Article Description Type.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">usageCode</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Description Type.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -739,19 +752,19 @@ documentation:
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Description.</td></tr>
+                                      <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Description.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">DateAndTimes</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Date and Time at the Orderline level.</span>
+                              <li><a href="#createOrder1"></a><span class="name">DateAndTimes</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Date and Time at the Orderline level.</span>
                                 <ul>
                                   <li>
                                     <table>
                                       <tr><td class="descParent">There are many different options for date and time.<br><br>Example&#58;<br>&lt;DateAndTimes subClass=&quot;ExpirationDate&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Date&gt;2028-02-07&lt;/Date&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Time&gt;00:00:00&lt;/Time&gt;<br>&lt;/DateAndTimes&gt;</td></tr>
                                     </table>
                                   </li>
-                                  <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">SubClass.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">SubClass.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -762,21 +775,21 @@ documentation:
                                   </li>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Date.</td></tr>
+                                      <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Date.</td></tr>
                                     </table>
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Time.</td></tr>
+                                      <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Time.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleMonetaryAmounts</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Article unit sales price and currency.</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleMonetaryAmounts</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Article unit sales price and currency.</span>
                                 <ul>
-                                  <li class="last"><a href="#createOrder1"></a><span class="name">UnitPrice</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Unit Price.</span>
+                                  <li class="last"><a href="#createOrder1"></a><span class="name">UnitPrice</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Unit Price.</span>
                                     <ul>
-                                      <li><a href="#createOrder1"></a><span class="name">currencyIdentificationCode</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Currency Identification Code.</span>
+                                      <li><a href="#createOrder1"></a><span class="name">currencyIdentificationCode</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Currency Identification Code.</span>
                                         <ul>
                                           <li class="last">
                                             <table>
@@ -787,21 +800,21 @@ documentation:
                                       </li>
                                       <li class="last">
                                         <table>
-                                          <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Unit Price Value.</td></tr>
+                                          <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Unit Price Value.</td></tr>
                                         </table>
                                       </li>
                                     </ul>
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">Utility</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Utility.</span>
+                              <li><a href="#createOrder1"></a><span class="name">Utility</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Utility.</span>
                                 <ul>
                                   <li>
                                     <table>
-                                      <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">usage Code.</td></tr>
+                                      <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">usage Code.</td></tr>
                                     </table>
                                   </li>
-                                  <li><a href="#createOrder1"></a><span class="name">codeListIdentifier</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Code List Identifier.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">codeListIdentifier</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Code List Identifier.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -812,19 +825,19 @@ documentation:
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Utility value.</td></tr>
+                                      <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Utility value.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
                               <li>
                                 <table>
-                                  <tr class="trwh"><td class="name">ArticleStatus</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Status.</td></tr>
+                                  <tr class="trwh"><td class="name">ArticleStatus</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Status.</td></tr>
                                 </table>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleSerialNos</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Serial numbers for the article.</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleSerialNos</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Serial numbers for the article.</span>
                                 <ul>
-                                  <li class="last"><a href="#createOrder1"></a><span class="name">ArticleSerialNo</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Article Serial No.</span>
+                                  <li class="last"><a href="#createOrder1"></a><span class="name">ArticleSerialNo</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Article Serial No.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -835,7 +848,7 @@ documentation:
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">ArticleBatchNo</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Batch number connected to the article.</span>
+                              <li><a href="#createOrder1"></a><span class="name">ArticleBatchNo</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Batch number connected to the article.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -844,14 +857,14 @@ documentation:
                                   </li>
                                 </ul>
                               </li>
-                              <li><a href="#createOrder1"></a><span class="name">FreeText</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Used for additional information</span>
+                              <li><a href="#createOrder1"></a><span class="name">FreeText</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Used for additional information</span>
                                 <ul>
                                   <li>
                                     <table>
                                       <tr><td class="descParent"><br>Example&#58;<br>&lt;FreeText usageCode=&quot;LIN&quot;&gt;<br>&nbsp;&nbsp;&nbsp;&nbsp;&lt;Text&gt;0002292492&lt;/Text&gt;<br>&lt;/FreeText&gt;</td></tr>
                                     </table>
                                   </li>
-                                  <li><a href="#createOrder1"></a><span class="name">usageCode</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Usage Code.</span>
+                                  <li><a href="#createOrder1"></a><span class="name">usageCode</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Usage Code.</span>
                                     <ul>
                                       <li class="last">
                                         <table>
@@ -862,12 +875,12 @@ documentation:
                                   </li>
                                   <li class="last">
                                     <table>
-                                      <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Text.</td></tr>
+                                      <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Text.</td></tr>
                                     </table>
                                   </li>
                                 </ul>
                               </li>
-                              <li class="last"><a href="#createOrder1"></a><span class="name">ArticleName</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Article Name.</span>
+                              <li class="last"><a href="#createOrder1"></a><span class="name">ArticleName</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Article Name.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -878,9 +891,9 @@ documentation:
                               </li>
                             </ul>
                           </li>
-                          <li class="last"><a href="#createOrder1"></a><span class="name">PalletInfo</span><span class="type">array</span><span class="req">Optional</span><span class="desc">Pallet Info</span>
+                          <li class="last"><a href="#createOrder1"></a><span class="name">PalletInfo</span><span class="type">array</span><span class="mb-badge">Optional</span><span class="desc">Pallet Info</span>
                             <ul>
-                              <li><a href="#createOrder1"></a><span class="name">EPDCode</span><span class="type">string</span><span class="req">Optional</span><span class="desc">EPD Code.</span>
+                              <li><a href="#createOrder1"></a><span class="name">EPDCode</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">EPD Code.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -889,7 +902,7 @@ documentation:
                                   </li>
                                 </ul>
                               </li>
-                              <li class="last"><a href="#createOrder1"></a><span class="name">PalletQuantity</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Pallet Quantity.</span>
+                              <li class="last"><a href="#createOrder1"></a><span class="name">PalletQuantity</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Pallet Quantity.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -902,11 +915,11 @@ documentation:
                           </li>
                         </ul>
                       </li>
-                      <li class="last"><a href="#createOrder1"></a><span class="name">CustomsClearance</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Customs Clearance</span>
+                      <li class="last"><a href="#createOrder1"></a><span class="name">CustomsClearance</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Customs Clearance</span>
                         <ul>
-                          <li><a href="#createOrder1"></a><span class="name">FreightChargeAmount</span><span class="type">object</span><span class="req">Optional</span><span class="desc">Freight Cost</span>
+                          <li><a href="#createOrder1"></a><span class="name">FreightChargeAmount</span><span class="type">object</span><span class="mb-badge">Optional</span><span class="desc">Freight Cost</span>
                             <ul>
-                              <li><a href="#createOrder1"></a><span class="name">currencyIdentificationCode</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">Currency Identification Code.</span>
+                              <li><a href="#createOrder1"></a><span class="name">currencyIdentificationCode</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">Currency Identification Code.</span>
                                 <ul>
                                   <li class="last">
                                     <table>
@@ -917,12 +930,12 @@ documentation:
                               </li>
                               <li class="last">
                                 <table>
-                                  <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Optional</span></td><td class="desc">Value of the Freight Charge Amount.</td></tr>
+                                  <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge">Optional</span></td><td class="desc">Value of the Freight Charge Amount.</td></tr>
                                 </table>
                               </li>
                             </ul>
                           </li>
-                          <li class="last"><a href="#createOrder1"></a><span class="name">FreightChargeCarrier</span><span class="type">string</span><span class="req">Optional</span><span class="desc">Customs Carrier.</span>
+                          <li class="last"><a href="#createOrder1"></a><span class="name">FreightChargeCarrier</span><span class="type">string</span><span class="mb-badge">Optional</span><span class="desc">Customs Carrier.</span>
                             <ul>
                               <li class="last">
                                 <table>
@@ -961,14 +974,20 @@ documentation:
 
   - title: Post Item Data
     content: |
-
       <p>This endpoint is used to submit article information to Bring Warehousing.</p>
-        <table class="codeBox"><tr><td class="dark">POST</td><td><a href="https://bapi.bring.com/wh/api/v1/itemdata">https://bapi.bring.com/wh/api/v1/itemdata</a></td></tr></table>
-      <h3>Request parameters</h3>
-      <table>
-        <tr><th>HTTP header</th><th>Type</th><th>Description</th></tr>
-        <tr><td>Accept</td><td>string</td><td><span class="req">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
-        <tr><td>Content-Type</td><td>string</td><td><span class="req">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
+      <div class="flex align-ifs mbl mts"><span class="mb-badge mb-badge--blue text-note ttu mrxs pas">post</span>
+        <span class="flex-auto">
+          <pre class="flex align-ic pas mb0 wrap-text">
+            <span>https://bapi.bring.com/wh/api/v1/itemdata</span>
+          </pre>
+        </span>
+      </div>
+      <table class="mb-table">
+        <thead><tr><th>HTTP header</th><th>Type</th><th>Description</th></tr></thead>
+        <tbody>
+          <tr><td>Accept</td><td>string</td><td><span class="mb-badge mb-badge--red">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
+          <tr><td>Content-Type</td><td>string</td><td><span class="mb-badge mb-badge--red">Required</span> Specify response format (application/xml, application/json)<br>Possible values&#58;<br>&bull; application/xml<br>&bull; application/json</td></tr>
+        </tbody>
       </table>
       <h3>Request body</h3>
       <table>
@@ -982,9 +1001,9 @@ documentation:
       </div>
       <button onclick="expandCollapseAll('itemData1',true)">Expand all</button><button onclick="expandCollapseAll('itemData1',false)">Collapse all</button>
       <ul id="itemData1" class="maketree">
-        <li class="last"><a href="#itemData1" onclick="compactMenu('itemData1',true,'&plusmn; ')"></a><span class="name">CreateItemDataRequest</span><span class="type">object</span><span class="req">Required</span><span class="desc">Send Item Data Request</span>
+        <li class="last"><a href="#itemData1" onclick="compactMenu('itemData1',true,'&plusmn; ')"></a><span class="name">CreateItemDataRequest</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Send Item Data Request</span>
           <ul>
-            <li><a href="#itemData1"></a><span class="name">version</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Version of Request.</span><br>
+            <li><a href="#itemData1"></a><span class="name">version</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Version of Request.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -993,7 +1012,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">definedBy</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Defined By.</span><br>
+            <li><a href="#itemData1"></a><span class="name">definedBy</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Defined By.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1002,7 +1021,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">domain</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Domain.</span><br>
+            <li><a href="#itemData1"></a><span class="name">domain</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Domain.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1011,7 +1030,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">collaboration</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Collaboration.</span><br>
+            <li><a href="#itemData1"></a><span class="name">collaboration</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Collaboration.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1020,7 +1039,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">messageFunction</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Type of order.</span><br>
+            <li><a href="#itemData1"></a><span class="name">messageFunction</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Type of order.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1029,7 +1048,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">profile</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Profile.</span><br>
+            <li><a href="#itemData1"></a><span class="name">profile</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Profile.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1038,7 +1057,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">messageId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Unique id for this message.</span><br>
+            <li><a href="#itemData1"></a><span class="name">messageId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Unique id for this message.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1047,7 +1066,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Update Indicator.</span><br>
+            <li><a href="#itemData1"></a><span class="name">updateIndicator</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Update Indicator.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1056,7 +1075,7 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">testIndicator</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Whether this is a test message.</span><br>
+            <li><a href="#itemData1"></a><span class="name">testIndicator</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Whether this is a test message.</span><br>
               <ul>
                 <li class="last">
                   <table>
@@ -1065,9 +1084,9 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">MessageDetails</span><span class="type">object</span><span class="req">Required</span><span class="desc">Message Details</span><br>
+            <li><a href="#itemData1"></a><span class="name">MessageDetails</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Message Details</span><br>
               <ul>
-                <li><a href="#createOrder1"></a><span class="name">MessageDate</span><span class="type">datetime</span><span class="req">Required</span><span class="desc">The date on which the message was sent.</span><br>
+                <li><a href="#createOrder1"></a><span class="name">MessageDate</span><span class="type">datetime</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">The date on which the message was sent.</span><br>
                   <ul>
                     <li class="last">
                       <table>
@@ -1076,9 +1095,9 @@ documentation:
                     </li>
                   </ul>
                 </li>
-                <li><a href="#createOrder1"></a><span class="name">MessageRecipient</span><span class="type">object</span><span class="req">Required</span><span class="desc">Message Recipient</span><br>
+                <li><a href="#createOrder1"></a><span class="name">MessageRecipient</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Message Recipient</span><br>
                   <ul>
-                    <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
+                    <li><a href="#createOrder1"></a><span class="name">partyId</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Customer number (6 or 11 digits) provided by Bring.</span><br>
                       <ul>
                         <li class="last">
                           <table>
@@ -1087,7 +1106,7 @@ documentation:
                         </li>
                       </ul>
                     </li>
-                    <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="req">Optional</span><span class="desc">partyId type.</span><br>
+                    <li class="last"><a href="#createOrder1"></a><span class="name">idType</span><span class="type">string (attribute)</span><span class="mb-badge">Optional</span><span class="desc">partyId type.</span><br>
                       <ul>
                         <li class="last">
                           <table>
@@ -1100,214 +1119,214 @@ documentation:
                 </li>
               </ul>
             </li>
-            <li><a href="#itemData1"></a><span class="name">PerformingUnit</span><span class="type">object</span><span class="req">Required</span><span class="desc">Performing Unit</span>
+            <li><a href="#itemData1"></a><span class="name">PerformingUnit</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Performing Unit</span>
               <ul>
                 <li>
                   <table>
-                    <tr class="trwh"><td class="name">Name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Performing Unit Name</td></tr>
+                    <tr class="trwh"><td class="name">Name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Performing Unit Name</td></tr>
                   </table>
                 </li>
                 <li class="last">
                   <table>
-                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Performing Unit Value</td></tr>
+                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Performing Unit Value</td></tr>
                   </table>
                 </li>
               </ul>
             </li>
-            <li class="last"><a href="#itemData1"></a><span class="name">SupplyStructure</span><span class="type">object</span><span class="req">Required</span><span class="desc">Supply Structure</span>
+            <li class="last"><a href="#itemData1"></a><span class="name">SupplyStructure</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Supply Structure</span>
               <ul>
-                <li class="last"><a href="#itemData1"></a><span class="name">ArticleInformationSet</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Information Set Array</span>
+                <li class="last"><a href="#itemData1"></a><span class="name">ArticleInformationSet</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Information Set Array</span>
                   <ul>
-                    <li class="last"><a href="#itemData1"></a><span class="name">ArticleInformation</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Information Array</span>
+                    <li class="last"><a href="#itemData1"></a><span class="name">ArticleInformation</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Information Array</span>
                       <ul>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">articleLineId</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Line Id</td></tr>
+                            <tr class="trwh"><td class="name">articleLineId</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Line Id</td></tr>
                           </table>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleNumber</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Number</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleNumber</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Number</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name250">ArticlePhysicalBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Physical Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name250">ArticlePhysicalBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Physical Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name250">ArticleAllocatedBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Allocated Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name250">ArticleAllocatedBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Allocated Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name250">ArticleInOrderBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">In Order Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name250">ArticleInOrderBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">In Order Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleFreeBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Free Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleFreeBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Free Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleAdjustedQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Adjusted Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleAdjustedQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Adjusted Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleCountedQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Counted Balance Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleCountedQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Counted Balance Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Item Quantity Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Item Quantity Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">Description</span><span class="type">array</span><span class="req">Required</span><span class="desc">Description</span>
+                        <li><a href="#itemData1"></a><span class="name">Description</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Description</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="req">Required</span><span class="desc">Language Code</span>
+                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Language Code</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="req">Required</span><span class="desc">Free Text Type Text</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Free Text Type Text</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sequence</td></tr>
+                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sequence</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code</td></tr>
+                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Free Text Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Free Text Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="req">Required</span><span class="desc">Date and Times</span>
+                        <li><a href="#itemData1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Date and Times</span>
                           <ul>
-                            <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Time zone.</span>
+                            <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Time zone.</span>
                               <ul>
                                 <li class="last">
                                   <table>
@@ -1318,366 +1337,366 @@ documentation:
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sub Class</td></tr>
+                                <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sub Class</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">dstIndicator</td><td class="type">stringstring (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Destination Indicator</td></tr>
+                                <tr class="trwh"><td class="name">dstIndicator</td><td class="type">stringstring (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Destination Indicator</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Date</td></tr>
+                                <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Date</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Time</td></tr>
+                                <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Time</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">Utility</span><span class="type">array</span><span class="req">Required</span><span class="desc">Utility</span>
+                        <li><a href="#itemData1"></a><span class="name">Utility</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Utility</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="req">Required</span><span class="desc">Language Code</span>
+                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Language Code</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="req">Required</span><span class="desc">Free Text Type Text</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Free Text Type Text</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sequence</td></tr>
+                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sequence</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code</td></tr>
+                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Free Text Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Free Text Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Quantity</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Quantity</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleUnitCode</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Unit Code</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleUnitCode</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Unit Code</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code Value</td></tr>
+                                <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code Value</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleName</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Name</td></tr>
+                            <tr class="trwh"><td class="name">ArticleName</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Name</td></tr>
                           </table>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleStatus</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Status</td></tr>
+                            <tr class="trwh"><td class="name">ArticleStatus</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Status</td></tr>
                           </table>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleSerialNos</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Serial Nos</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleSerialNos</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Serial Nos</span>
                           <ul>
                             <li class="last">
                               <table>
-                                <tr class="trwh"><td class="name">ArticleSerialNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article serial number</td></tr>
+                                <tr class="trwh"><td class="name">ArticleSerialNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article serial number</td></tr>
                               </table>
                             </li>
                           </ul>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleBatchNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Batch No</td></tr>
+                            <tr class="trwh"><td class="name">ArticleBatchNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Batch No</td></tr>
                           </table>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleUNno</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article UN no</td></tr>
+                            <tr class="trwh"><td class="name">ArticleUNno</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article UN no</td></tr>
                           </table>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleVariantIdentifier</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Variant Identifier</td></tr>
+                            <tr class="trwh"><td class="name">ArticleVariantIdentifier</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Variant Identifier</td></tr>
                           </table>
                         </li>
                         <li>
                           <table>
-                            <tr class="trwh"><td class="name">ArticleCountryOfOrigin</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Country Of Origin</td></tr>
+                            <tr class="trwh"><td class="name">ArticleCountryOfOrigin</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Country Of Origin</td></tr>
                           </table>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name250">ArticleWeightAndDimension</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Weight And Dimension</span>
+                        <li><a href="#itemData1"></a><span class="name250">ArticleWeightAndDimension</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Weight And Dimension</span>
                           <ul>
-                            <li><a href="#itemData1"></a><span class="name">Depth</span><span class="type">object</span><span class="req">Required</span><span class="desc">Depth</span>
+                            <li><a href="#itemData1"></a><span class="name">Depth</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Depth</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">Height</span><span class="type">object</span><span class="req">Required</span><span class="desc">Height</span>
+                            <li><a href="#itemData1"></a><span class="name">Height</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Height</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">NetWeight</span><span class="type">object</span><span class="req">Required</span><span class="desc">Net Weight</span>
+                            <li><a href="#itemData1"></a><span class="name">NetWeight</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Net Weight</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">Width</span><span class="type">object</span><span class="req">Required</span><span class="desc">Width</span>
+                            <li><a href="#itemData1"></a><span class="name">Width</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Width</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">GrossWeight</span><span class="type">object</span><span class="req">Required</span><span class="desc">Gross Weight</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">GrossWeight</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Gross Weight</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit Code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">FreeText</span><span class="type">array</span><span class="req">Required</span><span class="desc">Free Text</span>
+                        <li><a href="#itemData1"></a><span class="name">FreeText</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Free Text</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Usage Code</td></tr>
+                                <tr class="trwh"><td class="name">usageCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Usage Code</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="req">Required</span><span class="desc">Language Code</span>
+                            <li><a href="#itemData1"></a><span class="name">LanguageCode</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Language Code</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
+                                    <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code List Agency Identifier</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                    <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="req">Required</span><span class="desc">Free Text Type Text</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">Text</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Free Text Type Text</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sequence</td></tr>
+                                    <tr class="trwh"><td class="name">sequence</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sequence</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Code</td></tr>
+                                    <tr class="trwh"><td class="name">code</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Free Text Value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Free Text Value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">Reference</span><span class="type">array</span><span class="req">Required</span><span class="desc">Reference</span>
+                        <li><a href="#itemData1"></a><span class="name">Reference</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Reference</span>
                           <ul>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">referenceType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Reference type</td></tr>
+                                <tr class="trwh"><td class="name">referenceType</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Reference type</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">List Agency Identifier</td></tr>
+                                <tr class="trwh"><td class="name">codeListAgencyIdentifier</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">List Agency Identifier</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Name</td></tr>
+                                <tr class="trwh"><td class="name">name</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Name</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Reference number</td></tr>
+                                <tr class="trwh"><td class="name">ReferenceNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Reference number</td></tr>
                               </table>
                             </li>
                             <li>
                               <table>
-                                <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Reference Text</td></tr>
+                                <tr class="trwh"><td class="name">Text</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Reference Text</td></tr>
                               </table>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">ReferenceDate</span><span class="type">array</span><span class="req">Required</span><span class="desc">Reference Date</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">ReferenceDate</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Reference Date</span>
                               <ul>
-                                <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Time zone.</span>
+                                <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Time zone.</span>
                                   <ul>
                                     <li class="last">
                                       <table>
@@ -1688,126 +1707,126 @@ documentation:
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sub Class</td></tr>
+                                    <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sub Class</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">dstIndicator</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Destination Indicator</td></tr>
+                                    <tr class="trwh"><td class="name">dstIndicator</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Destination Indicator</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Date</td></tr>
+                                    <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Date</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Time</td></tr>
+                                    <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Time</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleTotals</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Totals</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleTotals</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Totals</span>
                           <ul>
-                            <li><a href="#itemData1"></a><span class="name">NumberOfPackages</span><span class="type">object</span><span class="req">Required</span><span class="desc">Number of packages</span>
+                            <li><a href="#itemData1"></a><span class="name">NumberOfPackages</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Number of packages</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (int)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Quantity value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (int)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Quantity value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">GrossWeight</span><span class="type">object</span><span class="req">Required</span><span class="desc">Gross Weight</span>
+                            <li><a href="#itemData1"></a><span class="name">GrossWeight</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Gross Weight</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Quantity value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Quantity value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">GrossVolume</span><span class="type">object</span><span class="req">Required</span><span class="desc">Gross Weight</span>
+                            <li><a href="#itemData1"></a><span class="name">GrossVolume</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Gross Weight</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Quantity value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Quantity value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">LoadingMetres</span><span class="type">object</span><span class="req">Required</span><span class="desc">Loading Metres</span>
+                            <li><a href="#itemData1"></a><span class="name">LoadingMetres</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Loading Metres</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Quantity value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Quantity value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li><a href="#itemData1"></a><span class="name">PalletFootPrints</span><span class="type">object</span><span class="req">Required</span><span class="desc">Palette Foot Prints</span>
+                            <li><a href="#itemData1"></a><span class="name">PalletFootPrints</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Palette Foot Prints</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                    <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Quantity value</td></tr>
+                                    <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Quantity value</td></tr>
                                   </table>
                                 </li>
                               </ul>
                             </li>
-                            <li class="last"><a href="#itemData1"></a><span class="name">Measures</span><span class="type">array</span><span class="req">Required</span><span class="desc">Measures</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">Measures</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Measures</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">subClass</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sub class</td></tr>
+                                    <tr class="trwh"><td class="name">subClass</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sub class</td></tr>
                                   </table>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">MeasureEntity</span><span class="type">array</span><span class="req">Required</span><span class="desc">Measure Entity</span>
+                                <li><a href="#itemData1"></a><span class="name">MeasureEntity</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Measure Entity</span>
                                   <ul>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">attributeCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Attribute code</td></tr>
+                                        <tr class="trwh"><td class="name">attributeCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Attribute code</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li class="last"><a href="#itemData1"></a><span class="name">Measure</span><span class="type">object</span><span class="req">Required</span><span class="desc">Measure</span>
+                                <li class="last"><a href="#itemData1"></a><span class="name">Measure</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Measure</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
@@ -1816,38 +1835,38 @@ documentation:
                             </li>
                           </ul>
                         </li>
-                        <li><a href="#itemData1"></a><span class="name">ArticleBatches</span><span class="type">object</span><span class="req">Required</span><span class="desc">Article Batches</span>
+                        <li><a href="#itemData1"></a><span class="name">ArticleBatches</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Batches</span>
                           <ul>
-                            <li class="last"><a href="#itemData1"></a><span class="name">ArticleBatch</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Batch</span>
+                            <li class="last"><a href="#itemData1"></a><span class="name">ArticleBatch</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Batch</span>
                               <ul>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">BatchNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Batch No</td></tr>
+                                    <tr class="trwh"><td class="name">BatchNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Batch No</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">WarehouseId</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Warehouse Id</td></tr>
+                                    <tr class="trwh"><td class="name">WarehouseId</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Warehouse Id</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">WarehouseArea</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Warehouse Area</td></tr>
+                                    <tr class="trwh"><td class="name">WarehouseArea</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Warehouse Area</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">WarehouseLocation</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Warehouse Location</td></tr>
+                                    <tr class="trwh"><td class="name">WarehouseLocation</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Warehouse Location</td></tr>
                                   </table>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">ParcelNumber</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Parcel Number</td></tr>
+                                    <tr class="trwh"><td class="name">ParcelNumber</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Parcel Number</td></tr>
                                   </table>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="req">Required</span><span class="desc">Date and Times</span>
+                                <li><a href="#itemData1"></a><span class="name">DateAndTimes</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Date and Times</span>
                                   <ul>
-                                    <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="req">Required</span><span class="desc">Time zone.</span>
+                                    <li><a href="#itemData1"></a><span class="name">subClass</span><span class="type">string (attribute)</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Time zone.</span>
                                       <ul>
                                         <li class="last">
                                           <table>
@@ -1858,132 +1877,132 @@ documentation:
                                     </li>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Sub Class</td></tr>
+                                        <tr class="trwh"><td class="name">timeZone</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Sub Class</td></tr>
                                       </table>
                                     </li>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">dstIndicator</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Destination Indicator</td></tr>
+                                        <tr class="trwh"><td class="name">dstIndicator</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Destination Indicator</td></tr>
                                       </table>
                                     </li>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Date</td></tr>
+                                        <tr class="trwh"><td class="name">Date</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Date</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Time</td></tr>
+                                        <tr class="trwh"><td class="name">Time</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Time</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">DeliveredQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Delivered Quantity</span>
+                                <li><a href="#itemData1"></a><span class="name">DeliveredQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Delivered Quantity</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">ExpectedQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Expected Quantity</span>
+                                <li><a href="#itemData1"></a><span class="name">ExpectedQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Expected Quantity</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">ReceivedQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Received Quantity</span>
+                                <li><a href="#itemData1"></a><span class="name">ReceivedQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Received Quantity</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">PhysicalBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Physical Balance Quantity</span>
+                                <li><a href="#itemData1"></a><span class="name">PhysicalBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Physical Balance Quantity</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">AllocatedBalanceQuantity</span><span class="type">object</span><span class="req">Required</span><span class="desc">Allocated Balance Quantity</span>
+                                <li><a href="#itemData1"></a><span class="name">AllocatedBalanceQuantity</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Allocated Balance Quantity</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">NetWeight</span><span class="type">object</span><span class="req">Required</span><span class="desc">Net Weight</span>
+                                <li><a href="#itemData1"></a><span class="name">NetWeight</span><span class="type">object</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Net Weight</span>
                                   <ul>
                                     <li>
                                       <table>
-                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Unit code</td></tr>
+                                        <tr class="trwh"><td class="name">unitCode</td><td class="type">string (attribute)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Unit code</td></tr>
                                       </table>
                                     </li>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Measure value</td></tr>
+                                        <tr class="trwh"><td class="name">Value</td><td class="type">number (float)</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Measure value</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">Locked</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Locked</td></tr>
+                                    <tr class="trwh"><td class="name">Locked</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Locked</td></tr>
                                   </table>
                                 </li>
-                                <li><a href="#itemData1"></a><span class="name">ArticleSerialNos</span><span class="type">array</span><span class="req">Required</span><span class="desc">Article Serial Nos</span>
+                                <li><a href="#itemData1"></a><span class="name">ArticleSerialNos</span><span class="type">array</span><span class="mb-badge mb-badge--red">Required</span><span class="desc">Article Serial Nos</span>
                                   <ul>
                                     <li class="last">
                                       <table>
-                                        <tr class="trwh"><td class="name">ArticleSerialNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article serial number</td></tr>
+                                        <tr class="trwh"><td class="name">ArticleSerialNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article serial number</td></tr>
                                       </table>
                                     </li>
                                   </ul>
                                 </li>
                                 <li>
                                   <table>
-                                    <tr class="trwh"><td class="name">SSCCNo</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">SSCC No</td></tr>
+                                    <tr class="trwh"><td class="name">SSCCNo</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">SSCC No</td></tr>
                                   </table>
                                 </li>
                                 <li class="last">
                                   <table>
-                                    <tr class="trwh"><td class="name">BatchStatus</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Batch Status</td></tr>
+                                    <tr class="trwh"><td class="name">BatchStatus</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Batch Status</td></tr>
                                   </table>
                                 </li>
                               </ul>
@@ -1992,7 +2011,7 @@ documentation:
                         </li>
                         <li class="last">
                           <table>
-                            <tr class="trwh"><td class="name">ArticleGroup</td><td class="type">string</td><td class="reqtd"><span class="req">Required</span></td><td class="desc">Article Group</td></tr>
+                            <tr class="trwh"><td class="name">ArticleGroup</td><td class="type">string</td><td class="reqtd"><span class="mb-badge mb-badge--red">Required</span></td><td class="desc">Article Group</td></tr>
                           </table>
                         </li>
                       </ul>

--- a/content/api/warehousing/warehousing.css
+++ b/content/api/warehousing/warehousing.css
@@ -41,12 +41,6 @@ ul.maketree li.last {
     display: inline-block;
     margin-left: 350px;
 }
-.req {
-    color: #7b3838;
-    background-color: #f6efef;
-    font-size: .9em;
-    width: 80px;
-}
 .reqtd {
     display: inline-block;
     width: 80px;

--- a/content/api/warehousing3/index.html
+++ b/content/api/warehousing3/index.html
@@ -28,20 +28,17 @@ information:
 documentation:
   - title: Order Information
     content: |
-      In order to obtain information about an order/get the receipt for an order, you have two choices:
+      In order to obtain information about an order/get the receipt for an order, you have two options:
       <head>
         <link rel="stylesheet" href="warehousing.css">
         <script src="listcollapse.js" type="text/javascript" language="javascript1.2"></script>
         <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.3.1/jquery.min.js"></script>
       </head>
       <body>
-        <p></p>
         <ul>
-          <li>You can obtain data from Mybring.</li>
-          <table class="codeBox"><tr><td class="dark">GET</td><td><a href="https://developer.bring.com/api/warehousing/#list-order-information">https://developer.bring.com/api/warehousing/#list-order-information</a></td></tr></table>
-          </ul>
+          <li>You can <a href='{{< relref "warehousing4" >}}#endpoints'>obtain data from Mybring</a>.</li>
           <li>We can push data to you if you set up a webservice on your side</li>
-        </ul><br>
+        </ul>
         <p>You should use a REST web service which needs to be secured through https.</p>
         <p>After you have set up your web service, you must send the information about the URL and its authentication to us, so that we can set up a link from our side.</p>
         <p>The data sent from Bring will be in GS1 3.3 format.

--- a/content/api/warehousing3/index.html
+++ b/content/api/warehousing3/index.html
@@ -10,6 +10,12 @@ menu:
     parent: warehouse
 weight: 2
 
+introduction:
+  Order information/update from Bring.<br>
+  Bring Warehousing can send order information to you or you can pull the data from us.<br>
+  How often you want order lifestyle updates is up to you.<br>
+  Bring Warehousing can also send you Inventory reports (full overview over all articles) and Inventory adjustment reports (update per article after an adjustment is made).
+
 information:
   - title: Authentication
     content: |
@@ -20,13 +26,6 @@ information:
       REST XML/JSON over HTTPS. This is common for most REST APIs.
 
 documentation:
-  - title: Introduction
-    content: |
-      Order information/update from Bring.<br><br>
-      Bring Warehousing can send order information to you or you can pull the data from us.<br><br>
-      How often you want order lifestyle updates is up to you.<br><br>
-      Bring Warehousing can also send you Inventory reports (full overview over all articles) and Inventory adjustment reports (update per article after an adjustment is made).
-
   - title: Order Information
     content: |
       In order to obtain information about an order/get the receipt for an order, you have two choices:

--- a/content/api/warehousing3/warehousing.css
+++ b/content/api/warehousing3/warehousing.css
@@ -41,12 +41,6 @@ ul.maketree li.last {
     display: inline-block;
     margin-left: 350px;
 }
-.req {
-    color: #7b3838;
-    background-color: #f6efef;
-    font-size: .9em;
-    width: 80px;
-}
 .reqtd {
     display: inline-block;
     width: 80px;

--- a/content/api/warehousing4/index.md
+++ b/content/api/warehousing4/index.md
@@ -10,6 +10,9 @@ menu:
     parent: warehouse
 weight: 3
 
+introduction:
+      You are able to extract detailed order information from our warehouse while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.
+
 information:
   - title: Authentication
     content: |
@@ -17,17 +20,9 @@ information:
 
   - title: Formats
     content: |
-      REST XML/JSON and SOAP over HTTP. This API doesn't support JSON for all methods yet. Look in the example section to see which are supported.
+      REST XML/JSON and SOAP over HTTP. Warehousing API has several interfaces (SOAP and XML/JSON). Choose the option that fits your needs best (see table below). The XML/JSON interface is the core interface with complete functionality. Please note that this API currently doesn't support json on all of its methods yet. Look in the example section to see which are supported.
 
 documentation:
-  - title: Introduction
-    content: |
-      You are able to extract detailed order information from our warehouse while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.
-
-      Warehousing API has several interfaces (SOAP and XML/JSON). Choose the option that fits your needs best (see table below). The XML/JSON interface is the core interface with complete functionality.
-
-      Please note that this API currently doesn't support json on all of its methods yet. Look in the example section to see which are supported.
-
   - title: Error handling
     content: |
       When using the Warehousing API, errors or service unavailability can occur, although we do our utmost to prevent any downtime. Thus it is important to use timeouts and other error handling techniques when making requests to the service.

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -62,7 +62,7 @@
                 <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
                 <div class="flex flex-wrap mbxl pbxl mb-border bb gal">
                   <div class="param-response-area">
-                    <div class="flex align-ic mbl mts">
+                    <div class="flex align-ifs mbl mts">
                       {{- partial "api/oas/endpoint-type" (dict "type" $type) -}}
                       <span class="flex-auto">
                         <pre class="flex align-ic pas mb0 wrap-text">

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -70,252 +70,261 @@
             {{- end -}}
           </div>
         </section>
-        <section class="dev-docscontent__section maxw64r">
-          <h2 class="dev-anchored mbm" id="endpoints">
-            Endpoints
-          </h2>
-
-          <h3 class="dn">Base URL</h3>
-          <pre>{{ .baseUri }}</pre>
-          <table>
-            <thead>
-              <th>Usage</th>
-              <th>Method</th>
-              <th>Endpoint</th>
-            </thead>
-            {{- range .resources -}}
-              {{ $displayName := .displayName }}
-              {{ $resRelUri := .relativeUri | safeHTML }}
-              {{- range .methods -}}
-                {{- $endpointId := (print $displayName "-" .method | anchorize) -}}
-                <tr>
-                  <td>
-                    <a href="#{{ $endpointId }}" title="{{- $displayName -}}">
-                      {{- .description | safeHTML -}}
-                    </a>
-                  </td>
-                  <td>
-                    {{- .method | upper -}}
-                  </td>
-                  <td>
-                    <code>{{- $resRelUri -}}</code>
-                  </td>
-                </tr>
-              {{- end -}}
-            {{- end -}}
-          </table>
-        </section>
-
-        {{- range .resources -}}
-          {{- $resources := . -}}
-          {{- $displayName := .displayName -}}
-          {{- $method := "" -}}
-          {{- range .methods -}}
-            {{- with .method -}}
-              {{- $method = . -}}
-            {{- end -}}
-          {{- end -}}
-          {{- $endpointId := (print $displayName "-" $method | anchorize) -}}
+        {{- $baseUri := .baseUri -}}
+        {{- with .resources -}}
           <section class="dev-docscontent__section maxw64r">
-            <h2 class="dev-anchored mbm" id="{{ $endpointId }}">
-              {{- $displayName -}}
+            <h2 class="dev-anchored mbm" id="endpoints">
+              Endpoints
             </h2>
 
-            {{ $description := "" }}
-            {{- with .description -}}
-              {{ $description = . }}
-            {{- end -}}
-
-            {{- range .methods -}}
-              {{- $urlOutput := slice -}}
-              {{- $absUri := $resources.absoluteUri -}}
-              {{- $hasExtension := false -}}
-              {{- with $resources.uriParameters.mediaTypeExtension -}}
-                {{- $hasExtension = true -}}
-              {{- end -}}
-
-              {{- if $hasExtension -}}
-                {{- range $resources.uriParameters.mediaTypeExtension.enum -}}
-                  {{- $urlWithExtension := replace $absUri "{mediaTypeExtension}" . -}}
-                  {{- $urlOutput = $urlOutput | append $urlWithExtension -}}
-                {{- end -}}
-                {{- else -}}
-                {{- $urlOutput = $urlOutput | append $absUri -}}
-              {{- end -}}
-
-              <div class="flex align-ic mbl mts">
-                {{- partial "api/oas/endpoint-type" (dict "type" .method) -}}
-                <span class="flex-auto">
-                  <pre class="flex align-ic pas mb0 wrap-text">
-                    <span>{{ delimit $urlOutput "<br>" }}</span>
-                  </pre>
-                </span>
-              </div>
-
-              {{- with $description -}}
-                {{- if in (string .) "\n\n" -}}
-                  {{ . | markdownify }}
-                  {{- else -}}
-                  <p>{{ . | markdownify }}</p>
+            <div class="flex align-ifs mbl mts">
+              <span class="mb-badge text-note mrxs pas">Base URL</span>
+              <span class="flex-auto maxw40r">
+                <pre class="flex align-ifs pas mb0 wrap-text">
+                    <span>{{ $baseUri }}</span>
+                </pre>
+              </span>
+            </div>
+            <table>
+              <thead>
+                <th>Usage</th>
+                <th>Method</th>
+                <th>Endpoint</th>
+              </thead>
+              {{- range . -}}
+                {{ $displayName := .displayName }}
+                {{ $resRelUri := .relativeUri | safeHTML }}
+                {{- range .methods -}}
+                  {{- $endpointId := (print $displayName "-" .method | anchorize) -}}
+                  <tr>
+                    <td>
+                      <a href="#{{ $endpointId }}" title="{{- $displayName -}}">
+                        {{- .description | safeHTML -}}
+                      </a>
+                    </td>
+                    <td>
+                      {{- .method | upper -}}
+                    </td>
+                    <td>
+                      <code>{{- $resRelUri -}}</code>
+                    </td>
+                  </tr>
                 {{- end -}}
               {{- end -}}
-
-              {{/* uri params exists and first one is not mediaTypeExtension */}}
-              {{- $otherUriParamsMediaType := false -}}
-              {{- with $resources.uriParameters -}}
-                {{- $uriParamNames := slice -}}
-                {{- range . -}}
-                  {{- $uriParamNames = $uriParamNames | append .name -}}
-                {{- end -}}
-                {{- $uriParamFirst := "" -}}
-                {{- range first 1 $uriParamNames -}}
-                  {{- $uriParamFirst = . -}}
-                {{- end -}}
-                {{- if gt (len .) 1 -}}
-                  {{- $otherUriParamsMediaType = true -}}
-                  {{- else if (and (eq (len .) 1) (not (in $uriParamFirst "mediaTypeExtension"))) -}}
-                  {{- $otherUriParamsMediaType = true -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{/* has method.headers */}}
-              {{- $hasMethodHeaders := false -}}
-              {{- $methodHeaders := slice -}}
-              {{- range .headers -}}
-                {{- $methodHeaders = $methodHeaders | append . -}}
-                {{- if gt (len $methodHeaders) 0 -}}
-                  {{- $hasMethodHeaders = true -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{/* has method.queryParameters */}}
-              {{- $hasMethodQueryParams := false -}}
-              {{- $methodQueryParams := slice -}}
-              {{- range .queryParameters -}}
-                {{- $methodQueryParams = $methodQueryParams | append . -}}
-                {{- if gt (len $methodQueryParams) 0 -}}
-                  {{- $hasMethodQueryParams = true -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{- if (or ($otherUriParamsMediaType) ($hasMethodHeaders) ($hasMethodQueryParams)) -}}
-                <h3>Request parameters</h3>
-              {{- end -}}
-
-              {{/* For each endpoint: List all URI parameters */}}
-              {{- $uriParameters := slice -}}
-              {{- range $resources.uriParameters -}}
-                {{- $uriParameters = $uriParameters | append . -}}
-              {{- end -}}
-              {{- if $otherUriParamsMediaType -}}
-                {{- partial "api/namedparams.html" (dict "context" . "includeParams" $uriParameters "title" "URI param" ) -}}
-              {{- end -}}
-
-              {{/* For each endpoint: List all headers */}}
-              {{- if $hasMethodHeaders -}}
-                {{- partial "api/namedparams.html" (dict "context" . "includeParams" $methodHeaders "title" "HTTP header") -}}
-              {{- end -}}
-
-              {{/* For each endpoint: List all query parameters */}}
-              {{- if $hasMethodQueryParams -}}
-                {{- partial "api/namedparams.html" (dict "context" . "includeParams" $methodQueryParams "title" "Query param") -}}
-              {{- end -}}
-
-              {{- $multiMediaTypes := false -}}
-
-              {{/* For each endpoint: Request body */}}
-              {{- with .body -}}
-                {{- if gt (len .) 1 -}}
-                  {{- $multiMediaTypes = true -}}
-                {{- end -}}
-                <h3>Request body</h3>
-                {{- range . -}}
-                  {{- partial "api/tabs.html" (dict "context" . "formatType" "Request" "idTypeString" (print $displayName "-request-") "types" $types "multiMethods" $multiMediaTypes ) -}}
-                {{- end -}}
-              {{- end -}}
-
-              {{/* For each endpoint: Response */}}
-              {{- with .responses -}}
-                <h3>Responses</h3>
-                {{- range $key, $response := . -}}
-                  {{- $responseID := (print $displayName "-response-" .code) | anchorize -}}
-                  {{- $exampleID := (print $displayName "-" .code) | anchorize -}}
-                  {{- $responseCode := .code -}}
-                  {{- $resBodies := slice -}}
-                  {{- range .body -}}
-                    {{- $resBodies = $resBodies | append . -}}
-                  {{- end -}}
-                  {{/* Collapsed additional examples in Booking API */}}
-                  {{- if and (gt $key 220) (lt $key 302) -}}
-                    {{- $body := .body -}}
-                    {{- $description := .description -}}
-                    {{- $oneBody := "" -}}
-                    {{- range $index, $body := .body -}}
-                      {{- $oneBody = $index -}}
-                    {{- end -}}
-                    {{- with (index .body $oneBody).examples -}}
-                      {{- range first 1 . -}}
-                        <div
-                          class="dev-collapsible"
-                          class="dev-anchored"
-                          id="{{ $responseID }}"
-                        >
-                          <a
-                            href="#"
-                            data-collapse="#{{ $exampleID }}"
-                            class="dev-collapsible__toggler dev-collapsible__toggler--collapsed"
-                            >
-                            <span
-                              data-mybicon="mybicon-arrow-right"
-                              data-mybicon-class="dev-collapsible__toggler__icon"
-                              data-mybicon-width="16"
-                              data-mybicon-height="16"
-                            ></span>
-                            <span>{{ .displayName }}</span>
-                          </a>
-                          <div
-                            id="{{ $exampleID }}"
-                            class="dev-collapsible__item dev-collapsible__item--collapsed"
-                          >
-                            {{- with $description -}}
-                              {{- if in (string .) "\n\n" -}}
-                                {{ . | markdownify }}
-                                {{- else -}}
-                                <p>{{ . | markdownify }}</p>
-                              {{- end -}}
-                              {{- range $body -}}
-                                {{- if gt (len $resBodies) 1 -}}
-                                  {{- $multiMediaTypes = true -}}
-                                {{- end -}}
-                                {{- partial "api/tabs.html" (dict "context" . "formatType" "Response" "idTypeString" (print $responseID "-") "types" $types "multiMethods" $multiMediaTypes ) -}}
-                              {{- end -}}
-                            {{- end -}}
-                          </div>
-                        </div>
-                      {{- end -}}
-                    {{- end -}}
-                    {{- else -}}
-                    <h4 class="dev-anchored" id="{{ $responseID }}">
-                      HTTP status code {{ $responseCode }}
-                    </h4>
-                    {{- with .description -}}
-                      {{- if in (string .) "\n\n" -}}
-                        {{ . | markdownify }}
-                        {{- else -}}
-                        <p>{{ . | markdownify }}</p>
-                      {{- end -}}
-                    {{- end -}}
-                    {{- range .body -}}
-                      {{- if gt (len $resBodies) 1 -}}
-                        {{- $multiMediaTypes = true -}}
-                      {{- end -}}
-                      {{- partial "api/tabs.html" (dict "context" . "formatType" "Response" "idTypeString" (print $responseID "-") "types" $types "multiMethods" $multiMediaTypes ) -}}
-                    {{- end -}}
-                  {{- end -}}
-                {{- end -}}
-              {{- end -}}
-            {{- end -}}
+            </table>
           </section>
+
+          {{- range . -}}
+            {{- $resources := . -}}
+            {{- $displayName := .displayName -}}
+            {{- $method := "" -}}
+            {{- range .methods -}}
+              {{- with .method -}}
+                {{- $method = . -}}
+              {{- end -}}
+            {{- end -}}
+            {{- $endpointId := (print $displayName "-" $method | anchorize) -}}
+            <section class="dev-docscontent__section maxw64r">
+              <h2 class="dev-anchored mbm" id="{{ $endpointId }}">
+                {{- $displayName -}}
+              </h2>
+
+              {{ $description := "" }}
+              {{- with .description -}}
+                {{ $description = . }}
+              {{- end -}}
+
+              {{- range .methods -}}
+                {{- $urlOutput := slice -}}
+                {{- $absUri := $resources.absoluteUri -}}
+                {{- $hasExtension := false -}}
+                {{- with $resources.uriParameters.mediaTypeExtension -}}
+                  {{- $hasExtension = true -}}
+                {{- end -}}
+
+                {{- if $hasExtension -}}
+                  {{- range $resources.uriParameters.mediaTypeExtension.enum -}}
+                    {{- $urlWithExtension := replace $absUri "{mediaTypeExtension}" . -}}
+                    {{- $urlOutput = $urlOutput | append $urlWithExtension -}}
+                  {{- end -}}
+                  {{- else -}}
+                  {{- $urlOutput = $urlOutput | append $absUri -}}
+                {{- end -}}
+
+                <div class="flex align-ifs mbl mts">
+                  {{- partial "api/oas/endpoint-type" (dict "type" .method) -}}
+                  <span class="flex-auto">
+                    <pre class="flex align-ic pas mb0 wrap-text">
+                      <span>{{ delimit $urlOutput "<br>" }}</span>
+                    </pre>
+                  </span>
+                </div>
+
+                {{- with $description -}}
+                  {{- if in (string .) "\n\n" -}}
+                    {{ . | markdownify }}
+                    {{- else -}}
+                    <p>{{ . | markdownify }}</p>
+                  {{- end -}}
+                {{- end -}}
+
+                {{/* uri params exists and first one is not mediaTypeExtension */}}
+                {{- $otherUriParamsMediaType := false -}}
+                {{- with $resources.uriParameters -}}
+                  {{- $uriParamNames := slice -}}
+                  {{- range . -}}
+                    {{- $uriParamNames = $uriParamNames | append .name -}}
+                  {{- end -}}
+                  {{- $uriParamFirst := "" -}}
+                  {{- range first 1 $uriParamNames -}}
+                    {{- $uriParamFirst = . -}}
+                  {{- end -}}
+                  {{- if gt (len .) 1 -}}
+                    {{- $otherUriParamsMediaType = true -}}
+                    {{- else if (and (eq (len .) 1) (not (in $uriParamFirst "mediaTypeExtension"))) -}}
+                    {{- $otherUriParamsMediaType = true -}}
+                  {{- end -}}
+                {{- end -}}
+
+                {{/* has method.headers */}}
+                {{- $hasMethodHeaders := false -}}
+                {{- $methodHeaders := slice -}}
+                {{- range .headers -}}
+                  {{- $methodHeaders = $methodHeaders | append . -}}
+                  {{- if gt (len $methodHeaders) 0 -}}
+                    {{- $hasMethodHeaders = true -}}
+                  {{- end -}}
+                {{- end -}}
+
+                {{/* has method.queryParameters */}}
+                {{- $hasMethodQueryParams := false -}}
+                {{- $methodQueryParams := slice -}}
+                {{- range .queryParameters -}}
+                  {{- $methodQueryParams = $methodQueryParams | append . -}}
+                  {{- if gt (len $methodQueryParams) 0 -}}
+                    {{- $hasMethodQueryParams = true -}}
+                  {{- end -}}
+                {{- end -}}
+
+                {{- if (or ($otherUriParamsMediaType) ($hasMethodHeaders) ($hasMethodQueryParams)) -}}
+                  <h3>Request parameters</h3>
+                {{- end -}}
+
+                {{/* For each endpoint: List all URI parameters */}}
+                {{- $uriParameters := slice -}}
+                {{- range $resources.uriParameters -}}
+                  {{- $uriParameters = $uriParameters | append . -}}
+                {{- end -}}
+                {{- if $otherUriParamsMediaType -}}
+                  {{- partial "api/namedparams.html" (dict "context" . "includeParams" $uriParameters "title" "URI param" ) -}}
+                {{- end -}}
+
+                {{/* For each endpoint: List all headers */}}
+                {{- if $hasMethodHeaders -}}
+                  {{- partial "api/namedparams.html" (dict "context" . "includeParams" $methodHeaders "title" "HTTP header") -}}
+                {{- end -}}
+
+                {{/* For each endpoint: List all query parameters */}}
+                {{- if $hasMethodQueryParams -}}
+                  {{- partial "api/namedparams.html" (dict "context" . "includeParams" $methodQueryParams "title" "Query param") -}}
+                {{- end -}}
+
+                {{- $multiMediaTypes := false -}}
+
+                {{/* For each endpoint: Request body */}}
+                {{- with .body -}}
+                  {{- if gt (len .) 1 -}}
+                    {{- $multiMediaTypes = true -}}
+                  {{- end -}}
+                  <h3>Request body</h3>
+                  {{- range . -}}
+                    {{- partial "api/tabs.html" (dict "context" . "formatType" "Request" "idTypeString" (print $displayName "-request-") "types" $types "multiMethods" $multiMediaTypes ) -}}
+                  {{- end -}}
+                {{- end -}}
+
+                {{/* For each endpoint: Response */}}
+                {{- with .responses -}}
+                  <h3>Responses</h3>
+                  {{- range $key, $response := . -}}
+                    {{- $responseID := (print $displayName "-response-" .code) | anchorize -}}
+                    {{- $exampleID := (print $displayName "-" .code) | anchorize -}}
+                    {{- $responseCode := .code -}}
+                    {{- $resBodies := slice -}}
+                    {{- range .body -}}
+                      {{- $resBodies = $resBodies | append . -}}
+                    {{- end -}}
+                    {{/* Collapsed additional examples in Booking API */}}
+                    {{- if and (gt $key 220) (lt $key 302) -}}
+                      {{- $body := .body -}}
+                      {{- $description := .description -}}
+                      {{- $oneBody := "" -}}
+                      {{- range $index, $body := .body -}}
+                        {{- $oneBody = $index -}}
+                      {{- end -}}
+                      {{- with (index .body $oneBody).examples -}}
+                        {{- range first 1 . -}}
+                          <div
+                            class="dev-collapsible"
+                            class="dev-anchored"
+                            id="{{ $responseID }}"
+                          >
+                            <a
+                              href="#"
+                              data-collapse="#{{ $exampleID }}"
+                              class="dev-collapsible__toggler dev-collapsible__toggler--collapsed"
+                              >
+                              <span
+                                data-mybicon="mybicon-arrow-right"
+                                data-mybicon-class="dev-collapsible__toggler__icon"
+                                data-mybicon-width="16"
+                                data-mybicon-height="16"
+                              ></span>
+                              <span>{{ .displayName }}</span>
+                            </a>
+                            <div
+                              id="{{ $exampleID }}"
+                              class="dev-collapsible__item dev-collapsible__item--collapsed"
+                            >
+                              {{- with $description -}}
+                                {{- if in (string .) "\n\n" -}}
+                                  {{ . | markdownify }}
+                                  {{- else -}}
+                                  <p>{{ . | markdownify }}</p>
+                                {{- end -}}
+                                {{- range $body -}}
+                                  {{- if gt (len $resBodies) 1 -}}
+                                    {{- $multiMediaTypes = true -}}
+                                  {{- end -}}
+                                  {{- partial "api/tabs.html" (dict "context" . "formatType" "Response" "idTypeString" (print $responseID "-") "types" $types "multiMethods" $multiMediaTypes ) -}}
+                                {{- end -}}
+                              {{- end -}}
+                            </div>
+                          </div>
+                        {{- end -}}
+                      {{- end -}}
+                      {{- else -}}
+                      <h4 class="dev-anchored" id="{{ $responseID }}">
+                        HTTP status code {{ $responseCode }}
+                      </h4>
+                      {{- with .description -}}
+                        {{- if in (string .) "\n\n" -}}
+                          {{ . | markdownify }}
+                          {{- else -}}
+                          <p>{{ . | markdownify }}</p>
+                        {{- end -}}
+                      {{- end -}}
+                      {{- range .body -}}
+                        {{- if gt (len $resBodies) 1 -}}
+                          {{- $multiMediaTypes = true -}}
+                        {{- end -}}
+                        {{- partial "api/tabs.html" (dict "context" . "formatType" "Response" "idTypeString" (print $responseID "-") "types" $types "multiMethods" $multiMediaTypes ) -}}
+                      {{- end -}}
+                    {{- end -}}
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            </section>
+          {{- end -}}
         {{- end -}}
         {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}
           <section id="api-support" class="dev-docscontent__section maxw64r">

--- a/layouts/partials/api/oas/endpoints.html
+++ b/layouts/partials/api/oas/endpoints.html
@@ -8,7 +8,7 @@
     <h2 class="dev-anchored mbm" id="endpoints">
     Endpoints
     </h2>
-    <div class="flex align-ic mbl mts">
+    <div class="flex align-ifs mbl mts">
       <span class="mb-badge text-note mrxs pas">Base URL</span>
       <span class="flex-auto maxw40r">
         <pre class="flex align-ic pas mb0 wrap-text">

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -31,7 +31,7 @@
             <h2 class="dev-anchored" id="{{ $endpointId }}">{{ .summary }}</h2>
             <div class="flex flex-wrap mbxl pbxl mb-border bb gal">
               <div class="param-response-area">
-                <div class="flex align-ic mbl mts">
+                <div class="flex align-ifs mbl mts">
                   {{- partial "api/oas/endpoint-type" (dict "type" $type) -}}
                   <span class="flex-auto">
                     <pre class="flex align-ic pas mb0 wrap-text">
@@ -183,7 +183,7 @@
                   {{- else -}}
                     {{- $urlOutput = $urlOutput | append $absUri -}}
                   {{- end -}}
-                  <div class="flex align-ic mbl mts">
+                  <div class="flex align-ifs mbl mts">
                     {{- partial "api/oas/endpoint-type" (dict "type" .method) -}}
                     <span class="flex-auto">
                       <pre class="flex align-ic pas mb0 wrap-text">

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -43,11 +43,13 @@ class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $curre
       {{- end -}}
 
       {{- with or (and (.apiData) (index .apiData .identifier)) $oasData -}}
-        <li>
-          <a href="#endpoints" data-list-item="endpoints">
-            <span data-hover="endpoints">Endpoints</span>
-          </a>
-        </li>
+        {{- with or .resources .paths -}}
+          <li>
+            <a href="#endpoints" data-list-item="endpoints">
+              <span data-hover="endpoints">Endpoints</span>
+            </a>
+          </li>
+        {{- end -}}
       {{- end -}}
 
       {{- with $oasData -}}


### PR DESCRIPTION
- Align request type at the top of the url box
- Not show endpoint section if there are none
- Some Warehousing related fixes
  - Move intro content into intro section
  - Use mb-table class
  - Remove custom "required" class, use mb-badges instead
  - Fix dead link and unncessary use of table tags
 
No content has been changed, just moved around.