### PR TITLE
Fix xml example problem for shipping guide docs

### DIFF
--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -99,8 +99,16 @@
       {{ with $schemaObj.xml.name }}
         {{ $name = . }}
       {{ end }}
-      {{ $xmlLine = printf "%s<%s>%s</%s>" $xmlLine $name (string $value) $name }}
-      {{ $XML = println (printf "%s%s" $XML $xmlLine) }}
+      {{ if reflect.IsSlice $value }}
+        {{ range $value }}
+          {{ $value = . }}
+          {{ $xmlLine = printf "%s<%s>%s</%s>" $indent $name (string $value) $name  }}
+          {{ $XML = println (printf "%s%s" $XML $xmlLine) }}
+        {{ end }}
+      {{ else }}
+        {{ $xmlLine = printf "%s<%s>%s</%s>" $xmlLine $name (string $value) $name }}
+        {{ $XML = println (printf "%s%s" $XML $xmlLine) }}
+      {{ end }}
     {{ end }}
   {{ end }}
 {{ end }}


### PR DESCRIPTION
Setting `string` on `$value` assumes that the `$value` is a single value, like a string or integer. After some investigations I found out that the `$value` was suddenly an array in a case, so to fix the issue we can check if `$value` is an array, loop over it, and output each value from the array as a xml line. Otherwise, just output the xml line as before.