### PR TITLE
Improve accessibility on different parts

### DIFF
--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -143,7 +143,7 @@ aliases:
     authentication; one user can have access to multiple customer numbers but
     also have different rights or accesses from number to number.
   </p>
-  <h4>If your company has a customer number</h4>
+  <h3>If your company has a customer number</h3>
   <p class="mbxs">
     You can see the numbers you have access to on the
     <a href="https://www.mybring.com/useradmin/account/settings/api"
@@ -163,7 +163,7 @@ aliases:
     <li>Contact your customer’s admin and get them to connect your user.</li>
   </ul>
 
-  <h4>If your company doesn’t have a customer number</h4>
+  <h3>If your company doesn’t have a customer number</h3>
   <p>Contact customer support via your country’s Bring site.</p>
   <p>
     If you need a customer number for testing purposes, it can be found in the

--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -12,7 +12,8 @@
     .dev-sidemenu a,
     a.dev-codetabs__link,
     .start__col,
-    .ecom-entrance) {
+    .ecom-entrance,
+    .skip-to-content-link) {
       color: var(--blue-light);
   }
 

--- a/css/syntax.css
+++ b/css/syntax.css
@@ -67,8 +67,8 @@
 /* CommentMultiline */ .chroma .cm { color: hsl(40, 36%, 37%); font-style: italic }
 /* CommentSingle */ .chroma .c1 { color: hsl(40, 36%, 37%); font-style: italic }
 /* CommentSpecial */ .chroma .cs { color: hsl(40, 36%, 37%); font-weight: bold; font-style: italic }
-/* CommentPreproc */ .chroma .cp { color: hsl(83, 40%, 35%) }
-/* CommentPreprocFile */ .chroma .cpf { color: hsl(83, 40%, 35%) }
+/* CommentPreproc */ .chroma .cp { color: hsl(83, 40%, 30%) }
+/* CommentPreprocFile */ .chroma .cpf { color: hsl(83, 40%, 30%) }
 /* Generic */ .chroma .g {  }
 /* GenericDeleted */ .chroma .gd { background-color: hsl(0, 100%, 90%) }
 /* GenericEmph */ .chroma .ge { font-style: italic }

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -42,7 +42,7 @@
         <button
           class="btn-link phs white themes-btn"
           id="themesBtn"
-          aria-label="Choose color mode"
+          aria-label="Auto color mode"
           aria-expanded="false"
           aria-controls="themeSwitchContainer"
         >
@@ -54,21 +54,18 @@
         <div class="paxs rad-a2px bg-gray1 bshadow--dark theme-switch-container w100p dn" id="themeSwitchContainer">
           <button
             class="btn-link btn--transparent phs theme-switch w100p"
-            aria-label="Auto color mode"
             data-color-theme="auto"
           >
             Auto
           </button>
           <button
             class="btn-link btn--transparent phs theme-switch w100p"
-            aria-label="Light color mode"
             data-color-theme="light"
           >
             Light
           </button>
           <button
             class="btn-link btn--transparent phs theme-switch w100p"
-            aria-label="Dark color mode"
             data-color-theme="dark"
           >
             Dark
@@ -135,9 +132,11 @@
       if (storedTheme === "dark") {
         htmlContainer.dataset.theme = darkOption;
         themesBtnText.innerText = "Dark";
+        themesBtn.setAttribute("aria-label","Dark color mode");
       } else if (storedTheme === "light") {
         htmlContainer.dataset.theme = lightOption;
         themesBtnText.innerText = "Light";
+        themesBtn.setAttribute("aria-label","Light color mode");
       }
       
       //Set the data-theme on click
@@ -155,16 +154,19 @@
               htmlContainer.removeAttribute("data-theme");
             }
             localStorage.removeItem("theme", selectedTheme);
+            themesBtn.setAttribute("aria-label","Auto color mode");
           } else if (selectedTheme === darkOption) {
             themesBtnText.innerText = e.target.innerText;
             //Set data-theme and store the chosen theme in local storage
             htmlContainer.dataset.theme = darkOption;
             localStorage.setItem("theme", selectedTheme);
+            themesBtn.setAttribute("aria-label","Dark color mode");
           } else if (selectedTheme === lightOption) {
             themesBtnText.innerText = e.target.innerText;
             //Set data-theme and store the chosen theme in local storage
             htmlContainer.dataset.theme = lightOption;
             localStorage.setItem("theme", selectedTheme);
+            themesBtn.setAttribute("aria-label","Light color mode");
           }
         });
       }

--- a/layouts/partials/subscribe.html
+++ b/layouts/partials/subscribe.html
@@ -24,12 +24,16 @@
       <div id="mce-responses" class="clear foot">
         <div class="mce-response" id="mce-error-response" style="display:none"></div>
         <div class="mce-response" id="mce-success-response" style="display:none"></div>
-      </div>    <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
-      <div style="position: absolute; left: -5000px;" aria-hidden="true"><input type="text" name="b_f6b9d5de1a234124c14558d51_8b45ecec29" tabindex="-1" value=""></div>
+      </div>
+      <!-- real people should not fill this in and expect good things - do not remove this or risk form bot signups-->
+      <div style="position: absolute; left: -5000px;" aria-hidden="true">
+        <label for="hiddenMCInput" class="form__label">Hidden input</label>
+        <input type="text" name="b_f6b9d5de1a234124c14558d51_8b45ecec29" tabindex="-1" value="" id="hiddenMCInput">
+      </div>
       <div class="optionalParent">
         <div class="clear foot">
           <input type="submit" value="Subscribe to API updates" name="subscribe" id="mc-embedded-subscribe" class="button btn btn--green">
-          <p class="brandingLogo"><a href="http://eepurl.com/hOnEJv" title="Mailchimp - email marketing made easy and fun"><img src="https://eep.io/mc-cdn-images/template_images/branding_logo_text_dark_dtp.svg" width="0" height="0"></a></p>
+          <p class="brandingLogo"><a href="http://eepurl.com/hOnEJv" title="Mailchimp - email marketing made easy and fun"><img src="https://eep.io/mc-cdn-images/template_images/branding_logo_text_dark_dtp.svg" width="0" height="0" alt="Hidden image"></a></p>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Improving the following accessibility issues with this PR:
- Frontpage: Mailchimp image with missing alt-text.
- Mailchimp hidden input is missing a label
- Getting started: Header levels skip from `h2` to `h4`
- Code examples: First line of XML contrast issue (light mode)
- Color mode / theme button aria-label should describe which theme is currently set.
- Ensure better accessibility on Environmental info modal (is handled in a separate PR: https://github.com/bring/developer-site/pull/1400)