### PR TITLE
Example tuning

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -153,6 +153,10 @@
   width: 38%;
 }
 
+.example-area > div {
+  margin-bottom: clamp(1.2rem, calc(1rem + 1.2vw), 3rem);
+}
+
 div.response {
   padding: 0.5rem 0.5rem 0.5rem 1.8em;
 }

--- a/css/sidemenu.css
+++ b/css/sidemenu.css
@@ -1,8 +1,12 @@
 .dev-sidemenu {
-  padding-top: 1rem;
+  padding-top: 3rem;
   padding-bottom: 1rem;
   width: 18rem;
   align-self: flex-start;
+}
+
+.dev-sidemenu--front {
+  padding-top: 6vmin;
 }
 
 .dev-sidemenu__title {

--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -221,7 +221,7 @@
                     {{- with .requestBody.content -}}
                       {{- partial "api/oas/requestexample.html" (dict "ctx" . "endpointId" $endpointId "components" $components) -}}
                     {{- end -}}
-                    {{ with .responses }}
+                    {{- with .responses -}}
                       {{- partial "api/oas/responseexample.html" (dict "ctx" . "endpointId" $endpointId "components" $components) -}}
                     {{- end -}}
                   </div>

--- a/layouts/partials/api/oas/requestexample.html
+++ b/layouts/partials/api/oas/requestexample.html
@@ -103,7 +103,7 @@
               {{- if not $multiExamples -}}
                 {{- with $exampleObject.description -}}
                   {{- if and (ne (. | lower) "example") (ne (. | lower) "request") -}}
-                    <h4 class="mb0 phm pvm fw600 bg-gray3">{{ . }}</h4>
+                    <h4 class="mb0 phm pvs fw600 text-note ttu bg-gray4">{{ . }}</h4>
                   {{- end -}}
                 {{- end -}}
               {{- end -}}

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -122,7 +122,7 @@
                   {{- if not $multiExamples -}}
                     {{- with $exampleObject.description -}}
                       {{- if and (ne (. | lower) "example") (ne (. | lower) "response") -}}
-                        <h4 class="mb0 phm pvm fw600 bg-gray3">{{ . }}</h4>
+                        <h4 class="mb0 phm pvs fw600 text-note ttu bg-gray4">{{ . }}</h4>
                       {{- end -}}
                     {{- end -}}
                   {{- end -}}

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -286,20 +286,45 @@
                   {{/* For each endpoint: Response */}}
                   {{- with .responses -}}
                     <h3>Response examples</h3>
-                    <p class="fw600 mb0">200</p>
-                    {{- range . -}}
-                      {{- $code := .code -}}
-                      {{- with .description -}}
-                        {{- if in (string .) "\n\n" -}}
-                          {{ . | markdownify }}
-                        {{- else -}}
-                          <p>{{ . | markdownify }}</p>
+                    <div class="bg-gray3 rad-t2px mts sticky-6r" id="{{$endpointId}}-response">
+                      <div class="pam flex flex-wrap" role="tablist">
+                        {{- $ariaSelected := true -}}
+                        {{- range $response, $_ := . -}}
+                          {{- $responseColor := "" -}}
+                          {{- if and (ge $response 200) (lt $response 300) -}}
+                            {{- $responseColor = "txt-success" -}}
+                          {{- else if ge $response 300 -}}
+                            {{- $responseColor = "txt-error" -}}
+                          {{- end -}}
+                          {{- $responseId := print $endpointId "-" $response -}}
+                          <button
+                            type="button"
+                            name="{{$endpointId}}-response"
+                            data-example="{{$responseId}}"
+                            class="btn-link--dark mrs {{$responseColor}}"
+                            aria-label="Response code {{$response}}"
+                            aria-selected="{{$ariaSelected}}"
+                            role="tab"
+                            id="{{$responseId}}">
+                            {{ $response }}
+                          </button>
+                          {{- $ariaSelected = false -}}
+                        {{- end -}}
+                      </div>
+                      {{- range . -}}
+                        {{- $code := .code -}}
+                        {{- with .description -}}
+                          {{- if in (string .) "\n\n" -}}
+                            {{ . | markdownify }}
+                          {{- else -}}
+                            <p>{{ . | markdownify }}</p>
+                          {{- end -}}
+                        {{- end -}}
+                        {{- range .body -}}
+                          {{- partial "api/tabssoap.html" (dict "context" . "endpointName" $displayName "code" $code "types" $types ) -}}
                         {{- end -}}
                       {{- end -}}
-                      {{- range .body -}}
-                        {{- partial "api/tabssoap.html" (dict "context" . "endpointName" $displayName "code" $code "types" $types ) -}}
-                      {{- end -}}
-                    {{- end -}}
+                    </div>
                   {{- end -}}
                 </div>
               {{- end -}}

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -124,7 +124,7 @@
                 {{- with .requestBody.content -}}
                   {{- partial "api/oas/requestexample.html" (dict "ctx" . "endpointId" $endpointId "components" $components) -}}
                 {{- end -}}
-                {{ with .responses }}
+                {{- with .responses -}}
                   {{- partial "api/oas/responseexample.html" (dict "ctx" . "endpointId" $endpointId "components" $components) -}}
                 {{- end -}}
               </div>

--- a/layouts/partials/api/tabssoap.html
+++ b/layouts/partials/api/tabssoap.html
@@ -15,7 +15,7 @@
   {{- $exId := "" -}}
   {{- $showResponse := false -}}
 
-  <div class="bg-gray3 rad-t2px mts">
+  <div class="bg-gray3 rad-t2px">
     <div class="relative bg-gray4 example-wrap" data-example="{{ print $endpointId $formatFull }}">
       {{ if gt (len .examples) 1 }}
         <div class="mhm pvm">

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -1,7 +1,7 @@
 {{- $currentPage := . -}}
 {{- $iconExHtml := "<span data-mybicon='mybicon-external-link' data-mybicon-class='mls dev-sidemenu__icon' data-mybicon-width='14' data-mybicon-height='14'></span>" -}}
 
-<nav class="dev-sidemenu" aria-label="Section">
+<nav class="dev-sidemenu {{ if .IsHome }}dev-sidemenu--front{{ end }}" aria-label="Section">
   {{- if or (eq .Section "api") (.IsHome) -}}
     <ul class="dev-sidemenu__list dev-sidemenu__separator">
       {{- $len := (len .Site.Menus.api) -}}


### PR DESCRIPTION
- Make singular example title background dark like when there are multiple
- Add spacing between example types
- Make soap examples response code display similar to the rest
- Make sidemenu top padding match content, so they start on the same place.

<img width="566" alt="Screenshot 2022-12-19 at 13 31 22" src="https://user-images.githubusercontent.com/9307503/208426996-f91db1c8-e4a8-4ed1-8b10-32a3362431c1.png">
