### PR TITLE
Prevent service portfolio from freezing (quickfix)

### DIFF
--- a/js/servicefiltering-vas.js
+++ b/js/servicefiltering-vas.js
@@ -194,7 +194,9 @@ if (container) {
         scrollToTarget(cleanAnchorTag)
       }, 100)
     } else {
-      cutoffRows(items, 10)
+        // Temporarily disabling hiding, since it crashes the page in Chrome
+        // cutoffRows(items, 10)
+        hideCutoffs(cutoff)
     }
   
     const anchors = document.querySelectorAll(".anchorjs-link")

--- a/layouts/partials/services/booking-sg.html
+++ b/layouts/partials/services/booking-sg.html
@@ -1,4 +1,4 @@
-{{- partial "services/spreadsheetinfo" (dict "filename" "services_booking_shippingguide.xlsx") -}}
+{{- partial "services/spreadsheetinfo" (dict "filename" "services_booking_shippingguide.xlsx" "name" "Booking and Shipping Guide") -}}
 <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
   <div class="mrl">
     <div class="flex flex-wrap-reverse align-ifs">

--- a/layouts/partials/services/reports-invoice.html
+++ b/layouts/partials/services/reports-invoice.html
@@ -1,4 +1,4 @@
-{{- partial "services/spreadsheetinfo" (dict "filename" "services_reports_invoice.xlsx") -}}
+{{- partial "services/spreadsheetinfo" (dict "filename" "services_reports_invoice.xlsx" "name" "Reports and Invoice") -}}
 <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 rad-a2px">
   <div class="mrl">
     <div class="flex flex-wrap-reverse align-ifs">

--- a/layouts/partials/services/spreadsheetinfo.html
+++ b/layouts/partials/services/spreadsheetinfo.html
@@ -1,13 +1,13 @@
 <p class="mtm mbl">
   {{ $href := printf "/services/%s" .filename }}
-  <a href="{{ $href | relURL }}" class="btn-link--dark mrm di">
+  <a href="{{ $href | relURL }}" class="flex align-ic maxwmaxc">
     <span
       data-mybicon="mybicon-download_file"
       data-mybicon-class="icon-ui mrxs"
       data-mybicon-width="16"
       data-mybicon-height="16"
     ></span
-    >Download spreadsheet</a
+    >Download spreadsheet for {{ .name }} APIs</a
   >
   Information applies to revised services only.
 </p>


### PR DESCRIPTION
A quickfix to prevent service portfolio from freezing in Chrome – have tried a number of things without luck. A working page is better than anything.

Also adjusted the two download links on the same page, they were identical and didn’t register as links in siteimprove.