### PR TITLE
Enable use of $ref in request examples

### DIFF
--- a/css/code.css
+++ b/css/code.css
@@ -32,6 +32,7 @@ p code {
   background-color: rgba(0, 0, 0, 0.08);
 }
 
+.schema__sublist label > code,
 .chroma > code {
   background-color: transparent;
 }

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -166,7 +166,11 @@
                   </div>
                   <div class="example-area">
                     {{- if .requestBody -}}
-                      {{- partial "api/oas/requestexample.html" (dict "requestBody" .requestBody "endpointId" $endpointId) -}}
+                      {{- if $components.examples -}}
+                        {{- partial "api/oas/requestexample-components.html" (dict "components" $components "requestBody" .requestBody "endpointId" $endpointId) -}}
+                      {{- else -}}
+                        {{- partial "api/oas/requestexample.html" (dict "requestBody" .requestBody "endpointId" $endpointId) -}}
+                      {{- end -}}
                     {{- end -}}
                     {{- if $components.examples -}}
                       {{- partial "api/oas/responseexample-components.html" (dict "components" $components "responses" .responses "endpointId" $endpointId) -}}

--- a/layouts/partials/api/oas/requestexample-components.html
+++ b/layouts/partials/api/oas/requestexample-components.html
@@ -1,0 +1,91 @@
+{{- $request := .requestBody -}}
+{{- $components := .components -}}
+{{- $endpointId := .endpointId -}}
+
+<h3>Request examples</h3>
+<div class="bg-gray3 rad-t2px mts" id="{{ $endpointId }}-request">
+  {{- with $request.content -}}
+    {{- $multiTypes := false -}}
+    {{- if gt (len .) 1 -}}
+      {{- $multiTypes = true -}}
+    {{- end }}
+    {{- $requestId := print $endpointId "-req" -}}
+
+    <div class="relative bg-gray4 example-wrap" data-example="{{ $endpointId }}">
+
+      {{/*  Make select if types > 1  */}}
+      {{- if $multiTypes -}}
+        <div class="mhm pvm">
+          <select data-sub-of="{{ $requestId }}" class="form__control w100p mb0 pas hauto" name="formats" aria-label="Select request format">
+            {{- range $mediaType, $_ := . -}}
+              {{- $typeClean := lower (anchorize $mediaType) -}}
+              <option value="{{ $typeClean }}">{{ $mediaType }}</option>
+            {{- end -}}
+          </select>
+        </div>
+      {{- end -}}
+
+      {{/*  Make examples according to number of types  */}}
+      {{- $exFormatInd := 0 -}}
+      {{- range $mediaType, $_ := . -}}
+        {{ $mediaType = lower (anchorize $mediaType) }}
+        {{- $format := "json" -}}
+        {{- if in $mediaType "xml" -}}
+          {{- $format = printf "xml" -}}
+        {{- end -}}
+        {{- $schema := .schema -}}
+
+        {{- if isset . "examples" -}}
+          <div class="" data-type="{{ $mediaType }}" {{ if ne $exFormatInd 0 }}hidden{{ end }}>
+            {{/*  make select if the request has multiple examples  */}}
+            {{- if gt (len .examples) 1 -}}
+              <div class="mhm {{ if not $multiTypes }}ptm{{ end }}">
+                <select class="form__control w100p mb0 pas hauto" name="{{ $mediaType }}-{{ $requestId }}" data-example-sub aria-label="Request examples {{ $format }}">
+                  {{- range $name, $obj := .examples -}}
+                    {{- with $obj.description -}}
+                      {{- $name = . -}}
+                    {{- end -}}
+                    {{- range $k, $_ := $obj -}}
+                      {{- if eq $k "$ref" -}}
+                        {{- $examplePath := path.Split . -}}
+                        {{- $exampleId := lower (printf "%s-%s" $requestId $examplePath.File) -}}
+                        <option value="{{ $exampleId }}">{{ $name }}</option>
+                      {{- end -}}
+                    {{- end -}}
+                  {{- end -}}
+                </select>
+              </div>
+            {{- end -}}
+
+            {{- $exInd := 0 -}}
+
+            {{/*  Make the actual examples with named components  */}}
+            {{- range .examples -}}
+              {{- range $k, $_ := . -}}
+                {{- if eq $k "$ref" -}}
+                  {{- $examplePath := path.Split . -}}
+                  {{- $exampleId := lower (printf "%s-%s" $requestId $examplePath.File) -}}
+                  {{- range $k, $_ := index $components.examples $examplePath.File -}}
+                    {{- if eq $k "description" -}}
+                      <p class="mlm">{{ . }}</p>
+                    {{- else -}}
+                      <div class="relative mtm" data-example-sub="{{$exampleId}}" {{ if ne $exInd 0 }}hidden{{ end }}>
+                        {{- if eq $format "xml" -}}
+                          {{- partial "api/oas/example-xml.html" (dict "schemaObj" $schema "name" "" "components" $components "exampleObj" . ) -}}
+                        {{- else -}}
+                          {{- partial "api/oas/example-json.html" (dict "key" $examplePath.File "ctx" . "schemas" $components.schemas) . -}}
+                        {{- end -}}
+                        {{- partial "api/oas/copy-btn.html" -}}
+                      </div>
+                    {{- end -}}
+                  {{- end -}}
+                  {{- $exInd = add $exInd 1 -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          </div>
+        {{- end -}}
+      {{- end -}}
+    </div>
+  {{- end -}}
+</div>

--- a/layouts/partials/api/oas/responseexample-components.html
+++ b/layouts/partials/api/oas/responseexample-components.html
@@ -4,7 +4,7 @@
 
 <h3>Response examples</h3>
 {{- $resInd := 0 -}}
-<div class="bg-gray3 rad-t2px mts sticky-6r" id="{{$endpointId}}-response">
+<div class="bg-gray3 rad-t2px mts sticky-6r" id="{{ $endpointId }}-response">
   {{- partial "api/oas/responsecode-btns.html" (dict "responses" .responses "endpointId" $endpointId) -}}
   {{- range $response, $_ := .responses -}}
     {{- with .content -}}
@@ -12,14 +12,14 @@
       {{- if gt (len .) 1 -}}
         {{- $multiTypes = true -}}
       {{- end }}
-
       {{- $responseId := print $endpointId "-" $response -}}
+
       <div class="relative bg-gray4 example-wrap" data-example="{{ $responseId }}" role="tabpanel" aria-labelledby="{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
 
         {{/*  Make select if types > 1  */}}
         {{- if $multiTypes -}}
           <div class="mhm pvm">
-            <select data-sub-of="{{ $responseId }}" class="form__control w100p mb0 pas hauto" name="formats" aria-label="Select format">
+            <select data-sub-of="{{ $responseId }}" class="form__control w100p mb0 pas hauto" name="formats" aria-label="Select response format">
               {{- range $mediaType, $_ := . -}}
                 {{- $typeClean := lower (anchorize $mediaType) -}}
                 <option value="{{ $typeClean }}">{{ $mediaType }}</option>
@@ -36,8 +36,8 @@
           {{- if in $mediaType "xml" -}}
             {{- $format = printf "xml" -}}
           {{- end -}}
-
           {{- $schema := .schema -}}
+
           {{- if isset . "examples" -}}
             <div class="" data-type="{{ $mediaType }}" {{ if ne $exFormatInd 0 }}hidden{{ end }}>
               {{/*  Make singular examples that are referenced using the response code in the components  */}}


### PR DESCRIPTION
It’s more or less the same as the response file, minus 20 lines of code because there is no need for different response codes in the request.

This is needed for the upcoming Shipping Guide OAS version.