### PR TITLE
Improve accessibility on Environmental info modal

### DIFF
--- a/js/webcomponent/bring-env/main.js
+++ b/js/webcomponent/bring-env/main.js
@@ -45,11 +45,12 @@ class BringEnv extends HTMLElement {
         closeModal.addEventListener('click', () => {
           close();
         });
-        closeModal.addEventListener('keydown', (e) => {
-          if (e.keyCode == 27) {
-            close();
-          }
-        });
+      });
+
+      this.shadowRoot.addEventListener('keydown', (e) => {
+        if (e.keyCode == 27) {
+          close();
+        }
       });
     }
 

--- a/js/webcomponent/bring-env/main.js
+++ b/js/webcomponent/bring-env/main.js
@@ -31,18 +31,24 @@ class BringEnv extends HTMLElement {
 
     this.shadowRoot.innerHTML = `${style} ${template}`;
     
+    const openModalBtn = document.querySelector('[data-bring-env-open]');
+
     if(isModal) {
-      const openModalBtn = document.querySelector('[data-bring-env-open]');
       if(openModalBtn) {
         openModalBtn.addEventListener('click', () => {
-          this.open();
+          open();
         });
       }
 
       const closeModalAttr = this.shadowRoot.querySelectorAll('[data-close-modal]');
       closeModalAttr.forEach((closeModal) => {
         closeModal.addEventListener('click', () => {
-          this.close();
+          close();
+        });
+        closeModal.addEventListener('keydown', (e) => {
+          if (e.keyCode == 27) {
+            close();
+          }
         });
       });
     }
@@ -68,14 +74,19 @@ class BringEnv extends HTMLElement {
         }
       })
     }
-  }
 
-  open() {
-    this.shadowRoot.querySelector('.bring-env').classList.add('open');
-  }
+    const open = () => {
+      this.shadowRoot.querySelector('.bring-env').classList.add('open');
+      const closeModalBtn = this.shadowRoot.querySelector('.close-modal-btn');
+      if(closeModalBtn) {
+        closeModalBtn.focus();
+      }
+    }
 
-  close() {
-    this.shadowRoot.querySelector('.bring-env').classList.remove('open');
+    const close = () => {
+      this.shadowRoot.querySelector('.bring-env').classList.remove('open');
+      openModalBtn.focus();
+    }
   }
 }
 

--- a/js/webcomponent/bring-env/template.js
+++ b/js/webcomponent/bring-env/template.js
@@ -8,7 +8,7 @@ import {train} from "./svgs/train.js";
 import {uploadingTruck} from "./svgs/uploading-truck.js";
 
 export default function bringEnvTemplate(isModal) {
-  return `<div class="bring-env" ${isModal ? 'role="dialog" aria-labelledby="modalTitle"' : ''}>
+  return `<div class="bring-env" ${isModal ? 'role="dialog" aria-modal="true" aria-labelledby="modalTitle"' : ''}>
     <div class="bring-env-wrapper">
       <div class="bring-env-header">
         ${postenLogo}


### PR DESCRIPTION
Improving the accessibility on Environmental info modal by adding `aria-modal="true"` in conjunction with `role="dialog"` (if it's a modal). The focus is also moved from the trigger when opening the modal, to the close button in the modal, so the user can continue in the modal, or easily close it. 
In addition, support is added for pressing the ESC key and closing the modal.
When the modal is closed, the focus is moved back to the trigger.