### PR TITLE
Support request body schema

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -72,8 +72,59 @@
                     </div>
                     <p class="mbl text-heading">{{ .description | safeHTML }}</p>
 
+                    {{- with or .parameters .requestBody -}}
+                      <h3 class="mbm">Request</h3>
+                    {{- end -}}
+
                     {{- with .parameters -}}
                       {{- partial "api/oas/request-params.html" (dict "parameters" .) -}}
+                    {{- end -}}
+
+                    {{- with .requestBody -}}
+                      {{- $hasSchema := partial "api/oas/has-schema.html" . -}}
+
+                      {{- if $hasSchema -}}
+                        {{- with .content -}}
+                          {{- $multiSchema := false -}}
+                          {{- if gt (len .) 1 -}}
+                            {{- $multiSchema = true -}}
+                          {{- end -}}
+                          <div class="mb-border bb flex flex-wrap mbm pbxs align-ib gcm">
+                            <h4 class="fw600 mb0">Body schema</h4>
+                            {{- if $multiSchema -}}
+                            <div class="flex flex-wrap align-ib gcxs">
+                              <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
+                              <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control wauto maxw100p paxs hauto mb0" name="formats">
+                                {{- range $applicationType, $_ := . -}}
+                                  {{- $typeClean := lower (anchorize $applicationType) -}}
+                                  <option value="{{ $typeClean }}">
+                                    {{ $applicationType }}
+                                  </option>
+                                {{- end -}}
+                              </select>
+                            </div>
+                            {{- else -}}
+                              {{- range $applicationType, $_ := . -}}
+                                <p class="mb0 text-note">Media type: {{ $applicationType }}</p>
+                              {{- end -}}
+                            {{- end -}}
+                          </div>
+
+                          {{- range $application, $_ := . -}}
+                            {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
+                            {{- $format := $fTC.format -}}
+                            {{- $typeClean := $fTC.typeClean -}}
+
+                            <dl class="schema-type-container desc-list" data-type="{{ $typeClean }}">
+                              {{- if eq "xml" $format -}}
+                                {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
+                              {{- else -}}
+                                {{- partial "api/oas/request-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
+                              {{- end -}}
+                            </dl>
+                          {{- end -}}
+                        {{- end -}}
+                      {{- end -}}
                     {{- end -}}
 
                     {{- with .responses -}}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -115,7 +115,7 @@
                             {{- $format := $fTC.format -}}
                             {{- $typeClean := $fTC.typeClean -}}
 
-                            <dl class="schema-type-container desc-list" data-type="{{ $typeClean }}">
+                            <dl class="schema-type-container desc-list mbl" data-type="{{ $typeClean }}">
                               {{- if eq "xml" $format -}}
                                 {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
                               {{- else -}}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -139,73 +139,55 @@
                           {{- $responseColorBg = "bg-red1" -}}
                           {{- $responseColorTxt = "red-dark" -}}
                         {{- end -}}
-
                         {{- $description := .description -}}
-
-                        {{ $hasSchema := false }}
-                        {{- with .content -}}
-                          {{- range . -}}
-                            {{/*  since go template doesn’t have loop breaks  */}}
-                            {{- if not $hasSchema -}}
-                              {{- with .schema -}}
-                                {{- $hasSchema = true -}}
-                              {{- end -}}
-                            {{- end -}}
-                          {{- end -}}
-                        {{- end -}}
+                        {{- $hasSchema := partial "api/oas/has-schema.html" . -}}
 
                         {{- if $hasSchema -}}
                           {{- with .content -}}
-                          {{- $multiSchema := false -}}
-                          {{- if gt (len .) 1 -}}
-                            {{- $multiSchema = true -}}
-                          {{- end -}}
-                          <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
-                            <summary class="{{ $responseColorTxt }}" aria-label="Disclose response {{$response}} {{$description}} details">
-                              <span
-                              data-mybicon="mybicon-arrow-right"
-                              data-mybicon-width="16"
-                              data-mybicon-height="16"
-                              ></span>
-                              <span class="fw600">{{ $response }}</span> {{ $description }}
-                            </summary>
-                            <div class="bg-gray1 pam">
-                              <h4>Schema</h4>
-                              {{- if $multiSchema -}}
-                                <label class="form__label text-basic dib" for="{{$endpointId}}-{{$response}}">Media type:</label>
-                                <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{$endpointId}}-{{$response}}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
+                            {{- $multiSchema := false -}}
+                            {{- if gt (len .) 1 -}}
+                              {{- $multiSchema = true -}}
+                            {{- end -}}
+                            <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
+                              <summary class="{{ $responseColorTxt }}" aria-label="Disclose response {{ $response }} {{ $description }} details">
+                                <span
+                                data-mybicon="mybicon-arrow-right"
+                                data-mybicon-width="16"
+                                data-mybicon-height="16"
+                                ></span>
+                                <span class="fw600">{{ $response }}</span> {{ $description }}
+                              </summary>
+                              <div class="bg-gray1 pam">
+                                <h4 class="fw600">Schema</h4>
+                                {{- if $multiSchema -}}
+                                  <label class="form__label text-basic dib" for="{{ $endpointId }}-{{ $response }}">Media type:</label>
+                                  <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{ $endpointId }}-{{ $response }}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
+                                    {{- range $applicationType, $_ := . -}}
+                                      {{- $typeClean := lower (anchorize $applicationType) -}}
+                                      <option value="{{ $typeClean }}">
+                                        {{ $applicationType }}
+                                      </option>
+                                    {{- end -}}
+                                  </select>
+                                {{- else -}}
                                   {{- range $applicationType, $_ := . -}}
-                                    {{- $typeClean := lower (anchorize $applicationType) -}}
-                                    <option value='{{$typeClean}}'>
-                                      {{ $applicationType }}
-                                    </option>
+                                    <p>Media type: {{ $applicationType }}</p>
                                   {{- end -}}
-                                </select>
-                              {{- else -}}
-                                {{- range $applicationType, $_ := . -}}
-                                  <p>Media type: {{ $applicationType }}</p>
-                                {{- end -}}
-                              {{- end -}}
-
-                              {{- range $application, $_ := . -}}
-                                {{- $format := "" -}}
-                                {{- $typeClean := "" -}}
-                                {{- if or (in $application "json") (in $application "javascript") -}}
-                                  {{- $format = printf "json" -}}
-                                  {{- $typeClean = lower (anchorize $application) -}}
-                                {{- else if in $application "xml" -}}
-                                  {{- $format = printf "xml" -}}
-                                  {{- $typeClean = lower (anchorize $application) -}}
                                 {{- end -}}
 
-                                <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{$typeClean}}">
-                                  {{- if eq "xml" $format -}}
-                                    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
-                                  {{- else -}}
-                                    {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
-                                  {{- end -}}
-                                </dl>
-                              {{- end -}}
+                                {{- range $application, $_ := . -}}
+                                  {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
+                                  {{- $format := $fTC.format -}}
+                                  {{- $typeClean := $fTC.typeClean -}}
+
+                                  <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{ $typeClean }}">
+                                    {{- if eq "xml" $format -}}
+                                      {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                                    {{- else -}}
+                                      {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                                    {{- end -}}
+                                  </dl>
+                                {{- end -}}
                               </div>
                             </details>
                           {{- end -}}

--- a/layouts/partials/api/oas/format-type-clean.html
+++ b/layouts/partials/api/oas/format-type-clean.html
@@ -1,0 +1,12 @@
+{{- $format := "" -}}
+{{- $typeClean := "" -}}
+
+{{- if or (in .application "json") (in .application "javascript") -}}
+  {{- $format = printf "json" -}}
+  {{- $typeClean = lower (anchorize .application) -}}
+{{- else if in .application "xml" -}}
+  {{- $format = printf "xml" -}}
+  {{- $typeClean = lower (anchorize .application) -}}
+{{- end -}}
+
+{{ return dict "format" $format "typeClean" $typeClean }}

--- a/layouts/partials/api/oas/has-schema.html
+++ b/layouts/partials/api/oas/has-schema.html
@@ -1,0 +1,13 @@
+{{ $hasSchema := false }}
+{{ with .content }}
+  {{ range . }}
+    {{/*  since go template doesn’t have loop breaks  */}}
+    {{ if not $hasSchema }}
+      {{ with .schema }}
+        {{ $hasSchema = true }}
+      {{ end }}
+    {{ end }}
+  {{ end }}
+{{ end }}
+
+{{ return $hasSchema}}

--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -8,7 +8,6 @@
 {{- end -}}
 {{- $paramArr = uniq $paramArr -}}
 
-<h3 class="mbm">Request</h3>
 {{- range $paramArr -}}
   {{- $paramType := . -}}
   <h4 class="mb-border bb pbxs fw600"><span class="ttc">{{ $paramType }}</span> parameters</h4>

--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -1,0 +1,160 @@
+{{- $schemaObj := .schemaObj -}}
+{{- $name := .name -}}
+{{- $required := .required -}}
+{{- $components := .components -}}
+{{- $endpointId := .endpointId -}}
+{{- $uniqueId := "" -}}
+{{- $recLevel := add .recLevel 1 -}}
+{{- $isOneOf := "" -}}
+{{- with .isOneOf }}
+  {{- $isOneOf = . -}}
+{{- end -}}
+{{- $parent := "" -}}
+{{- with .parent -}}
+  {{- $parent = . -}}
+{{- end -}}
+{{- $oneOfInd := 0 -}}
+{{- with .oneOfInd -}}
+  {{- $oneOfInd = . -}}
+{{- end -}}
+
+{{/*  If there’s a ref, pass the destination data again  */}}
+{{- $isRef := "false" -}}
+{{- range $key, $_ := $schemaObj -}}
+{{- if eq $key "$ref" -}}
+  {{- $isRef = true -}}
+    {{- $schemaPath := path.Split . -}}
+    {{- $schema := index $components.schemas $schemaPath.File -}}
+    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  If object or array, render and pass properties or items again  */}}
+{{- if or (eq $schemaObj.type "object") (eq $schemaObj.type "array") -}}
+  {{- with $schemaObj.xml.name -}}
+    {{- $name = . -}}
+  {{- end -}}
+  {{- $levelName := printf "%s-%s-%s" $endpointId (anchorize $name) "requestxml" -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
+  
+  {{/*  Render oneOf radio inputs  */}}
+  {{- if eq $isOneOf "radio" -}}
+    <div>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+    </div>
+  {{/*  Loop oneOf data  */}}
+  {{- else if eq $isOneOf "data" -}}
+    {{- with $schemaObj.properties -}}
+      <dl id="tab-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+        {{- range $key, $_ := . -}}
+          {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+        {{- end -}}
+      </dl>
+    {{- end -}}
+  {{ else }}
+    <div class="mb-border bb bw1 mbs">
+      <div class="flex flex-wrap align-ifs pbs">
+        <dt>
+          {{- if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.items) -}}
+            {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+          {{- else -}}
+            <code class="mls">{{ $name }}</code>
+          {{- end -}}
+          {{- if $required -}}
+            <div class="plm mls lh-solid param-required text-note">Required</div>
+          {{- end -}}
+        </dt>
+        <dd class="ptxs pls">
+          {{- with $schemaObj.description -}}
+            {{ . }}
+          {{- end -}}
+          <div class="gray text-note">
+            {{- $schemaObj.type -}}
+            {{- if $schemaObj.xml.wrapped -}}
+              {{- print " wrapped" -}}
+            {{- end -}}
+          </div>
+        </dd>
+      </div>
+      {{/*  object  */}}
+      {{- with $schemaObj.properties -}}
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
+          <dl class="pls">
+            {{- range $key, $_ := . -}}
+              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+            {{- end -}}
+          </dl>
+        </dd>
+      {{- end -}}
+      {{/*  oneOf object  */}}
+      {{- with $schemaObj.oneOf -}}
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
+          <form>
+            <fieldset class="mlxs mbs pls pbs">
+              <legend class="fw600 pts mbxs">oneOf</legend>
+              <div class="flex flex-wrap gcm" role="tabpanel">
+                {{- range $key, $_ := . -}}
+                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
+                  {{- $oneOfInd = add $oneOfInd 1 -}}
+                {{- end -}}
+              </div>
+            </fieldset>
+          </form>
+          {{- $oneOfInd = 0 -}}
+          {{- range $key, $_ := . -}}
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "data" "oneOfInd" $oneOfInd) -}}
+            {{- $oneOfInd = add $oneOfInd 1 -}}
+          {{- end -}}
+        </dd>
+      {{- end -}}
+      {{/*  array  */}}
+      {{- with $schemaObj.items -}}
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
+          <dl class="pls">
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" "" "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          </dl>
+        </dd>
+      {{- end -}}
+    </div>
+  {{ end }}
+
+{{/*  If neither obj, arr or ref, render the item */}}
+{{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}
+  {{- with $schemaObj.xml.name -}}
+    {{- $name = . -}}
+  {{- end -}}
+  <div class="mb-border bb bw1 mbs pbs pls">
+    <div class="flex flex-wrap align-ifs">
+      <dt>
+        <code>{{ $name }}</code>
+        {{- if $required -}}
+          <div class="lh-tight param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+          {{- with $schemaObj.format -}}
+            {{- printf " <%s>" . -}}
+          {{- end -}}
+          {{- if $schemaObj.xml.attribute -}}
+            {{- print " attribute" -}}
+          {{- end -}}
+        </div>
+        {{- with $schemaObj.enum -}}
+          <dl>
+            <dt><span class="text-note fw600">Enum</span></dt>
+            {{- range . -}}
+              <dd><code class="wrap-text">{{ . }}</code></dd>
+            {{- end -}}
+          </dl>
+        {{- end -}}
+      </dd>
+    </div>
+  </div>
+{{- end -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -1,0 +1,264 @@
+{{- $schemaObj := .schemaObj -}}
+{{- $name := .name -}}
+{{- $components := .components -}}
+{{- $required := .required -}}
+{{- $endpointId := .endpointId -}}
+{{- $uniqueId := "" -}}
+{{- $recLevel := add .recLevel 1 -}}
+{{- $oneOf := "" -}}
+{{- with .oneOf }}
+  {{- $oneOf = . -}}
+{{- end -}}
+{{- $parent := "" -}}
+{{- with .parent -}}
+  {{- $parent = . -}}
+{{- end -}}
+{{- $oneOfInd := 0 -}}
+{{- with .oneOfInd -}}
+  {{- $oneOfInd = . -}}
+{{- end -}}
+
+{{/*  If there’s a ref, pass the destination data again  */}}
+{{- $isRef := "false" -}}
+{{- range $key, $_ := $schemaObj -}}
+  {{- if eq $key "$ref" -}}
+    {{- $isRef = true -}}
+    {{- $schemaPath := path.Split . -}}
+    {{- $schema := index $components.schemas $schemaPath.File -}}
+    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+  {{- end -}}
+{{- end -}}
+
+{{/*  If object and first level, skip  */}}
+{{- if and (eq $schemaObj.type "object") (lt $recLevel 3) -}}
+  {{- with $schemaObj.properties -}}
+    {{- range $key, $_ := . -}}
+      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- end -}}
+  {{- end -}}
+
+  {{- else if $schemaObj.oneOf -}}
+    {{- with $schemaObj.oneOf -}}
+      <form>
+        <fieldset class="mlxs mbs pls pbs">
+          <legend class="fw600 pts mbxs">oneOf</legend>
+          <div class="flex flex-wrap gcm" role="tabpanel">
+            {{- range . -}}
+              {{- range . -}}
+                {{- $schemaPath := path.Split . -}}
+                {{- $schema := index $components.schemas $schemaPath.File -}}
+                {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
+              {{ end }}
+              {{- $oneOfInd = add $oneOfInd 1 -}}
+            {{- end -}}
+          </div>
+        </fieldset>
+      </form>
+      {{- $oneOfInd = 0 -}}
+      {{- range . -}}
+        {{- range . -}}
+          {{- $schemaPath := path.Split . -}}
+          {{- $schema := index $components.schemas $schemaPath.File -}}
+          {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
+          {{- $oneOfInd = add $oneOfInd 1 -}}
+        {{- end -}}
+      {{- end -}}
+    {{ end }} 
+
+{{/*  If object, render and pass properties  */}}
+{{- else if eq $schemaObj.type "object" -}}
+  {{- $levelName := printf "%s-%s-%s" $endpointId (anchorize $name) "requestjson" -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
+
+  {{/*  Render oneOf radio inputs  */}}
+  {{- if eq $oneOf "radio" -}}
+    <div>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+    </div>
+    {{/*  Loop oneOf data  */}}
+  {{- else if eq $oneOf "data" -}}
+    {{- with $schemaObj.properties -}}
+      <dl id="tab-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+        {{- range $key, $_ := . -}}
+          {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+        {{- end -}}
+      </dl>
+    {{- end -}}
+  {{- else -}}
+    <div class="mb-border bb bw1 mbs">
+      <div class="flex flex-wrap align-ifs pbs">
+        <dt>
+          {{- with $schemaObj.properties -}}
+            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+          {{- else -}}
+            <code class="mls">{{ $name }}</code>
+          {{- end -}}
+          {{- if $required -}}
+            <div class="plm mls lh-solid param-required text-note">Required</div>
+          {{- end -}}
+        </dt>
+        <dd class="ptxs pls">
+          {{- with $schemaObj.description -}}
+            {{ . }}
+          {{- end -}}
+          <div class="gray text-note">
+            {{- $schemaObj.type -}}
+          </div>
+        </dd>
+      </div>
+
+      {{- with $schemaObj.properties -}}
+        <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
+          <dl class="pls">
+            {{- range $key, $_ := . -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+            {{- end -}}
+          </dl>
+        </dd>
+      {{- end -}}
+    </div>
+  {{- end -}}
+
+{{/*  If array, render and pass items  */}}
+{{- else if eq $schemaObj.type "array" -}}
+  {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
+  {{- $uniqueId = slicestr $generateId 0 15 -}}
+  {{- $levelId := printf "%s-%s-%s" $endpointId (anchorize $name) $uniqueId -}}
+
+  {{/*  If items have children, ref has properties or oneOf  */}}
+  {{- $hasChildren := false -}}
+  {{- with $schemaObj.items -}}
+    {{- $hasChildren = true -}}
+    {{- range $key, $_ := . -}}
+      {{- if or (eq $key "type") (eq $key "format") -}}
+        {{- $hasChildren = false -}}
+      {{- end -}}
+      {{- if eq $key "$ref" -}}
+        {{- $hasChildren = false -}}
+        {{- $schemaPath := path.Split . -}}
+        {{- $schema := index $components.schemas $schemaPath.File -}}
+        {{- with $schema.properties -}}
+          {{- $hasChildren = true -}}
+        {{- end -}}
+        {{- with $schema.oneOf -}}
+          {{- $hasChildren = true -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
+
+  <div class="mb-border bb bw1 mbs">
+    <div class="flex flex-wrap align-ifs pbs">
+      <dt>
+        {{- if $hasChildren -}}
+          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+        {{- else -}}
+          <code class="mls">{{ $name }}</code>
+        {{- end -}}
+        {{- if $required -}}
+          <div class="plm mls lh-solid param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="ptxs pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
+
+        {{/*  See what it’s an array of */}}
+        {{- $schemaType := $schemaObj.type -}}
+        {{- $schemaFormat := "" -}}
+        {{- with $schemaObj.items -}}
+          {{- range $key, $_ := . -}}
+            {{- if eq $key "$ref" -}}
+              {{- $schemaPath := path.Split . -}}
+              {{- $schema := index $components.schemas $schemaPath.File -}}
+              {{- with $schema.type -}}
+                {{- $schemaType = printf "array of %ss" . -}}
+              {{- end -}}
+            {{- else -}}
+              {{- if eq $key "format" -}}
+                {{- $schemaFormat = printf " <%s>" . -}}
+              {{- end -}}
+              {{- if eq $key "type" -}}
+                {{- $schemaType = printf "array of %ss%s" . $schemaFormat -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaType -}}
+        </div>
+      </dd>
+    </div>
+
+    {{- with $schemaObj.items -}}
+      <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
+        {{- $isItemRef := false -}}
+        {{- $isItemOneOfRef := false -}}
+        {{/*  Check for oneOf  */}}
+        {{- range $key, $_ := . -}}
+          {{- if eq $key "$ref" -}}
+            {{- $schemaPath := path.Split . -}}
+            {{- $schema := index $components.schemas $schemaPath.File -}}
+            {{- if $schema.oneOf -}}
+              {{ $isItemOneOfRef = true }}
+                {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+        {{- if not $isItemOneOfRef -}}
+          <dl class="pls">
+            {{- range $key, $_ := . -}}
+              {{- if eq $key "$ref" -}}
+                {{- $isItemRef = true -}}
+                {{- $schemaPath := path.Split . -}}
+                {{- $schema := index $components.schemas $schemaPath.File -}}
+                {{- $items := $schema.properties -}}
+                {{- range $key, $_ := $items -}}
+                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+            {{- if not $isItemRef -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" "" "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+            {{- end -}}
+          </dl>
+        {{- end -}}
+      </dd>
+    {{- end -}}
+  </div>
+
+{{/*  If neither obj, arr or ref, render the item */}}
+{{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}
+  <div class="mb-border bb bw1 mbs pbs pls">
+    <div class="flex flex-wrap align-ifs">
+      <dt>
+        <code>{{ $name }}</code>
+        {{- if $required -}}
+          <div class="lh-tight param-required text-note">Required</div>
+        {{- end -}}
+      </dt>
+      <dd class="pls">
+        {{- with $schemaObj.description -}}
+          {{ . }}
+        {{- end -}}
+        <div class="gray text-note">
+          {{- $schemaObj.type -}}
+          {{- with $schemaObj.format -}}
+            {{- printf " <%s>" . -}}
+          {{- end -}}
+        </div>
+        {{- with $schemaObj.enum -}}
+          <dl>
+            <dt><span class="text-note fw600">Enum</span></dt>
+            {{- range . -}}
+              <dd><code class="wrap-text">{{ . }}</code></dd>
+            {{- end -}}
+          </dl>
+        {{- end -}}
+      </dd>
+    </div>
+  </div>
+{{- end -}}

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -42,6 +42,7 @@
                 <p class="mbl text-heading">{{ .description | safeHTML }}</p>
 
                 {{- with .parameters -}}
+                  <h3 class="mbm">Request</h3>
                   {{- partial "api/oas/request-params.html" (dict "parameters" .) -}}
                 {{- end -}}
 
@@ -57,20 +58,8 @@
                       {{- $responseColorBg = "bg-red1" -}}
                       {{- $responseColorTxt = "red-dark" -}}
                     {{- end -}}
-
                     {{- $description := .description -}}
-
-                    {{ $hasSchema := false }}
-                    {{- with .content -}}
-                      {{- range . -}}
-                        {{/*  since go template doesn’t have loop breaks  */}}
-                        {{- if not $hasSchema -}}
-                          {{- with .schema -}}
-                            {{- $hasSchema = true -}}
-                          {{- end -}}
-                        {{- end -}}
-                      {{- end -}}
-                    {{- end -}}
+                    {{- $hasSchema := partial "api/oas/has-schema.html" . -}}
 
                     {{- if $hasSchema -}}
                       {{- with .content -}}
@@ -268,7 +257,7 @@
                     {{- $uriParameters = $uriParameters | append . -}}
                   {{- end -}}
                   {{- if $otherUriParamsMediaType -}}
-                    {{- partial "api/namedparamsdl.html" (dict "context" . "includeParams" $uriParameters "title" "URI param" ) -}}
+                    {{- partial "api/namedparamsdl.html" (dict "context" . "includeParams" $uriParameters "title" "URI" ) -}}
                   {{- end -}}
 
                   {{/* For each endpoint: List all header params */}}
@@ -278,7 +267,7 @@
 
                   {{/* For each endpoint: List all query params */}}
                   {{- if $hasMethodQueryParams -}}
-                    {{- partial "api/namedparamsdl.html" (dict "context" . "includeParams" $methodQueryParams "title" "Query param") -}}
+                    {{- partial "api/namedparamsdl.html" (dict "context" . "includeParams" $methodQueryParams "title" "Query") -}}
                   {{- end -}}
 
                   {{/* For each endpoint: List XML request body params */}}


### PR DESCRIPTION
More or less the same templates as for the response, but without the response code levels and the background. They could possibly be using the same template with some reworking, so I’m adding that to the card for cleanup that we have.

Turns out that Modify Shipment API has had this all along, so that gives a small example. Otherwise, I’ve tested the switching between media types and it looks like this for Shipping Guide:
<img width="767" alt="Screenshot 2022-11-17 at 21 04 37" src="https://user-images.githubusercontent.com/9307503/202549776-5a994be3-1d7b-4351-a54f-cd7bbcd90da0.png">
<img width="772" alt="Screenshot 2022-11-17 at 21 04 54" src="https://user-images.githubusercontent.com/9307503/202549770-1650f01f-c18f-4121-af6e-96cea4d41fed.png">

