### PR TITLE
Render req example value correctly with 3 strings

### DIFF
--- a/layouts/partials/api/oas/requestexample.html
+++ b/layouts/partials/api/oas/requestexample.html
@@ -75,7 +75,7 @@
                         {{- $examplePath := path.Split . -}}
                         {{- $exampleId = (printf "%s-%s-%s" $requestId $examplePath.File (string $exInd)) | anchorize -}}
                       {{- else if not $hasRef -}}
-                        {{- $exampleId = (printf "%s-%s" $requestId $name (string $exInd)) | anchorize -}}
+                        {{- $exampleId = (printf "%s-%s-%s" $requestId $name (string $exInd)) | anchorize -}}
                       {{- end -}}
                     {{- end -}}
                     <option value="{{ $exampleId }}">{{ $name }}</option>


### PR DESCRIPTION
Leaving out a string renders the string but with some extra text. Either way the value of the select option is wrong and didn’t match the element it was meant to control.

This only affected request examples that were not using $ref.