### PR TITLE
Always show singular media type schemas

### DIFF
--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -62,12 +62,15 @@
                   {{- end -}}
                 </div>
 
+                {{- $multiTypes := false -}}
+                {{- if gt (len .) 1 -}}
+                  {{- $multiTypes = true -}}
+                {{- end -}}
                 {{- range $application, $_ := . -}}
                   {{- $fTC := partial "api/oas/format-type-clean.html" (dict "application" $application) -}}
                   {{- $format := $fTC.format -}}
                   {{- $typeClean := $fTC.typeClean -}}
-
-                  <dl class="schema-type-container desc-list mbl" data-type="{{ $typeClean }}">
+                  <dl class="schema-type-container desc-list mbl" {{ if $multiTypes }}data-type="{{ $typeClean }}"{{ end }}>
                     {{- if eq "xml" $format -}}
                       {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" .schema "name" "" "components" $components "endpointId" $endpointId "recLevel" 0) -}}
                     {{- else -}}


### PR DESCRIPTION
Prevents JSON to be hidden if XML is selected and JSON is the only type in a schema.
Example in bookingnew API.