### PR TITLE
Cleaning up Klimanøytral Servicepakke naming

### DIFF
--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -67,7 +67,7 @@ documentation:
              <td>No</td>
           </tr>
           <tr>
-             <td>Klimanøytral Servicepakke</td>
+             <td>Servicepakke</td>
              <td>1202</td>
              <td>Yes</td>
              <td>Yes</td>

--- a/content/api/services/revisedservice.html
+++ b/content/api/services/revisedservice.html
@@ -40,7 +40,7 @@ notanapi: true
     </thead>
     <tbody>
       <tr id="5800">
-        <td>Klimanøytral Servicepakke</td>
+        <td>Servicepakke</td>
         <td>SERVICEPAKKE</td>
         <td>Pakke til hentested</td>
         <td>

--- a/content/api/shipping-guide_2/callingsg.md
+++ b/content/api/shipping-guide_2/callingsg.md
@@ -211,11 +211,11 @@ The response may have changed since it was documented but you will get a respons
                                 <ns2:Trackable>false</ns2:Trackable>
                                 <ns2:Logo>BRING</ns2:Logo>
                                 <ns2:LogoUrl>https://www.mybring.com/shipping-guide/assets/img/Bring_logo.svg</ns2:LogoUrl>
-                                <ns2:DisplayName>Klimanøytral Servicepakke</ns2:DisplayName>
-                                <ns2:ProductName>Klimanøytral Servicepakke</ns2:ProductName>
+                                <ns2:DisplayName>Servicepakke</ns2:DisplayName>
+                                <ns2:ProductName>Servicepakke</ns2:ProductName>
                                 <ns2:DescriptionText>Pakken kan spores og utleveres på ditt lokale hentested.</ns2:DescriptionText>
-                                <ns2:HelpText>Klimanøytral Servicepakke leveres til mottakers lokale hentested (postkontor eller Post i Butikk). Mottaker kan velge å hente sendingen på et annet hentested enn sitt lokale. Mottaker varsles om at sendingen er ankommet via SMS, e-post eller hentemelding i postkassen. Sendingen kan spores ved hjelp av sporingsnummeret.</ns2:HelpText>
-                                <ns2:ShortName>Klimanøytral Servicepakke</ns2:ShortName>
+                                <ns2:HelpText>Servicepakke leveres til mottakers lokale hentested (postkontor eller Post i Butikk). Mottaker kan velge å hente sendingen på et annet hentested enn sitt lokale. Mottaker varsles om at sendingen er ankommet via SMS, e-post eller hentemelding i postkassen. Sendingen kan spores ved hjelp av sporingsnummeret.</ns2:HelpText>
+                                <ns2:ShortName>Servicepakke</ns2:ShortName>
                                 <ns2:ProductURL>http://www.bring.no/sende/pakker/private-i-norge/hentes-pa-posten</ns2:ProductURL>
                                 <ns2:DeliveryType>Hentested</ns2:DeliveryType>
                                 <ns2:MaxWeightInKgs>35</ns2:MaxWeightInKgs>
@@ -322,10 +322,10 @@ The response may have changed since it was documented but you will get a respons
                   "logo": "BRING",
                   "logoUrl": "https://www.qa.mybring.com/shipping-guide/assets/img/Bring_logo.svg",
                   "displayName": "Til hentested",
-                  "productName": "Klimanøytral Servicepakke",
+                  "productName": "Servicepakke",
                   "descriptionText": "Pakken kan spores og utleveres på ditt lokale hentested.",
-                  "helpText": "Klimanøytral Servicepakke leveres til mottakers lokale hentested (postkontor eller Post i Butikk). Mottaker kan velge å hente sendingen på et annet hentested enn sitt lokale. Mottaker varsles om at sendingen er ankommet via SMS, e-post eller hentemelding i postkassen. Sendingen kan spores ved hjelp av sporingsnummeret.",
-                  "shortName": "Klimanøytral Servicepakke",
+                  "helpText": "Servicepakke leveres til mottakers lokale hentested (postkontor eller Post i Butikk). Mottaker kan velge å hente sendingen på et annet hentested enn sitt lokale. Mottaker varsles om at sendingen er ankommet via SMS, e-post eller hentemelding i postkassen. Sendingen kan spores ved hjelp av sporingsnummeret.",
+                  "shortName": "Servicepakke",
                   "productURL": "http://www.bring.no/sende/pakker/private-i-norge/hentes-pa-posten",
                   "deliveryType": "Hentested",
                   "maxWeightInKgs": "35"

--- a/content/api/shipping-guide_2/eta.md
+++ b/content/api/shipping-guide_2/eta.md
@@ -13,7 +13,7 @@ hidden: true
 For the following Norwegian domestic parcel and cargo services you can now get extended leadtime information - the estimated arrival time.
 * Bedriftspakke (BPAKKE_DOR-DOR)
 * Pakke til bedrift (5000)
-* Klimanøytral Servicepakke (SERVICEPAKKE)
+* Servicepakke (SERVICEPAKKE)
 * Pakke til hentested (5800)
 * Stykkgods til bedrift (5100)
 * Stykkgods (CARGO)
@@ -79,7 +79,7 @@ Even though the API response schema supports minute granularity for start and en
 Note that Bring cannot guarantee the arrival time for a specific parcel. The estimated arrival time indicates when, based on historical scanning data, the parcel normally will arrive at the recipient address.
 
 ## Parcels going to pickup points
-For the services Klimanøytral Servicepakke (SERVICEPAKKE) and Pakke til hentested (5800), you can now get extended leadtime information - the estimated arrival time for one or more pickup points.
+For the services Servicepakke (SERVICEPAKKE) and Pakke til hentested (5800), you can now get extended leadtime information - the estimated arrival time for one or more pickup points.
 
 Earlier, we have just returned the expected delivery **date** when you request our Shipping Guide API to get leadtime for SERVICEPAKKE/5800. Now, based on a machine learning model gathering scanning data from all pickup points in Norway, we are also predicting the **arrival window** - i.e. when the parcel is expected to arrive at a specific pickup point on that specific date. If you are already showing expected delivery date in your checkout, we strongly recomment that you consider increasing the value by also including the predicted arrival window.
 


### PR DESCRIPTION
Should be referred to as Servicepakke from now on

- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.
