### PR TITLE
Highlighting the importance of the provided shipping date

### DIFF
--- a/content/api/pickup-point/_index.md
+++ b/content/api/pickup-point/_index.md
@@ -82,5 +82,5 @@ documentation:
 subpages:
   title: Special topics
 
-oas: https://api.qa.bring.com/pickuppoint/openapi
+oas: https://api.bring.com/pickuppoint/openapi
 ---

--- a/content/api/shipping-guide_2/_index.md
+++ b/content/api/shipping-guide_2/_index.md
@@ -40,5 +40,12 @@ information:
 subpages:
   title: Special topics
 
-oas: https://api.qa.bring.com/shippingguide/api-docs
+guides:
+- title: The importance of provided shipping date
+  content: | 
+    Providing the **actual shipping date** in the request is a prerequisite for getting the correct lead times, as the lead time is always calculated from the day and time when the parcel **arrives** at a Bring terminal. It is recommended to read [this guide](/api/e-commerce-solutions/checkout-guide-norway/implement-estimated-delivery/) for a better understanding of how the provided shipping date affects the returned lead time. 
+    
+    **NOTE**: In absence of a shipping date set by the user, the Shipping Guide API will default to `now`. If shipping date is set to `now`, lead times will be calculated on the assumption that the packages has just arrived at a terminal.
+
+oas: https://api.bring.com/shippingguide/api-docs
 ---


### PR DESCRIPTION
Also adjusting the oas refs to point to production urls, to make sure that dev-site is not built based on some temporary deployed version.

<img width="794" alt="Screenshot 2023-01-03 at 12 37 56" src="https://user-images.githubusercontent.com/1623401/210350564-5ac074b9-8f00-4170-b8ba-a1744e8a4893.png">

Link points to this page:

<img width="1203" alt="Screenshot 2023-01-03 at 12 38 11" src="https://user-images.githubusercontent.com/1623401/210350571-710d7bf2-2d92-41a3-8c48-7bfd2aea264a.png">


- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.
