### PR TITLE
Example stability fixes

### DIFF
--- a/layouts/partials/api/oas/requestexample.html
+++ b/layouts/partials/api/oas/requestexample.html
@@ -56,6 +56,7 @@
             {{- if $multiExamples -}}
               <div class="mhm {{ if not $multiTypes }}ptm{{ end }}">
                 <select class="form__control w100p pas hauto" name="{{ $mediaType }}-{{ $requestId }}" data-example-sub aria-label="Request examples {{ $format }}">
+                  {{- $exInd := 0 -}}
                   {{- range $name, $obj := . -}}
 
                     {{- $hasRef := false -}}
@@ -72,12 +73,13 @@
                       {{/*  Support both ref components and not ref  */}}
                       {{- if eq $k "$ref" -}}
                         {{- $examplePath := path.Split . -}}
-                        {{- $exampleId = (printf "%s-%s" $requestId $examplePath.File) | anchorize -}}
+                        {{- $exampleId = (printf "%s-%s-%s" $requestId $examplePath.File (string $exInd)) | anchorize -}}
                       {{- else if not $hasRef -}}
-                        {{- $exampleId = (printf "%s-%s" $requestId $name) | anchorize -}}
+                        {{- $exampleId = (printf "%s-%s" $requestId $name (string $exInd)) | anchorize -}}
                       {{- end -}}
                     {{- end -}}
                     <option value="{{ $exampleId }}">{{ $name }}</option>
+                    {{- $exInd = add $exInd 1 -}}
                   {{- end -}}
                 </select>
               </div>
@@ -86,7 +88,7 @@
             {{/*  Make the actual examples  */}}
             {{- $exInd := 0 -}}
             {{- range $name, $exampleObject := . -}}
-              {{- $exampleId := (printf "%s-%s" $requestId $name) | anchorize -}}
+              {{- $exampleId := (printf "%s-%s-%s" $requestId $name (string $exInd)) | anchorize -}}
 
               {{/*  Get possible $ref example object  */}}
               {{- if isset . "$ref" -}}
@@ -94,7 +96,7 @@
                 {{- range $k, $_ := $exampleObject -}}
                   {{- if eq $k "$ref" -}}
                     {{- $examplePath := path.Split . -}}
-                    {{- $exampleId = (printf "%s-%s" $requestId $examplePath.File) | anchorize -}}
+                    {{- $exampleId = (printf "%s-%s-%s" $requestId $examplePath.File (string $exInd)) | anchorize -}}
                     {{- $exampleObject = index $components.examples $examplePath.File -}}
                   {{- end -}}
                 {{- end -}}

--- a/layouts/partials/api/oas/responsecode-btns.html
+++ b/layouts/partials/api/oas/responsecode-btns.html
@@ -20,7 +20,7 @@
         aria-label="Response code {{$response}}"
         aria-selected="{{$ariaSelected}}"
         role="tab"
-        id="{{$responseId}}">
+        id="tabctrl-{{ $responseId }}">
         {{ $response }}
       </button>
       {{- $ariaSelected = false -}}

--- a/layouts/partials/api/oas/responsecode-btns.html
+++ b/layouts/partials/api/oas/responsecode-btns.html
@@ -1,33 +1,35 @@
 {{- $endpointId := .endpointId -}}
 {{- $responses := .responses -}}
-{{- $resExamples := false -}}
 
 <div class="pam flex flex-wrap" role="tablist">
   {{- $ariaSelected := true -}}
   {{- range $response, $_ := $responses -}}
-    {{- if not $resExamples -}}
-      {{- range .content -}}
-        {{- with .examples -}}
-          {{- $resExamples = true -}}
-          {{- $responseColor := "" -}}
-          {{- if and (ge $response 200) (lt $response 300) -}}
-            {{- $responseColor = "txt-success" -}}
-          {{- else if ge $response 300 -}}
-            {{- $responseColor = "txt-error" -}}
+    {{- with .content -}}
+      {{- $resExamples := false -}}
+      {{- range . -}}
+        {{- if not $resExamples -}}
+          {{- with .examples -}}
+            {{- $resExamples = true -}}
+            {{- $responseColor := "" -}}
+            {{- if and (ge $response 200) (lt $response 300) -}}
+              {{- $responseColor = "txt-success" -}}
+            {{- else if ge $response 300 -}}
+              {{- $responseColor = "txt-error" -}}
+            {{- end -}}
+            {{- $responseId := print $endpointId "-" $response -}}
+            <button
+              type="button"
+              name="{{ $endpointId }}-response"
+              data-example="{{ $responseId }}"
+              class="btn-link--dark mrs {{ $responseColor }}"
+              aria-label="Response code {{ $response }}"
+              aria-selected="{{ $ariaSelected }}"
+              role="tab"
+              id="tabctrl-{{ $responseId }}">
+              {{ $response }}
+            </button>
+            {{- $ariaSelected = false -}}
           {{- end -}}
-          {{- $responseId := print $endpointId "-" $response -}}
-          <button
-            type="button"
-            name="{{ $endpointId }}-response"
-            data-example="{{ $responseId }}"
-            class="btn-link--dark mrs {{ $responseColor }}"
-            aria-label="Response code {{ $response }}"
-            aria-selected="{{ $ariaSelected }}"
-            role="tab"
-            id="tabctrl-{{ $responseId }}">
-            {{ $response }}
-          </button>
-          {{- $ariaSelected = false -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/partials/api/oas/responsecode-btns.html
+++ b/layouts/partials/api/oas/responsecode-btns.html
@@ -1,29 +1,35 @@
 {{- $endpointId := .endpointId -}}
 {{- $responses := .responses -}}
+{{- $resExamples := false -}}
 
 <div class="pam flex flex-wrap" role="tablist">
   {{- $ariaSelected := true -}}
   {{- range $response, $_ := $responses -}}
-    {{- with .content -}}
-      {{- $responseColor := "" -}}
-      {{- if and (ge $response 200) (lt $response 300) -}}
-        {{- $responseColor = "txt-success" -}}
-      {{- else if ge $response 300 -}}
-        {{- $responseColor = "txt-error" -}}
+    {{- if not $resExamples -}}
+      {{- range .content -}}
+        {{- with .examples -}}
+          {{- $resExamples = true -}}
+          {{- $responseColor := "" -}}
+          {{- if and (ge $response 200) (lt $response 300) -}}
+            {{- $responseColor = "txt-success" -}}
+          {{- else if ge $response 300 -}}
+            {{- $responseColor = "txt-error" -}}
+          {{- end -}}
+          {{- $responseId := print $endpointId "-" $response -}}
+          <button
+            type="button"
+            name="{{ $endpointId }}-response"
+            data-example="{{ $responseId }}"
+            class="btn-link--dark mrs {{ $responseColor }}"
+            aria-label="Response code {{ $response }}"
+            aria-selected="{{ $ariaSelected }}"
+            role="tab"
+            id="tabctrl-{{ $responseId }}">
+            {{ $response }}
+          </button>
+          {{- $ariaSelected = false -}}
+        {{- end -}}
       {{- end -}}
-      {{- $responseId := print $endpointId "-" $response -}}
-      <button 
-        type="button" 
-        name="{{$endpointId}}-response" 
-        data-example="{{$responseId}}" 
-        class="btn-link--dark mrs {{$responseColor}}" 
-        aria-label="Response code {{$response}}"
-        aria-selected="{{$ariaSelected}}"
-        role="tab"
-        id="tabctrl-{{ $responseId }}">
-        {{ $response }}
-      </button>
-      {{- $ariaSelected = false -}}
     {{- end -}}
   {{- end -}}
 </div>

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -34,7 +34,7 @@
     {{- range $response, $_ := $responseCodes -}}
       {{- with .content -}}
         {{- $responseId := print $endpointId "-" $response -}}
-        <div class="relative bg-gray4 example-wrap" data-example="{{ $responseId }}" role="tabpanel" aria-labelledby="{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
+        <div class="relative bg-gray4 example-wrap" data-example="{{ $responseId }}" role="tabpanel" aria-labelledby="tabctrl-{{ $responseId }}" {{ if ne $resInd 0 }}hidden{{ end }}>
 
           {{/*  Check if there are multiple types within response  */}}
           {{- $mediaTypes := . -}}

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -75,6 +75,7 @@
                 {{- if $multiExamples -}}
                   <div class="mhm {{ if not $multiTypes }}ptm{{ end }}">
                     <select class="form__control w100p pas hauto" name="{{ $mediaType }}-{{ $responseId }}" data-example-sub aria-label="Response code {{ $response }} examples {{ $format }}">
+                      {{- $exInd := 0 -}}
                       {{- range $name, $obj := . -}}
 
                         {{- $hasRef := false -}}
@@ -91,12 +92,13 @@
                           {{/*  Support both ref components and not ref  */}}
                           {{- if eq $k "$ref" -}}
                             {{- $examplePath := path.Split . -}}
-                            {{- $exampleId = (printf "%s-%s" $responseId $examplePath.File) | anchorize -}}
+                            {{- $exampleId = (printf "%s-%s-%s" $responseId $examplePath.File (string $exInd)) | anchorize -}}
                           {{- else if not $hasRef -}}
                             {{- $exampleId = (printf "%s-%s" $responseId $name) | anchorize -}}
                           {{- end -}}
                         {{- end -}}
                         <option value="{{ $exampleId }}">{{ $name }}</option>
+                        {{- $exInd = add $exInd 1 -}}
                       {{- end -}}
                     </select>
                   </div>
@@ -105,7 +107,7 @@
                 {{/*  Make the actual examples  */}}
                 {{- $exInd := 0 -}}
                 {{- range $name, $exampleObject := . -}}
-                  {{- $exampleId := (printf "%s-%s" $responseId $name) | anchorize -}}
+                  {{- $exampleId := (printf "%s-%s-%s" $responseId $name (string $exInd)) | anchorize -}}
 
                   {{/*  Get possible $ref example object  */}}
                   {{- if isset . "$ref" -}}
@@ -113,7 +115,7 @@
                     {{- range $k, $_ := $exampleObject -}}
                       {{- if eq $k "$ref" -}}
                         {{- $examplePath := path.Split . -}}
-                        {{- $exampleId = (printf "%s-%s" $responseId $examplePath.File) | anchorize -}}
+                        {{- $exampleId = (printf "%s-%s-%s" $responseId $name (string $exInd)) | anchorize -}}
                         {{- $exampleObject = index $components.examples $examplePath.File -}}
                       {{- end -}}
                     {{- end -}}

--- a/layouts/partials/api/oas/responseexample.html
+++ b/layouts/partials/api/oas/responseexample.html
@@ -89,12 +89,12 @@
                         {{- end -}}
 
                         {{- range $k, $_ := $obj -}}
-                          {{/*  Support both ref components and not ref  */}}
+                          {{/*  Support both components and not  */}}
                           {{- if eq $k "$ref" -}}
                             {{- $examplePath := path.Split . -}}
                             {{- $exampleId = (printf "%s-%s-%s" $responseId $examplePath.File (string $exInd)) | anchorize -}}
                           {{- else if not $hasRef -}}
-                            {{- $exampleId = (printf "%s-%s" $responseId $name) | anchorize -}}
+                            {{- $exampleId = (printf "%s-%s-%s" $responseId $name (string $exInd)) | anchorize -}}
                           {{- end -}}
                         {{- end -}}
                         <option value="{{ $exampleId }}">{{ $name }}</option>
@@ -115,7 +115,7 @@
                     {{- range $k, $_ := $exampleObject -}}
                       {{- if eq $k "$ref" -}}
                         {{- $examplePath := path.Split . -}}
-                        {{- $exampleId = (printf "%s-%s-%s" $responseId $name (string $exInd)) | anchorize -}}
+                        {{- $exampleId = (printf "%s-%s-%s" $responseId $examplePath.File (string $exInd)) | anchorize -}}
                         {{- $exampleObject = index $components.examples $examplePath.File -}}
                       {{- end -}}
                     {{- end -}}


### PR DESCRIPTION
- Prevents rendering of example response buttons when there is no corresponding example (it only did a general example check before assuming that all responses had examples if only one of them had one)
- Makes the same button’s id unique (it was only used by the corresponding tabpanel for aria-label)
- Enables reuse of examples within a response code by adding an index to the rendered example id