### PR TITLE
Enable api docs subpages with subnavigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,30 @@ oas: {Link to OAS JSON, typically outputted by Swagger}
 ---
 ```
 
+## Adding subpages to an API
+
+If the API documentation has many special topics and much text content before the endpoint listing, it can be a good idea to split the topics into subpages. This can be enabled by renaming the index file to _index and making a folder for the subpages. Navigation and listing on the main page is solved automatially by adding the following to the frontmatter of the index page:
+
+```
+subpages:
+  title: Special topics {this will be the title in the main api page and in the sidemenu}
+```
+
+And to the subpages’ frontmatter:
+```
+---
+title: {title that appears at the top of the page}
+layout: api
+notanapi: true
+menu:
+  apidocs:
+    identifier: {unique id, for instance apifolder+pagename}
+    title: {title that appears in the sidemenu, usually the same as the page title}
+    parent: {parent’s identifier value, usually the api folder name}
+weight: {menu position within the subpage structure}
+---
+```
+
 ## Updating Booking & SG and VAS tables
 
 1. Clone and make changes in

--- a/content/_index.html
+++ b/content/_index.html
@@ -1,6 +1,7 @@
 ---
 title: Bring Developer
 layout: frontpage
+notanapi: true
 hero: Integrate your systems with Bring
 start:
   Developing an e-commerce site? Or dealing with logistics software in the

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -35,6 +35,10 @@
   text-decoration: underline;
 }
 
+.dev-docscontent__backnav {
+  padding: 0 6vw 2rem;
+}
+
 .dev-docscontent__section {
   margin-bottom: 3rem;
   padding: 0 6vw 1rem;
@@ -114,6 +118,10 @@
 
   .dev-docscontent h1 {
     padding-left: 2rem;
+  }
+
+  .dev-docscontent__backnav {
+    padding: 0 2rem 2rem 2rem;
   }
 
   .dev-docscontent__section {

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -28,7 +28,17 @@
         {{- if and (isset .Params "apidoc") (isset .Params "apiresource") -}}
           {{- partial "api/guideapiresource.html" . -}}
         {{- end -}}
-        {{- .Content -}}
+
+        {{ with .Content }}
+          {{- if in (string .) "dev-docscontent__section" -}}
+            {{- . -}}
+          {{- else -}}
+            <section class="dev-docscontent__section">
+              {{- . -}}
+            </section>
+          {{- end -}}
+        {{ end }}
+
         {{- if (in .CurrentSection "revision-history") -}}
           {{- partial "api/changelog.html" . -}}
         {{- end -}}

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -7,6 +7,11 @@
 
   {{- if (eq $notAnApi true) -}}
     <main id="main" class="dev-docscontent w100p {{ $maxwidth }}">
+      {{- with $.Parent.Params.subpages -}}
+        <div class="dev-docscontent__backnav">
+          <a href="{{ $.Parent.Permalink }}">&larr; Back to {{ $.Parent.Title }}</a>
+        </div>
+      {{- end -}}
       <article>
         <h1>
           {{- .Title -}}
@@ -33,6 +38,11 @@
           </section>
         {{- end -}}
       </article>
+      {{- with $.Parent.Params.subpages -}}
+        <div class="dev-docscontent__backnav">
+          <a href="{{ $.Parent.Permalink }}">&larr; Back to {{ $.Parent.Title }}</a>
+        </div>
+      {{- end -}}
     </main>
 
   {{- else if in .Title "Order Management" -}}

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -47,6 +47,20 @@
         {{- end -}}
       </div>
     {{- end -}}
+    {{- with $.Params.subpages -}}
+      {{- with .title }}
+        <h2 class="dev-anchored" id="{{ . | urlize }}">
+          {{- . -}}
+        </h2>
+      {{- end -}}
+      {{- range $.Menus -}}
+        <ul>
+          {{- range .Children -}}
+            <li><a href="{{ .URL }}">{{ .Title }}</a></li>
+          {{- end -}}
+        </ul>
+      {{- end -}}
+    {{- end -}}
     {{- range $.Params.documentation -}}
       {{- with .title }}
         <h2 class="dev-anchored" id="{{ . | urlize }}">

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -16,7 +16,6 @@
   {{- $target = "target=\"_blank\" rel=\"noopener noreferrer\"" -}}
   {{- $iconEx = "<span data-mybicon='mybicon-external-link' data-mybicon-class='mls dev-sidemenu__icon' data-mybicon-width='14' data-mybicon-height='14'></span>" -}}
 {{- end -}}
-{{ .Params }}
 
 <li
   class="dev-sidemenu__level1 {{ if or ($currentPage.IsMenuCurrent $currentMenu $currentMenuItem) ($currentPage.IsMenuCurrent $currentMenu $currentMenuItem) ($currentPage.HasMenuCurrent $currentMenu $currentMenuItem) }}active{{ end }}"
@@ -164,14 +163,16 @@
         {{- range .paths -}}
           {{- range $k, $v := . -}}
             {{- $method := $k -}}
-            {{- $endpointId := (printf "%s-%s" .summary $method) | anchorize -}}
-            <li>
-              <a href="#{{ $endpointId }}" data-list-item="{{ $endpointId }}">
-                <span data-hover="{{ .summary }}">
-                  {{- .summary -}}
-                </span>
-              </a>
-            </li>
+            {{- with .summary -}}
+              {{- $endpointId := (printf "%s-%s" . $method) | anchorize -}}
+              <li>
+                <a href="#{{ $endpointId }}" data-list-item="{{ $endpointId }}">
+                  <span data-hover="{{ . }}">
+                    {{- . -}}
+                  </span>
+                </a>
+              </li>
+            {{- end -}}
           {{- end -}}
         {{- end -}}
       {{- end -}}
@@ -197,12 +198,9 @@
 
       {{- if and (eq (getenv "HUGO_ENV") "production") (isset $currentPage.Params "disqus_identifier") -}}
         <li>
-          <a href="#api-support">
-            API support
-          </a>
+          <a href="#api-support"> API support </a>
         </li>
       {{- end -}}
-
     </ul>
   {{- end -}}
 </li>

--- a/layouts/partials/sidemenuitem.html
+++ b/layouts/partials/sidemenuitem.html
@@ -19,11 +19,119 @@
 {{ .Params }}
 
 <li
-class="dev-sidemenu__level1 {{ if $currentPage.IsMenuCurrent $currentMenu $currentMenuItem }}active{{ end }}"
+  class="dev-sidemenu__level1 {{ if or ($currentPage.IsMenuCurrent $currentMenu $currentMenuItem) ($currentPage.IsMenuCurrent $currentMenu $currentMenuItem) ($currentPage.HasMenuCurrent $currentMenu $currentMenuItem) }}active{{ end }}"
 >
-  <a href="{{ .url }}" class="dev-sidemenu__apititle" {{ $target | safeHTMLAttr }}>{{ .pageTitle }}{{ safeHTML $iconEx }}</a>
-  {{- if $currentPage.IsMenuCurrent $currentMenu $currentMenuItem -}}
+  <a
+    href="{{ .url }}"
+    class="dev-sidemenu__apititle"
+    {{ $target | safeHTMLAttr }}
+    >{{ .pageTitle }}{{ safeHTML $iconEx }}</a
+  >
+  {{- if or ($currentPage.IsMenuCurrent $currentMenu $currentMenuItem) ($currentPage.HasMenuCurrent $currentMenu $currentMenuItem) -}}
     <ul class="dev-sidemenu__sublist">
+
+      {{/*  Generate submenu when on subpage TODO: reuse existing code  */}}
+      {{- with $currentPage.Params.subpages -}}
+        {{- with .title -}}
+          <li>
+            <a href="#{{ . | anchorize }}" data-list-item="{{ . | anchorize }}">
+              <span data-hover="{{ . }}">{{ . }}</span>
+            </a>
+          </li>
+        {{- end -}}
+      {{- end -}}
+
+      {{- $currentParent := .Parent -}}
+      {{- $currentId := "" -}}
+      {{- range $currentMenuItem.Children -}}
+        {{- $currentParent = .Parent -}}
+      {{- end -}}
+      {{- range $currentPage.Menus -}}
+        {{- $currentId = .Identifier -}}
+      {{- end -}}
+
+      {{- if ne $currentParent $currentId -}}
+        {{- with $currentPage.Parent.Params.subpages -}}
+          {{- with .title -}} 
+            <li>
+              <a
+                href="../#{{ . | anchorize }}"
+                data-list-item="{{ . | anchorize }}"
+              >
+                <span data-hover="{{ . }}">{{ . }}</span>
+              </a>
+            </li>
+          {{- end -}}
+
+          <ul class="dev-sidemenu__sublist text-note">
+            {{- range $currentMenuItem.Children -}}
+              <li><a href="{{ .URL }}" class="{{ if eq .Identifier $currentId }} active {{ end }}">{{ .Title }}</a></li>
+            {{- end -}}
+          </ul>
+
+          {{- range $currentPage.Parent.Params.documentation -}}
+            {{- with .title -}}
+              <li>
+                <a
+                  href="../#{{ . | anchorize }}"
+                  data-list-item="{{ . | anchorize }}"
+                >
+                  <span data-hover="{{ . }}">{{ . }}</span>
+                </a>
+              </li>
+            {{- end -}}
+          {{- end -}}
+
+          {{- with $currentPage.Parent.Params.guides -}}
+            <li>
+              <a href="../#tips-and-guides" data-list-item="tips-and-guides">
+                <span data-hover="Tips and guides">Tips and guides</span>
+              </a>
+            </li>
+          {{- end -}}
+
+          {{ $oasData := "" }}
+          {{- with $currentPage.Parent.Params.oas -}}
+            {{- $oasData = getJSON . -}}
+          {{ end }}
+
+          {{ with $oasData }}
+            {{- with .paths -}}
+              <li>
+                <a href="../#endpoints" data-list-item="endpoints">
+                  <span data-hover="endpoints">Endpoints</span>
+                </a>
+              </li>
+
+              {{- range . -}}
+                {{- range $k, $v := . -}}
+                  {{- $method := $k -}}
+                  {{- with .summary -}}
+                    {{- $endpointId := (printf "%s-%s" . $method) | anchorize -}}
+                    <li>
+                      <a
+                        href="../#{{ $endpointId }}"
+                        data-list-item="{{ $endpointId }}"
+                      >
+                        <span data-hover="{{ . }}">
+                          {{- . -}}
+                        </span>
+                      </a>
+                    </li>
+                  {{- end -}}
+                {{- end -}}
+              {{- end -}}
+            {{- end -}}
+          {{- end -}}
+
+          {{- if and (eq (getenv "HUGO_ENV") "production") (isset $currentPage.Params "disqus_identifier") -}}
+            <li>
+              <a href="../#api-support"> API support </a>
+            </li>
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+
       {{- range $currentPage.Params.documentation -}}
         {{- with .title -}}
           <li>


### PR DESCRIPTION
This creates a subnav in the sidemenu, a backward nav on the subpages and a subpage list on the main API page. This is done by adding frontmatter as described in the readme.

Not completely satisfied with the duplication of the menu code, but it’s what we have time for now – will add a cleanup to a card.

The "bookings" API is just a test. We don't have any data on this in master yet, only a screenshot.

![Screenshot 2022-12-02 at 12 50 52](https://user-images.githubusercontent.com/9307503/205287106-ceb4fcfd-e875-4e0b-96ff-a155ae1e14e9.png)
