### PR TITLE
Upgrade checkout action to v3

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
+++ b/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
@@ -19,7 +19,7 @@ jobs:
       ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
       ALGOLIA_INDEX: ${{ github.ref == 'refs/heads/master' && 'devsite_prod' || 'devsite_qa' }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           submodules: true
       - name: Build and Deploy


### PR DESCRIPTION
Got a warning in the workflow that we should use node 16 – which required an upgrade of https://github.com/actions/checkout to v3.