### PR TITLE
Add API updates signup form on all API pages

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -60,18 +60,35 @@
   row-gap: 2rem;
 }
 
-.dev-docscontent__side {
-  flex: 1 1 24rem;
-  max-width: 64rem;
-}
-
 .dev-docscontent__main {
   flex: 2 1 32rem;
-  overflow: auto;
 }
 
 .dev-docscontent__info {
   max-width: 68ch;
+}
+
+.dev-docscontent__grid {
+  display: grid;
+  gap: 0 2rem;
+  grid-template-areas:
+  "intro messages"
+  "intro signup";
+  grid-template-columns: minmax(20rem,60rem) minmax(20rem, 28rem);
+  grid-template-rows: auto 1fr;
+  padding: 0 2rem;
+}
+
+.grid__intro {
+  grid-area: intro;
+}
+
+.grid__messages {
+  grid-area: messages;
+}
+
+.grid__signup {
+  grid-area: signup;
 }
 
 .dev-docs__menu {
@@ -126,6 +143,14 @@
 
   .dev-docscontent__section {
     padding: 0 2rem 3rem 2rem;
+  }
+}
+
+@media screen and (max-width: 48em) {
+  .dev-docscontent__grid {
+    display: flex;
+    flex-flow: column nowrap;
+    padding: 0 6vw;
   }
 }
 

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -76,7 +76,6 @@
   "intro signup";
   grid-template-columns: minmax(20rem,60rem) minmax(20rem, 28rem);
   grid-template-rows: auto 1fr;
-  padding: 0 2rem;
 }
 
 .grid__intro {
@@ -150,7 +149,6 @@
   .dev-docscontent__grid {
     display: flex;
     flex-flow: column nowrap;
-    padding: 0 6vw;
   }
 }
 

--- a/css/updates.css
+++ b/css/updates.css
@@ -8,6 +8,11 @@
  max-width: 32rem;
 }
 
+@media screen and (max-width: 48em) {
+  .updates__sub {
+    margin-bottom: 2rem;
+  }
+}
 
 /* Overwrites */
 input.mce_inline_error  {

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -8,7 +8,7 @@
     >
       <article>
         <h1>{{ .title }}</h1>
-        <section id="api-documentation" class="dev-docscontent__grid">
+        <section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
           {{- with $.Params.important -}}
             <div class="grid__messages">
               <div class="mbl">
@@ -23,7 +23,7 @@
               </div>
             </div>
           {{- end -}}
-          <div class="dev-docscontent__main maxw64r mbl grid__intro">
+          <div class="dev-docscontent__main maxw64r mbm grid__intro">
             {{- with $.Params.introduction -}}
               {{- if in (string .) "\n\n" -}}
               <div class="text-heading fw600">

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -8,12 +8,12 @@
     >
       <article>
         <h1>{{ .title }}</h1>
-        <section id="api-documentation" class="dev-docscontent__section dev-docscontent__wrap">
-          <div class="dev-docscontent__side">
-            {{- with $.Params.important -}}
+        <section id="api-documentation" class="dev-docscontent__grid">
+          {{- with $.Params.important -}}
+            <div class="grid__messages">
               <div class="mbl">
                 {{- range . -}}
-                  <div class="message--{{ .type }} updates__sub pal mbs">
+                  <div class="message--{{ .type }} pal mbs">
                     {{- with .title -}}
                       <strong class="db mbxs">{{ . }}</strong>
                     {{- end -}}
@@ -21,13 +21,9 @@
                   </div>
                 {{- end -}}
               </div>
-            {{- end -}}
-            <div class="updates__sub bg-green1 pal align-sfs">
-              <h2>Subscribe to updates</h2>
-              {{- partial "subscribe.html" -}}
             </div>
-          </div>
-          <div class="dev-docscontent__main maxw64r">
+          {{- end -}}
+          <div class="dev-docscontent__main maxw64r mbl grid__intro">
             {{- with $.Params.introduction -}}
               {{- if in (string .) "\n\n" -}}
               <div class="text-heading fw600">
@@ -75,10 +71,14 @@
               {{- end -}}
             {{- end -}}
           </div>
+          <div class="updates__sub bg-green1 pal align-sfs grid__signup">
+            <h2>Subscribe to updates</h2>
+            {{- partial "subscribe.html" -}}
+          </div>
         </section>
         {{- $baseUri := .baseUri -}}
         {{- with .resources -}}
-          <section class="dev-docscontent__section maxw64r">
+          <section class="dev-docscontent__section maxw96r">
             <h2 class="dev-anchored mbm" id="endpoints">
               Endpoints
             </h2>

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -4,23 +4,29 @@
     {{- $types := .types -}}
     <main 
       id="main"
-      class="dev-docscontent w100p maxw96r {{ replace .title "API" "" | anchorize }}"
+      class="dev-docscontent w100p {{ replace .title "API" "" | anchorize }}"
     >
       <article>
         <h1>{{ .title }}</h1>
         <section id="api-documentation" class="dev-docscontent__section dev-docscontent__wrap">
-          {{- with $.Params.important -}}
-            <div class="dev-docscontent__side">
-              {{- range . -}}
-                <div class="message--{{ .type }} pal mbs">
-                  {{- with .title -}}
-                    <strong class="db mbxs">{{ . }}</strong>
-                  {{- end -}}
-                  {{ .message | markdownify }}
-                </div>
-              {{- end -}}
+          <div class="dev-docscontent__side">
+            {{- with $.Params.important -}}
+              <div class="mbl">
+                {{- range . -}}
+                  <div class="message--{{ .type }} updates__sub pal mbs">
+                    {{- with .title -}}
+                      <strong class="db mbxs">{{ . }}</strong>
+                    {{- end -}}
+                    {{ .message | markdownify }}
+                  </div>
+                {{- end -}}
+              </div>
+            {{- end -}}
+            <div class="updates__sub bg-green1 pal align-sfs">
+              <h2>Subscribe to updates</h2>
+              {{- partial "subscribe.html" -}}
             </div>
-          {{- end -}}
+          </div>
           <div class="dev-docscontent__main maxw64r">
             {{- with $.Params.introduction -}}
               {{- if in (string .) "\n\n" -}}

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -1,17 +1,23 @@
 <h1>{{ .Title }}</h1>
 <section id="api-documentation" class="dev-docscontent__section dev-docscontent__wrap">
-  {{- with $.Params.important -}}
-    <div class="dev-docscontent__side">
-      {{- range . -}}
-        <div class="message--{{ .type }} pal mbs">
-          {{- with .title -}}
-            <strong class="db mbxs">{{ . }}</strong>
-          {{- end -}}
-          {{ .message | markdownify }}
-        </div>
-      {{- end -}}
+  <div class="dev-docscontent__side">
+    {{- with $.Params.important -}}
+      <div class="mbl">
+        {{- range . -}}
+          <div class="message--{{ .type }} updates__sub pal mbs">
+            {{- with .title -}}
+              <strong class="db mbxs">{{ . }}</strong>
+            {{- end -}}
+            {{ .message | markdownify }}
+          </div>
+        {{- end -}}
+      </div>
+    {{- end -}}
+    <div class="updates__sub bg-green1 pal align-sfs">
+      <h2>Subscribe to updates</h2>
+      {{- partial "subscribe.html" -}}
     </div>
-  {{- end -}}
+  </div>
   <div class="dev-docscontent__main maxw64r">
     {{- with $.Params.introduction -}}
       {{- if in (string .) "\n\n" -}}

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -1,5 +1,5 @@
 <h1>{{ .Title }}</h1>
-<section id="api-documentation" class="dev-docscontent__grid">
+<section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
   {{- with $.Params.important -}}
     <div class="grid__messages">
       <div class="mbl">
@@ -14,7 +14,7 @@
       </div>
     </div>
   {{- end -}}
-  <div class="dev-docscontent__main maxw64r mbl grid__intro">
+  <div class="dev-docscontent__main maxw64r mbm grid__intro">
     {{- with $.Params.introduction -}}
       {{- if in (string .) "\n\n" -}}
       <div class="text-heading fw600">

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -1,10 +1,10 @@
 <h1>{{ .Title }}</h1>
-<section id="api-documentation" class="dev-docscontent__section dev-docscontent__wrap">
-  <div class="dev-docscontent__side">
-    {{- with $.Params.important -}}
+<section id="api-documentation" class="dev-docscontent__grid">
+  {{- with $.Params.important -}}
+    <div class="grid__messages">
       <div class="mbl">
         {{- range . -}}
-          <div class="message--{{ .type }} updates__sub pal mbs">
+          <div class="message--{{ .type }} pal mbs">
             {{- with .title -}}
               <strong class="db mbxs">{{ . }}</strong>
             {{- end -}}
@@ -12,13 +12,9 @@
           </div>
         {{- end -}}
       </div>
-    {{- end -}}
-    <div class="updates__sub bg-green1 pal align-sfs">
-      <h2>Subscribe to updates</h2>
-      {{- partial "subscribe.html" -}}
     </div>
-  </div>
-  <div class="dev-docscontent__main maxw64r">
+  {{- end -}}
+  <div class="dev-docscontent__main maxw64r mbl grid__intro">
     {{- with $.Params.introduction -}}
       {{- if in (string .) "\n\n" -}}
       <div class="text-heading fw600">
@@ -82,5 +78,9 @@
     {{- with $.Params.guides -}}
       {{- partial "api/oas/tips-and-guides.html" . -}}
     {{- end -}}
+  </div>
+  <div class="updates__sub bg-green1 pal align-sfs grid__signup">
+    <h2>Subscribe to updates</h2>
+    {{- partial "subscribe.html" -}}
   </div>
 </section>

--- a/layouts/partials/subscribe.html
+++ b/layouts/partials/subscribe.html
@@ -55,8 +55,15 @@
             <label class="checkbox subfield form__check mbm" for="gdpr_366129"><input type="checkbox" id="gdpr_366129" name="gdpr[366129]" value="Y" class="av-checkbox gdpr">I confirm that Posten Norge AS can send me API update emails</label>
           </fieldset>
         </div>
-        <details class="mb-disclosure mbl bg-gray1">
-          <summary>Privacy policy</summary>
+        <details class="mb-disclosure mb-disclosure--arrow bg-green1 mbl">
+          <summary>
+            <span
+              data-mybicon="mybicon-arrow-right"
+              data-mybicon-width="16"
+              data-mybicon-height="16"
+            ></span>
+            Privacy policy
+          </summary>
           <div class="text-note pas content__gdprLegal">
             <p>You can unsubscribe at any time by clicking the link in the footer of our emails. Read more about <a href="https://www.bring.com/privacy-policy" target="_blank" rel="noopener noreferrer">our privacy policy</a>.</p>
             <p>We use Mailchimp. By clicking below to subscribe, you acknowledge that your information will be transferred to Mailchimp for processing. <a href="https://mailchimp.com/legal/terms" target="_blank">Learn more about Mailchimp's privacy practices here.</a></p>


### PR DESCRIPTION
Adding the API updates signup form on all API pages with this PR. Also, refactoring the upper part into grid, so the signup form can move beneath the intro section on smaller screens.

**Without any "important" messages**
<img width="1370" alt="Skjermbilde 2023-01-26 kl  10 35 17" src="https://user-images.githubusercontent.com/65193388/214803091-d3c8881f-69a5-48e7-abe7-1ba0cda735bd.png">

**With some "important" messages**
<img width="1365" alt="Skjermbilde 2023-01-26 kl  10 38 52" src="https://user-images.githubusercontent.com/65193388/214803764-de08b3be-073c-495f-b5db-f06379c841cb.png">
