### PR TITLE
Adding change-log notification about the new postal code API

### DIFF
--- a/content/api/postal-code/index.md
+++ b/content/api/postal-code/index.md
@@ -10,11 +10,6 @@ menu:
     parent: checkout
 weight: 14
 
-important:
-  - type: warn
-    message: |
-      Integration with shipping guide for postal code lookup is deprecated (Base url: https://api.bring.com/shippingguide/api). We recommend switching to pickup point if you have not already done so (Base url: https://api.bring.com/pickuppoint/api).
-
 introduction: |
   The Postal Code API can be used for:
   * postal code validation

--- a/content/api/revision-history/2023-01-24.md
+++ b/content/api/revision-history/2023-01-24.md
@@ -1,0 +1,8 @@
+---
+title: New postal code API
+publishDate: 2023-01-24
+layout: api
+notanapi: true
+---
+
+A new [postal code API](https://developer.bring.com/api/postal-code/) is now available. The postal code API hosted under /pickuppoint/api/postalCode has been deprecated.


### PR DESCRIPTION
And removing warning about shippingguide being deprecated. We could add another warning that the postal code api in pickuppoint is deprecated

- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.
