### PR TITLE
Add API area to RSS feed titles

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -31,10 +31,14 @@
 {{- $latestPage = . }}
 {{- end -}}
 {{- $pLink := .Permalink -}}
+{{- $pageTitle := .Title -}}
+{{- if .Params.apiArea -}}
+{{- $pageTitle = (printf "%s %s %s %s" $pageTitle " - " .Params.apiArea "APIs") -}}
+{{- end -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>
-    <title>Bring {{ if eq .Title .Site.Title }}{{ .Site.Title }}{{ else }}{{ with .Title }}{{.}}{{ end }}{{ end }}</title>
+    <title>Bring {{ $pageTitle }}</title>
     <link>{{ .Permalink }}</link>
     <description>{{ if ne .Title .Site.Title }}{{ with .Title }}{{.}} {{ end }}{{ end }}on {{ .Site.Title }}</description>
     <generator>Hugo -- gohugo.io</generator>


### PR DESCRIPTION
Adding the API area to RSS feed titles, if the param `apiArea` is present. This title is also read by Mailchimp for sending the campaigns that are set up based on the RSS feeds for the Bring API updates.

The general RSS (all API updates combined):
- Bring API updates

Each API area RSS:
- Bring API updates - `param.apiArea` APIs

**Examples:** 
Bring API updates - Checkout APIs
Bring API updates - Reports and invoices APIs
