### PR TITLE
Remove EVARSLING support for 3584, 3570 and 5800

### DIFF
--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -209,36 +209,6 @@
     "senderCountries" : "-",
     "destinations" : "-"
   }, {
-    "serviceName" : "Pakke i postkassen",
-    "serviceType" : "B2C",
-    "serviceFamily" : "Parcel Norway domestic",
-    "serviceFamilySortOrder" : 1,
-    "serviceCode" : "3584",
-    "productionCode" : "3584",
-    "domesticAllowedIn" : "NO",
-    "senderCountries" : "-",
-    "destinations" : "-"
-  }, {
-    "serviceName" : "Pakke i postkassen med RFID",
-    "serviceType" : "B2C",
-    "serviceFamily" : "Parcel Norway domestic",
-    "serviceFamilySortOrder" : 1,
-    "serviceCode" : "3570",
-    "productionCode" : "3570",
-    "domesticAllowedIn" : "NO",
-    "senderCountries" : "-",
-    "destinations" : "-"
-  }, {
-    "serviceName" : "Pakke til hentested",
-    "serviceType" : "B2C",
-    "serviceFamily" : "Parcel Norway domestic",
-    "serviceFamilySortOrder" : 1,
-    "serviceCode" : "5800",
-    "productionCode" : "5800",
-    "domesticAllowedIn" : "NO",
-    "senderCountries" : "-",
-    "destinations" : "-"
-  }, {
     "serviceName" : "Norgespakke",
     "serviceType" : "C2C",
     "serviceFamily" : "",


### PR DESCRIPTION
**eVarsling supported services before:**

<img width="1043" alt="evarsling before" src="https://user-images.githubusercontent.com/78538590/210772039-6dacf05a-32f2-419d-9d9b-ca297e7a7c56.png">

**eVarsling supported services after:**

<img width="1030" alt="evarsling after" src="https://user-images.githubusercontent.com/78538590/210772051-0e85c1e6-024d-4f80-a88d-4f2f72113388.png">
