### PR TITLE
Adding versioning details to pickup point API

### DIFF
--- a/content/api/pickup-point/_index.md
+++ b/content/api/pickup-point/_index.md
@@ -52,14 +52,6 @@ information:
       REST XML/JSON over HTTP.
 
 documentation:
-  - title: Filtering results
-    content: |
-      The list of pickup points can be narrowed down by using `searchForText=<texts>`, where the pickup points will have at least a partial match with the search string given in `<texts>`. This can be the name of the pickup point, its address, city, county, municipality or location. See the examples for more information.
-
-  - title: Postbox and visiting address
-    content: |
-      There are two sets of addresses in the response, postbox (`address` and `postalCode`) and visiting address (`visitingAddress` and `visitingPostalCode`). Postbox address is required to get a package produced correctly, use this AS RECIPIENT address on label. Visiting address is more appropriate for user interface (Street address of the PIB).
-
   - title: Pickup point types
     content: |
       A pickup point is any location delivering shipments on behalf of Bring and Posten, such as post offices, selected grocery stores, lockers.
@@ -86,5 +78,9 @@ documentation:
         - Type Posti: Finland Posti Pickup Point
         - Type Noutopiste: Finland Pickup Point
         - Type LOCKER: Finland Locker Pickup Point **_(These lockers are placed inside buildings only accessible to the residents and workers in the building)_**
+
+subpages:
+  title: Special topics
+
 oas: https://api.qa.bring.com/pickuppoint/openapi
 ---

--- a/content/api/pickup-point/filtering.md
+++ b/content/api/pickup-point/filtering.md
@@ -1,0 +1,14 @@
+---
+title: Filtering results
+layout: api
+notanapi: true
+menu:
+  apidocs:
+    identifier: pupfiltering
+    title: Filtering results
+    parent: pickuppoint
+weight: 3
+hidden: true
+---
+The list of pickup points can be narrowed down by using `searchForText=<texts>`, where the pickup points will have at least a partial match with the search string given in `<texts>`. This can be the name of the pickup point, its address, city, county, municipality or location. See the examples for more information.
+

--- a/content/api/pickup-point/versioning.md
+++ b/content/api/pickup-point/versioning.md
@@ -1,0 +1,16 @@
+---
+title: Versioning
+layout: api
+notanapi: true
+menu:
+  apidocs:
+    identifier: pupversioning
+    title: Versioning
+    parent: pickuppoint
+weight: 2
+hidden: true
+---
+The Pickup Point API makes an effort to always be backwards compatible regarding data format for requests and responses.
+
+**Important**: All clients must accept **new (unknown) elements** in the response. E.g. unknown elements should be ignored. Also, **new error codes** could be added as well. The client framework used by client must not crash when **unknown elements or new code values** are encountered.
+

--- a/content/api/pickup-point/visitingaddress.md
+++ b/content/api/pickup-point/visitingaddress.md
@@ -1,0 +1,14 @@
+---
+title: Postbox and visiting address
+layout: api
+notanapi: true
+menu:
+  apidocs:
+    identifier: visitingaddress
+    title: Postbox and visiting address
+    parent: pickuppoint
+weight: 4
+hidden: true
+---
+There are two sets of addresses in the response, postbox (`address` and `postalCode`) and visiting address (`visitingAddress` and `visitingPostalCode`). Postbox address is required to get a package produced correctly, use this AS RECIPIENT address on label. Visiting address is more appropriate for user interface (Street address of the PIB).
+


### PR DESCRIPTION
- also moved some main page topics to the new subpage structure

<img width="939" alt="Screenshot 2023-01-03 at 10 06 45" src="https://user-images.githubusercontent.com/1623401/210327436-307597a3-cc82-4d5e-b6a5-1a1b3aa9d05a.png">

<img width="755" alt="Screenshot 2023-01-03 at 10 07 21" src="https://user-images.githubusercontent.com/1623401/210327438-ef1c62a7-1bed-4518-a706-8f8089c7035d.png">

- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.
