### PR TITLE
Updating address api oas ref

### DIFF
--- a/content/api/address/index.md
+++ b/content/api/address/index.md
@@ -29,5 +29,5 @@ information:
 
       Returned format is controlled by the `Accept` header. Supported values are `application/json` and `application/xml`. Default returned format is JSON.
 
-oas: https://api.bring.com/address/api-docs/
+oas: https://api.bring.com/address/api-docs/address
 ---


### PR DESCRIPTION
With postal code API migrated to address API, the oas data for address api is moved to new url. 

- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.
