### PR TITLE
allOf request schema

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -16,17 +16,17 @@ paramToggleBtn.forEach((btn) => {
 })
 
 // oneOf and allOf
-function setOneOf(radio) {
-  const radioVal = radio.value,
-    closest = radio.closest("dd"),
-    oneOfArr = Array.from(closest.children)
+function showSelectedSchema(ofElement) {
+  const elementVal = ofElement.value,
+    closest = ofElement.closest("dd"),
+    ofArr = Array.from(closest.children)
 
-  radio.setAttribute("checked", "")
-  oneOfArr.forEach((child) => {
-    if (child.tagName === "DL") {
-      child.classList.add("dn")
-      if (child.dataset.ofOne === radioVal) {
-        child.classList.remove("dn")
+  ofElement.setAttribute("checked", "")
+  ofArr.forEach((ofChild) => {
+    if (ofChild.tagName === "DL") {
+      ofChild.classList.add("dn")
+      if (ofChild.dataset.ofOne === elementVal) {
+        ofChild.classList.remove("dn")
       }
     }
   })
@@ -35,14 +35,14 @@ function setOneOf(radio) {
 const oneOfRadioArr = document.querySelectorAll("input[data-one-of]")
 oneOfRadioArr.forEach((radio) => {
   radio.addEventListener("change", function () {
-    setOneOf(radio)
+    showSelectedSchema(radio)
   })
 })
 
 const allOfSelectArr = document.querySelectorAll("select[data-one-of]")
 allOfSelectArr.forEach((select) => {
   select.addEventListener("change", function () {
-    setOneOf(select)
+    showSelectedSchema(select)
   })
 })
 
@@ -195,7 +195,7 @@ document.addEventListener("DOMContentLoaded", function () {
   // set oneOf selection if reload/backward/forward navigation
   oneOfRadioArr.forEach((radio) => {
     if (radio.checked) {
-      setOneOf(radio)
+      showSelectedSchema(radio)
     } else {
       radio.removeAttribute("checked")
     }

--- a/js/api.js
+++ b/js/api.js
@@ -15,7 +15,7 @@ paramToggleBtn.forEach((btn) => {
   })
 })
 
-// oneOf
+// oneOf and allOf
 function setOneOf(radio) {
   const radioVal = radio.value,
     closest = radio.closest("dd"),
@@ -36,6 +36,13 @@ const oneOfRadioArr = document.querySelectorAll("input[data-one-of]")
 oneOfRadioArr.forEach((radio) => {
   radio.addEventListener("change", function () {
     setOneOf(radio)
+  })
+})
+
+const allOfSelectArr = document.querySelectorAll("select[data-one-of]")
+allOfSelectArr.forEach((select) => {
+  select.addEventListener("change", function () {
+    setOneOf(select)
   })
 })
 

--- a/js/search/Result.jsx
+++ b/js/search/Result.jsx
@@ -48,7 +48,7 @@ const Result = (props) => {
     <>
       <label
         htmlFor="autosuggestneedslabel"
-        class="form__label white screen-reader-text"
+        className="form__label white screen-reader-text"
       >
         Search the documentation
       </label>

--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -63,6 +63,7 @@
       </dl>
     {{- end -}}
   {{- else -}}
+    {{/*  Render first level isOf without visible dt  */}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>

--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -5,17 +5,21 @@
 {{- $endpointId := .endpointId -}}
 {{- $uniqueId := "" -}}
 {{- $recLevel := add .recLevel 1 -}}
-{{- $isOneOf := "" -}}
-{{- with .isOneOf }}
-  {{- $isOneOf = . -}}
+{{- $isOf := "" -}}
+{{- with .isOf -}}
+  {{- $isOf = . -}}
 {{- end -}}
 {{- $parent := "" -}}
 {{- with .parent -}}
   {{- $parent = . -}}
 {{- end -}}
-{{- $oneOfInd := 0 -}}
-{{- with .oneOfInd -}}
-  {{- $oneOfInd = . -}}
+{{- $ofInd := 0 -}}
+{{- with .ofInd -}}
+  {{- $ofInd = . -}}
+{{- end -}}
+{{- $isFirstLevelOf := false -}}
+{{- if and (eq $recLevel 1) (or ($schemaObj.oneOf) ($schemaObj.allOf)) -}}
+  {{- $isFirstLevelOf = true -}}
 {{- end -}}
 
 {{/*  If there’s a ref, pass the destination data again  */}}
@@ -25,7 +29,7 @@
   {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
   {{- end -}}
 {{- end -}}
 
@@ -38,26 +42,33 @@
   {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
   {{- $uniqueId = slicestr $generateId 0 15 -}}
   {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
-  
+
   {{/*  Render oneOf radio inputs  */}}
-  {{- if eq $isOneOf "radio" -}}
+  {{- if eq $isOf "radio" -}}
     <div>
-      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-xml-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of aria-controls="xml-{{ $name | anchorize }}" {{ if eq $ofInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
-  {{/*  Loop oneOf data  */}}
-  {{- else if eq $isOneOf "data" -}}
+
+  {{/*  Render allOf select options  */}}
+  {{- else if eq $isOf "select" -}}
+    <option value="{{ $levelName }}" {{ if eq $ofInd 0 }}selected{{ end }}>{{ $name }}</option>
+
+    {{/*  Loop oneOf data  */}}
+  {{- else if in $isOf "Data" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+      <dl id="xml-{{ $name | anchorize }}" class="pls {{ if ne $ofInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" {{ if in $isOf "one" }}aria-label="{{ $name }}"{{ end }}>
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
-  {{ else }}
-    <div class="mb-border bb bw1 mbs">
-      <div class="flex flex-wrap align-ifs pbs">
+  {{- else -}}
+    <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
+      <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>
-          {{- if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.items) -}}
+          {{- if $isFirstLevelOf -}}
+            Schema selector
+          {{- else if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.allOf) ($schemaObj.items) -}}
             {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
@@ -90,22 +101,41 @@
       {{- end -}}
       {{/*  oneOf object  */}}
       {{- with $schemaObj.oneOf -}}
-        <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
+        <dd class="{{ if gt $recLevel 2 }}schema__sublist mb-border dn{{ end }}" id="{{ $levelId }}">
           <form>
             <fieldset class="mlxs mbs pls pbs">
-              <legend class="fw600 pts mbxs">oneOf</legend>
-              <div class="flex flex-wrap gcm" role="tabpanel">
+              <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
+              <div class="flex flex-wrap gcm">
                 {{- range $key, $_ := . -}}
-                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
-                  {{- $oneOfInd = add $oneOfInd 1 -}}
+                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                  {{- $ofInd = add $ofInd 1 -}}
                 {{- end -}}
               </div>
             </fieldset>
           </form>
-          {{- $oneOfInd = 0 -}}
+          {{- $ofInd = 0 -}}
           {{- range $key, $_ := . -}}
-            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "data" "oneOfInd" $oneOfInd) -}}
-            {{- $oneOfInd = add $oneOfInd 1 -}}
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+            {{- $ofInd = add $ofInd 1 -}}
+          {{- end -}}
+        </dd>
+      {{- end -}}
+      {{/*  allOf object  */}}
+      {{- with $schemaObj.allOf -}}
+        <dd class="{{ if gt $recLevel 2 }}schema__sublist mb-border dn{{ end }}" id="{{ $levelId }}">
+          <div class="mlxs mbs pls pbs">
+              <label class="form__label" for="{{ $levelName }}">Schema (allOf)</label>
+              <select class="form__control wauto maxw100p" id="{{ $levelName }}" data-one-of>
+                {{- range $key, $_ := . -}}
+                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                  {{- $ofInd = add $ofInd 1 -}}
+                {{- end -}}
+              </select>
+            </div>
+          {{- $ofInd = 0 -}}
+          {{- range $key, $_ := . -}}
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+            {{- $ofInd = add $ofInd 1 -}}
           {{- end -}}
         </dd>
       {{- end -}}
@@ -118,7 +148,7 @@
         </dd>
       {{- end -}}
     </div>
-  {{ end }}
+  {{- end -}}
 
 {{/*  If neither obj, arr or ref, render the item */}}
 {{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -5,17 +5,21 @@
 {{- $endpointId := .endpointId -}}
 {{- $uniqueId := "" -}}
 {{- $recLevel := add .recLevel 1 -}}
-{{- $oneOf := "" -}}
-{{- with .oneOf }}
-  {{- $oneOf = . -}}
+{{- $isOf := "" -}}
+{{- with .isOf -}}
+  {{- $isOf = . -}}
 {{- end -}}
 {{- $parent := "" -}}
 {{- with .parent -}}
   {{- $parent = . -}}
 {{- end -}}
-{{- $oneOfInd := 0 -}}
-{{- with .oneOfInd -}}
-  {{- $oneOfInd = . -}}
+{{- $ofInd := 0 -}}
+{{- with .ofInd -}}
+  {{- $ofInd = . -}}
+{{- end -}}
+{{- $isFirstLevelOf := false -}}
+{{- if and (eq $recLevel 1) (or ($schemaObj.oneOf) ($schemaObj.allOf)) -}}
+  {{- $isFirstLevelOf = true -}}
 {{- end -}}
 
 {{/*  If there’s a ref, pass the destination data again  */}}
@@ -25,45 +29,17 @@
     {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
   {{- end -}}
 {{- end -}}
 
-{{/*  If object and first level, skip  */}}
-{{- if and (eq $schemaObj.type "object") (lt $recLevel 3) -}}
+{{/*  If object, first level and not Of, skip  */}}
+{{- if and (eq $schemaObj.type "object") (lt $recLevel 3) (not (or $schemaObj.allOf $schemaObj.oneOf)) (not $isOf) -}}
   {{- with $schemaObj.properties -}}
     {{- range $key, $_ := . -}}
-      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
     {{- end -}}
   {{- end -}}
-
-  {{- else if $schemaObj.oneOf -}}
-    {{- with $schemaObj.oneOf -}}
-      <form>
-        <fieldset class="mlxs mbs pls pbs">
-          <legend class="fw600 pts mbxs">oneOf</legend>
-          <div class="flex flex-wrap gcm" role="tabpanel">
-            {{- range . -}}
-              {{- range . -}}
-                {{- $schemaPath := path.Split . -}}
-                {{- $schema := index $components.schemas $schemaPath.File -}}
-                {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
-              {{ end }}
-              {{- $oneOfInd = add $oneOfInd 1 -}}
-            {{- end -}}
-          </div>
-        </fieldset>
-      </form>
-      {{- $oneOfInd = 0 -}}
-      {{- range . -}}
-        {{- range . -}}
-          {{- $schemaPath := path.Split . -}}
-          {{- $schema := index $components.schemas $schemaPath.File -}}
-          {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
-          {{- $oneOfInd = add $oneOfInd 1 -}}
-        {{- end -}}
-      {{- end -}}
-    {{ end }} 
 
 {{/*  If object, render and pass properties  */}}
 {{- else if eq $schemaObj.type "object" -}}
@@ -73,24 +49,32 @@
   {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
 
   {{/*  Render oneOf radio inputs  */}}
-  {{- if eq $oneOf "radio" -}}
+  {{- if eq $isOf "radio" -}}
     <div>
-      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of role="tab" aria-controls="tab-json-{{ $name | anchorize }}" {{ if eq $oneOfInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
+      <input id="{{ $levelId }}" type="radio" value="{{ $levelName }}" name="{{ anchorize $parent }}" class="mrxs" data-one-of aria-controls="json-{{ $name | anchorize }}" {{ if eq $ofInd 0 }}checked{{ end }}/><label for="{{ $levelId }}"><code>{{ $name }}</code></label>
     </div>
-    {{/*  Loop oneOf data  */}}
-  {{- else if eq $oneOf "data" -}}
+
+  {{/*  Render allOf select options  */}}
+  {{- else if eq $isOf "select" -}}
+    <option value="{{ $levelName }}" {{ if eq $ofInd 0 }}selected{{ end }}>{{ $name }}</option>
+
+  {{/*  Loop oneOf data  */}}
+  {{- else if in $isOf "Data" -}}
     {{- with $schemaObj.properties -}}
-      <dl id="tab-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" role="tabpanel" aria-labelledby="{{ $levelName }}">
+      <dl id="json-{{ $name | anchorize }}" class="pls {{ if ne $ofInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" {{ if in $isOf "one" }}aria-label="{{ $name }}"{{ end }}>
         {{- range $key, $_ := . -}}
           {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
   {{- else -}}
-    <div class="mb-border bb bw1 mbs">
-      <div class="flex flex-wrap align-ifs pbs">
+    {{/*  countering the effect of isOf below reclevel 2  */}}
+    <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
+      <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>
-          {{- with $schemaObj.properties -}}
+          {{- if $isFirstLevelOf -}}
+            Schema selector
+          {{- else if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.allOf) ($schemaObj.items) -}}
             {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
@@ -108,7 +92,7 @@
           </div>
         </dd>
       </div>
-
+      {{/*  object  */}}
       {{- with $schemaObj.properties -}}
         <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
@@ -116,6 +100,63 @@
               {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
             {{- end -}}
           </dl>
+        </dd>
+      {{- end -}}
+      {{/*  oneOf object  */}}
+      {{- with $schemaObj.oneOf -}}
+        <dd class="{{ if gt $recLevel 2 }}schema__sublist mb-border dn{{ end }}" id="{{ $levelId }}">
+          <form>
+            <fieldset class="mlxs mbs pls pbs">
+              <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
+              <div class="flex flex-wrap gcm">
+                {{- range . -}}
+                  {{- range . -}}
+                    {{- $schemaPath := path.Split . -}}
+                    {{- $schema := index $components.schemas $schemaPath.File -}}
+                    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                  {{- end -}}
+                  {{- $ofInd = add $ofInd 1 -}}
+                {{- end -}}
+              </div>
+            </fieldset>
+          </form>
+          {{- $ofInd = 0 -}}
+          {{- range . -}}
+            {{- range . -}}
+              {{- $schemaPath := path.Split . -}}
+              {{- $schema := index $components.schemas $schemaPath.File -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+              {{- $ofInd = add $ofInd 1 -}}
+            {{- end -}}
+          {{- end -}}
+        </dd>
+      {{- end -}}
+      {{/*  allOf object  */}}
+      {{- with $schemaObj.allOf -}}
+        {{- $levelName := printf "%s-%s-%s" $endpointId (anchorize $name) "requestjson" -}}
+        <dd class="{{ if gt $recLevel 2 }}schema__sublist mb-border dn{{ end }}" id="{{ $levelId }}">
+          <div class="mlxs mbs pls pbs">
+            <label class="form__label" for="{{ $levelName }}">Schema (allOf)</label>
+            <select class="form__control wauto maxw100p" id="{{ $levelName }}" data-one-of>
+              {{- range . -}}
+                {{- range . -}}
+                  {{- $schemaPath := path.Split . -}}
+                  {{- $schema := index $components.schemas $schemaPath.File -}}
+                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                {{- end -}}
+                {{- $ofInd = add $ofInd 1 -}}
+              {{- end -}}
+            </select>
+          </div>
+          {{- $ofInd = 0 -}}
+          {{- range . -}}
+            {{- range . -}}
+              {{- $schemaPath := path.Split . -}}
+              {{- $schema := index $components.schemas $schemaPath.File -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+              {{- $ofInd = add $ofInd 1 -}}
+            {{- end -}}
+          {{- end -}}
         </dd>
       {{- end -}}
     </div>
@@ -145,6 +186,9 @@
         {{- with $schema.oneOf -}}
           {{- $hasChildren = true -}}
         {{- end -}}
+        {{- with $schema.allOf -}}
+          {{- $hasChildren = true -}}
+      {{- end -}}
       {{- end -}}
     {{- end -}}
   {{- end -}}
@@ -196,19 +240,19 @@
     {{- with $schemaObj.items -}}
       <dd class="schema__sublist mb-border {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
         {{- $isItemRef := false -}}
-        {{- $isItemOneOfRef := false -}}
+        {{- $isItemOfRef := false -}}
         {{/*  Check for oneOf  */}}
         {{- range $key, $_ := . -}}
           {{- if eq $key "$ref" -}}
             {{- $schemaPath := path.Split . -}}
             {{- $schema := index $components.schemas $schemaPath.File -}}
-            {{- if $schema.oneOf -}}
-              {{ $isItemOneOfRef = true }}
+            {{- if or $schema.oneOf $schema.allOf -}}
+              {{- $isItemOfRef = true }}
                 {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
             {{- end -}}
           {{- end -}}
         {{- end -}}
-        {{- if not $isItemOneOfRef -}}
+        {{- if not $isItemOfRef -}}
           <dl class="pls">
             {{- range $key, $_ := . -}}
               {{- if eq $key "$ref" -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -202,7 +202,7 @@
           <code class="mls">{{ $name }}</code>
         {{- end -}}
         {{- if $required -}}
-          <div class="plm mls lh-solid param-required text-note">Required</div>
+          <div class="mls lh-solid param-required text-note">Required</div>
         {{- end -}}
       </dt>
       <dd class="ptxs pls">

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -68,7 +68,7 @@
       </dl>
     {{- end -}}
   {{- else -}}
-    {{/*  countering the effect of isOf below reclevel 2  */}}
+    {{/*  Render first level isOf without visible dt  */}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -96,8 +96,8 @@
         <dd class="schema__sublist mb-border {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <form>
             <fieldset class="mlxs mbs pls pbs">
-              <legend class="fw600 pts mbxs">oneOf</legend>
-              <div class="flex flex-wrap gcm" role="tabpanel">
+              <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
+              <div class="flex flex-wrap gcm">
                 {{- range $key, $_ := . -}}
                   {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
                   {{- $oneOfInd = add $oneOfInd 1 -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -42,8 +42,8 @@
     {{- with $schemaObj.oneOf -}}
       <form>
         <fieldset class="mlxs mbs pls pbs">
-          <legend class="fw600 pts mbxs">oneOf</legend>
-          <div class="flex flex-wrap gcm" role="tabpanel">
+          <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
+          <div class="flex flex-wrap gcm">
             {{- range . -}}
               {{- range . -}}
                 {{- $schemaPath := path.Split . -}}


### PR DESCRIPTION
Adds support for [allOf schema](https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/) in the request body. It will be used in the Shipment API as a way to switch between the different request body examples it has today. There is no live code for this yet, only a screenshot: 
<img width="827" alt="Screenshot 2023-01-06 at 15 23 20" src="https://user-images.githubusercontent.com/9307503/211034005-41af3af1-205b-43c9-b43f-0cc41b9b3808.png">

Updated the legend in the response schema for oneOf to something a bit less cryptic – open to suggestions on those.

Also fixed a couple of things that was excluded from https://github.com/bring/developer-site/pull/1408 and I messed up in https://github.com/bring/developer-site/pull/1411