### PR TITLE
Add expand and collapse all buttons for schemas

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -259,3 +259,8 @@ div.response {
   margin-bottom: 0;
   flex: 1 1 8rem;
 }
+
+.schema__header:has(+ .schema__container .param-toggle-btn)
+  button[data-toggle-all] {
+  display: flex;
+}

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -253,7 +253,7 @@ div.response {
   margin-top: 0;
 }
 
-.schematype-select {
+.schematype__select {
   padding: 0.25rem;
   height: auto;
   margin-bottom: 0;

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -252,3 +252,10 @@ div.response {
 .example-wrap :first-child {
   margin-top: 0;
 }
+
+.schematype-select {
+  padding: 0.25rem;
+  height: auto;
+  margin-bottom: 0;
+  flex: 1 1 8rem;
+}

--- a/js/api.js
+++ b/js/api.js
@@ -15,6 +15,50 @@ paramToggleBtn.forEach((btn) => {
   })
 })
 
+// Show toggle all on pageload if there’s more than one toggle button in schema
+function showToggleAll() {
+  const schemaContainerArr = document.querySelectorAll('.schemacontainer')
+  if (schemaContainerArr) {
+    schemaContainerArr.forEach((schemaContainer) => {
+      const schemaToggles = schemaContainer.querySelectorAll(
+        '.param-toggle-btn'
+      )
+      if (schemaToggles.length > 1) {
+        const toggleAllContainer = schemaContainer.previousElementSibling,
+          toggleAllPair = toggleAllContainer.querySelectorAll(
+            'button[data-toggle-all]'
+          )
+        toggleAllPair.forEach((toggleAllBtn) => {
+          toggleAllBtn.classList.remove('dn')
+        })
+      }
+    })
+  }
+}
+
+// Toggle all within a schema
+const toggleAllArr = document.querySelectorAll('button[data-toggle-all]')
+
+toggleAllArr.forEach((toggleAllBtn) => {
+  toggleAllBtn.addEventListener('click', function () {
+    const toggleType = toggleAllBtn.dataset.toggleAll,
+      closestDiv = toggleAllBtn.closest('div'),
+      closestSchema = closestDiv.nextElementSibling,
+      toggleBtnArr = closestSchema.querySelectorAll('.param-toggle-btn')
+
+    let expand = 'false'
+    if (toggleType === 'collapse') {
+      expand = 'true'
+    }
+
+    toggleBtnArr.forEach((toggleBtn) => {
+      if (toggleBtn.getAttribute('aria-expanded') === expand) {
+        toggleBtn.click()
+      }
+    })
+  })
+})
+
 // oneOf and allOf
 function showSelectedSchema(ofElement) {
   const elementVal = ofElement.value,
@@ -192,6 +236,7 @@ if('clipboard' in navigator) {
 }
 
 document.addEventListener("DOMContentLoaded", function () {
+  showToggleAll()
   // set oneOf selection if reload/backward/forward navigation
   oneOfRadioArr.forEach((radio) => {
     if (radio.checked) {

--- a/js/api.js
+++ b/js/api.js
@@ -15,9 +15,10 @@ paramToggleBtn.forEach((btn) => {
   })
 })
 
+// Firefox fallback because it lacks of support for css has()
 // Show toggle all on pageload if there’s more than one toggle button in schema
 function showToggleAll() {
-  const schemaContainerArr = document.querySelectorAll('.schemacontainer')
+  const schemaContainerArr = document.querySelectorAll('.schema__container')
   if (schemaContainerArr) {
     schemaContainerArr.forEach((schemaContainer) => {
       const schemaToggles = schemaContainer.querySelectorAll(

--- a/layouts/partials/api/namedparamsdl.html
+++ b/layouts/partials/api/namedparamsdl.html
@@ -15,17 +15,17 @@
             <dd>{{- . -}}</dd>
           {{- end -}}
           <dt class="screen-reader-text">Type</dt>
-          <dd class="gray">{{ delimit .type " " }}</dd>
+          <dd class="gray text-note">{{ delimit .type " " }}</dd>
 
           {{- with .enum -}}
-              <dt><span class="fw600">Enum</span></dt>
+              <dt><span class="text-note fw600">Enum</span></dt>
               {{- range . -}}
                 <dd><code>{{ . }}</code></dd>
               {{- end -}}
           {{- end -}}
 
           {{- with .example -}}
-            <dt><span class="fw600">Example</span></dt>
+            <dt><span class="text-note fw600">Example</span></dt>
             {{- $type := printf "%T" . -}}
             {{- if eq $type "[]interface {}" -}}
               {{- range . -}}

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -47,7 +47,7 @@
                     {{- if $multiSchema -}}
                     <div class="flex flex-wrap align-ib gcxs">
                       <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
-                      <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control schematype-select" name="formats">
+                      <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control schematype__select" name="formats">
                         {{- range $applicationType, $_ := . -}}
                           {{- $typeClean := lower (anchorize $applicationType) -}}
                           <option value="{{ $typeClean }}">
@@ -129,7 +129,7 @@
                           {{- if $multiSchema -}}
                             <div class="flex flex-wrap align-ib gcxs">
                               <label class="form__label text-basic" for="{{ $endpointId }}-{{ $response }}">Media type:</label>
-                              <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{ $endpointId }}-{{ $response }}" class="form__control schematype-select" name="formats">
+                              <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{ $endpointId }}-{{ $response }}" class="form__control schematype__select" name="formats">
                                 {{- range $applicationType, $_ := . -}}
                                   {{- $typeClean := lower (anchorize $applicationType) -}}
                                   <option value="{{ $typeClean }}">

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -41,40 +41,53 @@
                 {{- if gt (len .) 1 -}}
                   {{- $multiSchema = true -}}
                 {{- end -}}
-                <div class="mb-border bb flex flex-wrap mbm pbxs align-ib gcm">
-                  <h4 class="fw600 mb0">Body schema</h4>
-                  {{- if $multiSchema -}}
-                  <div class="flex flex-wrap align-ib gcxs">
-                    <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
-                    <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control wauto maxw100p paxs hauto mb0" name="formats">
+                <div class="mb-border bb flex align-ib gas mbm pbxs">
+                  <div class="flex flex-wrap align-ib gcm grs mr-auto">
+                    <h4 class="fw600 mb0">Body schema</h4>
+                    {{- if $multiSchema -}}
+                    <div class="flex flex-wrap align-ib gcxs">
+                      <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
+                      <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control schematype-select" name="formats">
+                        {{- range $applicationType, $_ := . -}}
+                          {{- $typeClean := lower (anchorize $applicationType) -}}
+                          <option value="{{ $typeClean }}">
+                            {{ $applicationType }}
+                          </option>
+                        {{- end -}}
+                      </select>
+                    </div>
+                    {{- else -}}
                       {{- range $applicationType, $_ := . -}}
-                        {{- $typeClean := lower (anchorize $applicationType) -}}
-                        <option value="{{ $typeClean }}">
-                          {{ $applicationType }}
-                        </option>
+                        <p class="mb0">Media type: {{ $applicationType }}</p>
                       {{- end -}}
-                    </select>
-                  </div>
-                  {{- else -}}
-                    {{- range $applicationType, $_ := . -}}
-                      <p class="mb0 text-note">Media type: {{ $applicationType }}</p>
                     {{- end -}}
+                  </div>
+                  <button
+                    type="button"
+                    class="btn-link--dark dn"
+                    data-toggle-all="expand"
+                    aria-label="Expand all body schema levels">Expand all</button>
+                  <button
+                    type="button"
+                    class="btn-link--dark dn"
+                    data-toggle-all="collapse"
+                    aria-label="Collapse all body schema levels">Collapse all</button>
+                </div>
+                <div class="schemacontainer">
+                  {{- range $application, $_ := . -}}
+                    {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
+                    {{- $format := $fTC.format -}}
+                    {{- $typeClean := $fTC.typeClean -}}
+
+                    <dl class="schema-type-container desc-list mbl" data-type="{{ $typeClean }}">
+                      {{- if eq "xml" $format -}}
+                        {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
+                      {{- else -}}
+                        {{- partial "api/oas/request-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
+                      {{- end -}}
+                    </dl>
                   {{- end -}}
                 </div>
-
-                {{- range $application, $_ := . -}}
-                  {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
-                  {{- $format := $fTC.format -}}
-                  {{- $typeClean := $fTC.typeClean -}}
-
-                  <dl class="schema-type-container desc-list mbl" data-type="{{ $typeClean }}">
-                    {{- if eq "xml" $format -}}
-                      {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
-                    {{- else -}}
-                      {{- partial "api/oas/request-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
-                    {{- end -}}
-                  </dl>
-                {{- end -}}
               {{- end -}}
             {{- end -}}
           {{- end -}}
@@ -110,36 +123,53 @@
                       <span class="fw600">{{ $response }}</span> {{ $description }}
                     </summary>
                     <div class="bg-gray1 pam">
-                      <h4 class="fw600">Schema</h4>
-                      {{- if $multiSchema -}}
-                        <label class="form__label text-basic dib" for="{{ $endpointId }}-{{ $response }}">Media type:</label>
-                        <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{ $endpointId }}-{{ $response }}" class="form__control wauto maxw100p paxs dib hauto" name="formats">
-                          {{- range $applicationType, $_ := . -}}
-                            {{- $typeClean := lower (anchorize $applicationType) -}}
-                            <option value="{{ $typeClean }}">
-                              {{ $applicationType }}
-                            </option>
-                          {{- end -}}
-                        </select>
-                      {{- else -}}
-                        {{- range $applicationType, $_ := . -}}
-                          <p>Media type: {{ $applicationType }}</p>
-                        {{- end -}}
-                      {{- end -}}
-
-                      {{- range $application, $_ := . -}}
-                        {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
-                        {{- $format := $fTC.format -}}
-                        {{- $typeClean := $fTC.typeClean -}}
-
-                        <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{ $typeClean }}">
-                          {{- if eq "xml" $format -}}
-                            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                      <div class="flex align-ib gas mbs">
+                        <div class="flex flex-wrap align-ib gcm grs mr-auto">
+                          <h4 class="fw600">Schema</h4>
+                          {{- if $multiSchema -}}
+                            <div class="flex flex-wrap align-ib gcxs">
+                              <label class="form__label text-basic" for="{{ $endpointId }}-{{ $response }}">Media type:</label>
+                              <select id="{{$endpointId}}-{{$response}}" data-sub-of="{{ $endpointId }}-{{ $response }}" class="form__control schematype-select" name="formats">
+                                {{- range $applicationType, $_ := . -}}
+                                  {{- $typeClean := lower (anchorize $applicationType) -}}
+                                  <option value="{{ $typeClean }}">
+                                    {{ $applicationType }}
+                                  </option>
+                                {{- end -}}
+                              </select>
+                            </div>
                           {{- else -}}
-                            {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                            {{- range $applicationType, $_ := . -}}
+                              <p class="mb0">Media type: {{ $applicationType }}</p>
+                            {{- end -}}
                           {{- end -}}
-                        </dl>
-                      {{- end -}}
+                        </div>
+                        <button
+                          type="button"
+                          class="btn-link--dark dn"
+                          data-toggle-all="expand"
+                          aria-label="Expand all code {{ $response }} schema levels">Expand all</button>
+                        <button
+                          type="button"
+                          class="btn-link--dark dn"
+                          data-toggle-all="collapse"
+                          aria-label="Collapse all code {{ $response }} schema levels">Collapse all</button>
+                      </div>
+                      <div class="schemacontainer">
+                        {{- range $application, $_ := . -}}
+                          {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
+                          {{- $format := $fTC.format -}}
+                          {{- $typeClean := $fTC.typeClean -}}
+
+                          <dl class="schema-type-container desc-list pam bshadow bg-white" data-type="{{ $typeClean }}">
+                            {{- if eq "xml" $format -}}
+                              {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                            {{- else -}}
+                              {{- partial "api/oas/response-schema.html" (dict "schemaObj" .schema "name" "" "components" $components "responseCode" $response "endpointId" $endpointId "recLevel" 0) -}}
+                            {{- end -}}
+                          </dl>
+                        {{- end -}}
+                      </div>
                     </div>
                   </details>
                 {{- end -}}

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -41,7 +41,7 @@
                 {{- if gt (len .) 1 -}}
                   {{- $multiSchema = true -}}
                 {{- end -}}
-                <div class="mb-border bb flex align-ib gas mbm pbxs">
+                <div class="mb-border bb flex align-ib gas mbm pbxs schema__header">
                   <div class="flex flex-wrap align-ib gcm grs mr-auto">
                     <h4 class="fw600 mb0">Body schema</h4>
                     {{- if $multiSchema -}}
@@ -73,7 +73,7 @@
                     data-toggle-all="collapse"
                     aria-label="Collapse all body schema levels">Collapse all</button>
                 </div>
-                <div class="schemacontainer">
+                <div class="schema__container">
                   {{- range $application, $_ := . -}}
                     {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
                     {{- $format := $fTC.format -}}
@@ -123,7 +123,7 @@
                       <span class="fw600">{{ $response }}</span> {{ $description }}
                     </summary>
                     <div class="bg-gray1 pam">
-                      <div class="flex align-ib gas mbs">
+                      <div class="flex align-ib gas mbs schema__header">
                         <div class="flex flex-wrap align-ib gcm grs mr-auto">
                           <h4 class="fw600">Schema</h4>
                           {{- if $multiSchema -}}
@@ -155,7 +155,7 @@
                           data-toggle-all="collapse"
                           aria-label="Collapse all code {{ $response }} schema levels">Collapse all</button>
                       </div>
-                      <div class="schemacontainer">
+                      <div class="schema__container">
                         {{- range $application, $_ := . -}}
                           {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
                           {{- $format := $fTC.format -}}

--- a/layouts/partials/api/oas/param-toggle-btn-xml.html
+++ b/layouts/partials/api/oas/param-toggle-btn-xml.html
@@ -1,9 +1,0 @@
-<button title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn" aria-expanded="{{ if lt .recLevel 3 }}true{{ else }}false{{ end }}" aria-controls="{{ .levelId }}">
-  <span
-    data-mybicon="mybicon-arrow-right"
-    data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 3}}rotate-icon-90{{end}}"
-    data-mybicon-width="16"
-    data-mybicon-height="16">
-  </span>
-  <code>{{ .name }}</code>
-</button>

--- a/layouts/partials/api/oas/param-toggle-btn.html
+++ b/layouts/partials/api/oas/param-toggle-btn.html
@@ -1,7 +1,7 @@
-<button title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn" aria-expanded="{{ if lt .recLevel 3 }}true{{ else }}false{{ end }}" aria-controls="{{ .levelId }}">
+<button title="Toggle {{ .name }} parameters" class="btn-link param-collapsed-btn param-toggle-btn" aria-expanded="{{ if lt .recLevel .threshold }}true{{ else }}false{{ end }}" aria-controls="{{ .levelId }}">
   <span
     data-mybicon="mybicon-arrow-right"
-    data-mybicon-class="icon-ui mrxs param-toggle-icon {{if lt .recLevel 2}}rotate-icon-90{{end}}"
+    data-mybicon-class="icon-ui mrxs param-toggle-icon {{ if lt .recLevel .threshold }}rotate-icon-90{{ end }}"
     data-mybicon-width="16"
     data-mybicon-height="16">
   </span>

--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -65,7 +65,7 @@
         <dt class="pls">
           <code>{{- replace .name "MyBring" "Mybring" -}}</code>
           {{- if eq .required true -}}
-            <br><span class="mb-badge mb-badge--red">Required</span>
+            <div class="param-required text-note">Required</div>
           {{- end -}}
         </dt>
         <dd class="pls">
@@ -75,11 +75,11 @@
               <dd>{{- . -}}</dd>
             {{- end -}}
             <dt class="screen-reader-text">Type</dt>
-            <dd class="gray">{{ $type }}</dd>
+            <dd class="gray text-note">{{ $type }}</dd>
 
             {{- if and (reflect.IsSlice $enum) ( gt (len $enum) 0 ) -}}
               <div class="mbxs">
-                <dt><span class="fw600">
+                <dt><span class="fw600 text-note">
                   {{- if gt (len $enum) 1 -}}
                     Enum
                   {{- else -}}
@@ -94,20 +94,20 @@
 
             {{- if gt (len $default) 0 -}}
               <div class="mbxs">
-                <dt><span class="fw600">Default</span></dt>
+                <dt><span class="fw600 text-note">Default</span></dt>
                 <dd><code>{{ $default }}</code></dd>
               </div>
             {{- end -}}
 
             {{- if gt (len $example) 0 -}}
               <div class="mbxs">
-                <dt><span class="fw600">Example</span></dt>
+                <dt><span class="fw600 text-note">Example</span></dt>
                 <dd><code class="mbxs db maxwmaxc">{{ $example }}</code></dd>
               </div>
             {{- end -}}
 
             {{- if gt (len $examples) 0 -}}
-              <dt><span class="fw600">
+              <dt><span class="fw600 text-note">
                 {{- if gt (len $examples) 1 -}}
                   Examples
                 {{- else -}}

--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -70,7 +70,7 @@
           {{- if $isFirstLevelOf -}}
             Schema selector
           {{- else if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.allOf) ($schemaObj.items) -}}
-            {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 3) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
           {{- end -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -75,7 +75,7 @@
           {{- if $isFirstLevelOf -}}
             Schema selector
           {{- else if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.allOf) ($schemaObj.items) -}}
-            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 2) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
           {{- end -}}
@@ -197,7 +197,7 @@
     <div class="flex flex-wrap align-ifs pbs">
       <dt>
         {{- if $hasChildren -}}
-          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 2) -}}
         {{- else -}}
           <code class="mls">{{ $name }}</code>
         {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -61,7 +61,7 @@
       <div class="flex flex-wrap align-ifs pbs">
         <dt>
           {{- if or ($schemaObj.properties) ($schemaObj.oneOf) ($schemaObj.items) -}}
-            {{- partial "api/oas/param-toggle-btn-xml.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 3) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
           {{- end -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -94,7 +94,7 @@
       <div class="flex flex-wrap align-ifs pbs">
         <dt>
           {{- with $schemaObj.properties -}}
-            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+            {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 2) -}}
           {{- else -}}
             <code class="mls">{{ $name }}</code>
           {{- end -}}
@@ -156,7 +156,7 @@
     <div class="flex flex-wrap align-ifs pbs">
       <dt>
         {{- if $hasChildren -}}
-          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel) -}}
+          {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 2) -}}
         {{- else -}}
           <code class="mls">{{ $name }}</code>
         {{- end -}}


### PR DESCRIPTION
Small things that turn out to not be that small …

Adds two buttons because neither really reflect state. For example, it’s possible to expand all and then collapse individual ones.
I tried to make keep it simple – there’s always the possibility to check every media type for levels and just not render the buttons at all, but I ended up hiding them as default and use JS to show them based for schemas that have a total of more than one toggle button.
Most of the time, if they have one toggle, it’s the first XML level which is open by default – or if there’s only JSON, one single toggle doesn’t need three buttons to do the same.

Responsiveness was probably the most tricky to solve.

The request and response schemas had slightly different text sizes and the "required" tag was styled differently. So that’s fixed now. Room for improvement on that still – some of the text looks a bit too small, but let’s return to it if it bugs us over time.

The toggle button had a bug, but it wasn’t visible until looking at some of the new, unpublished docs, where one toggle remained had mismatch between its state and the aria-expanded, rendering the toggle unresponsive as the JS operate with the aria. Fixing it while reducing the two template files into one.

![Screenshot 2023-01-13 at 15 37 55](https://user-images.githubusercontent.com/9307503/212346026-33552582-8550-43eb-8112-6cc1777beaf5.png)