### PR TITLE
Make XML examples render correctly

### DIFF
--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -63,11 +63,15 @@
 
       {{/*  object  */}}
       {{ with $schemaObj.properties }}
-
-        {{ range $key, $val := . }}
-          {{ $xmlObjectPart := partial "api/oas/json-to-xml.html" (dict "schemaObj" $val "name" $key "components" $components "exampleObj" $exampleObj "lev" $lev) }}
-          {{ with $xmlObjectPart }}
-            {{ $xmlObject = printf "%s%s" $xmlObject $xmlObjectPart }}
+        {{ $properties := . }}
+        {{ range $exampleKey, $_ := $exampleObj }}
+          {{ range $key, $val := $properties }}
+            {{ if eq (lower $key) (lower $exampleKey) }}
+              {{ $xmlObjectPart := partial "api/oas/json-to-xml.html" (dict "schemaObj" $val "name" $key "components" $components "exampleObj" $exampleObj "lev" $lev) }}
+              {{ with $xmlObjectPart }}
+                {{ $xmlObject = printf "%s%s" $xmlObject $xmlObjectPart }}
+              {{ end }}
+            {{ end }}
           {{ end }}
         {{ end }}
       {{ end }}

--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -1,9 +1,10 @@
-{{/*  Works similar to the schema template but $exampleObj is added to the mix to get values and numbers  */}}
+{{/*  Works similar to the schema template but $exampleObj is added to the mix to check for existence of keys and get values and numbers  */}}
 {{ $schemaObj := .schemaObj }}
 {{ $exampleObj := .exampleObj }}
+{{/*  name can change if there is an xml name  */}}
 {{ $name := .name }}
+{{/*  objName doesn’t change  */}}
 {{ $objName := .name }}
-{{ $required := .required }}
 {{ $components := .components }}
 
 {{ $lev := add .lev 1 }}
@@ -17,7 +18,7 @@
   {{ $XML = $exampleObj }}
 {{ else }}
 
-  {{/*  If there’s a ref, pass the destination data again  */}}
+  {{/*  If there’s a ref, get the data from components and pass it again  */}}
   {{ $isRef := "false" }}
   {{ range $key, $_ := $schemaObj }}
     {{ if eq $key "$ref" }}
@@ -77,11 +78,11 @@
       {{ end }}
 
       {{/*  array  */}}
-      {{/*  loop exampleobject and pass the it further in since arrays are wrapped  */}}
+      {{/*  loop exampleobject and pass it further in since arrays are wrapped  */}}
       {{ with $schemaObj.items }}
         {{ $xmlArray := "" }}
         {{ range $key, $_ := $exampleObj }}
-          {{ if eq $objName $key }}
+          {{ if eq (lower $objName) (lower $key) }}
             {{ range . }}
               {{ $xmlArrayPart := partial "api/oas/json-to-xml.html" (dict "schemaObj" $schemaObj.items "name" $key "components" $components "exampleObj" . "lev" $lev) }}
               {{ $xmlArray = printf "%s%s" $xmlArray $xmlArrayPart }}


### PR DESCRIPTION
All objects in the schema were rendered in the XML version of the examples even if they didn’t have any content or weren’t otherwise present in the JSON example.

### before
<img width="493" alt="Screenshot 2023-03-20 at 16 29 40" src="https://user-images.githubusercontent.com/9307503/226388892-b08755a2-3eb7-45d0-83c8-36087a88d470.png">

### after
<img width="492" alt="Screenshot 2023-03-20 at 16 29 24" src="https://user-images.githubusercontent.com/9307503/226388908-54d99598-3d8b-497e-a6ad-93839f1eb708.png">
