### PR TITLE
Colour and aria fixes

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -166,7 +166,7 @@
     &.txt-error {
       color: var(--red-light);
       &:hover {
-        color: var(--red-dark);
+        color: var(--red);
       }
     }
 

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -235,6 +235,10 @@ div.response {
   color: var(--red-dark);
 }
 
+.txt-success[aria-selected="true"] {
+  color: var(--green-darker);
+}
+
 .minw0 {
   min-width: 0;
 }

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -101,7 +101,7 @@
                     {{- $multiSchema = true -}}
                   {{- end -}}
                   <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
-                    <summary class="{{ $responseColorTxt }}" aria-label="Disclose response {{ $response }} {{ $description }} details">
+                    <summary class="{{ $responseColorTxt }}">
                       <span
                       data-mybicon="mybicon-arrow-right"
                       data-mybicon-width="16"

--- a/layouts/partials/api/oas/requestexample.html
+++ b/layouts/partials/api/oas/requestexample.html
@@ -55,7 +55,7 @@
 
             {{- if $multiExamples -}}
               <div class="mhm {{ if not $multiTypes }}ptm{{ end }}">
-                <select class="form__control w100p pas hauto" name="{{ $mediaType }}-{{ $requestId }}" data-example-sub aria-label="Request examples {{ $format }}">
+                <select class="form__control w100p pas hauto" name="{{ $mediaType }}-{{ $requestId }}" data-example-sub aria-label="{{ $format }} request example">
                   {{- $exInd := 0 -}}
                   {{- range $name, $obj := . -}}
 

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -44,13 +44,13 @@
   {{- if eq $isOneOf "radio" -}}
     {{- $levelId = printf "%s-%s" $levelName "oneof-xml" -}}
     <div>
-      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of aria-controls="{{ $responseCode }}-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
   {{/*  Loop oneOf data  */}}
   {{- else if eq $isOneOf "data" -}}
     {{- $levelId = printf "%s-%s" $levelName "oneof-xml" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
+      <dl id="{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" aria-label="{{ $name }}">
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -42,13 +42,15 @@
   
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $isOneOf "radio" -}}
+    {{- $levelId = printf "%s-%s" $levelName "ofone-xml" -}}
     <div>
       <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
   {{/*  Loop oneOf data  */}}
   {{- else if eq $isOneOf "data" -}}
+    {{- $levelId = printf "%s-%s" $levelName "ofone-xml" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+      <dl id="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -42,13 +42,13 @@
   
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $isOneOf "radio" -}}
-    {{- $levelId = printf "%s-%s" $levelName "ofone-xml" -}}
+    {{- $levelId = printf "%s-%s" $levelName "oneof-xml" -}}
     <div>
       <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
   {{/*  Loop oneOf data  */}}
   {{- else if eq $isOneOf "data" -}}
-    {{- $levelId = printf "%s-%s" $levelName "ofone-xml" -}}
+    {{- $levelId = printf "%s-%s" $levelName "oneof-xml" -}}
     {{- with $schemaObj.properties -}}
       <dl id="tab-{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
         {{- range $key, $_ := . -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -77,13 +77,13 @@
   {{- if eq $oneOf "radio" -}}
     {{- $levelId = printf "%s-%s" $levelName "oneof" -}}
     <div>
-      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of aria-controls="{{ $responseCode }}-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
     {{/*  Loop oneOf data  */}}
   {{- else if eq $oneOf "data" -}}
     {{- $levelId = printf "%s-%s" $levelName "oneof" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
+      <dl id="{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" aria-label="{{ $name }}">
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -75,13 +75,13 @@
 
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $oneOf "radio" -}}
-    {{- $levelId = printf "%s-%s" $levelName "ofone" -}}
+    {{- $levelId = printf "%s-%s" $levelName "oneof" -}}
     <div>
       <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
     {{/*  Loop oneOf data  */}}
   {{- else if eq $oneOf "data" -}}
-    {{- $levelId = printf "%s-%s" $levelName "ofone" -}}
+    {{- $levelId = printf "%s-%s" $levelName "oneof" -}}
     {{- with $schemaObj.properties -}}
       <dl id="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
         {{- range $key, $_ := . -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -75,13 +75,15 @@
 
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $oneOf "radio" -}}
+    {{- $levelId = printf "%s-%s" $levelName "ofone" -}}
     <div>
       <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
     {{/*  Loop oneOf data  */}}
   {{- else if eq $oneOf "data" -}}
+    {{- $levelId = printf "%s-%s" $levelName "ofone" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+      <dl id="tab-{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelId }}">
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}


### PR DESCRIPTION
- Fixes 20 broken aria references in tracking where the aria-labelledby on the tabpanel didn’t match the id of the tab in the oneOf schema.
- Removes the tab roles from the oneOf response schema (doing the request schema separately as part of the shipment API improvement) and just connect the radio input to the description list with aria-controls and describing the list with aria-label.
- Improves colour contrast on the examples buttons plus a couple of other small things.