### PR TITLE
Anchorize guid and remove whitespace from RSS feed

### DIFF
--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -65,8 +65,10 @@
         <title>{{ .Title }}</title>
         <link>{{ $pLink }}</link>
         <pubDate>{{ .PublishDate.Format "Mon, 02 Jan 2006" | safeHTML }} 06:04:05 +0100</pubDate>
-        {{ with .Site.Author.email }}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{end}}
-        <guid>{{ .PublishDate.Format "2006-01-02" | safeHTML }}{{ .Title }}</guid>
+        {{- with .Site.Author.email -}}<author>{{.}}{{ with $.Site.Author.name }} ({{.}}){{end}}</author>{{- end -}}
+        {{- $dateTitle := print (.PublishDate.Format "2006-01-02" | safeHTML) "-" .Title -}}
+        {{- $guid := anchorize $dateTitle -}}
+        <guid isPermaLink="false">{{ $guid }}</guid>
         <description>{{ .Content | html }}</description>
       </item>
     {{- end -}}


### PR DESCRIPTION
RSS feed validation is complaining about some invalid characters in the `guid` element for each `item` in the RSS feed we are generating for API updates. Could be the spaces in the `guid`, so here are the adjustments that are done with this PR:

- Anchorizing the `guid` value, that consists of publish date and title, so the spaces are replaced by dash `-`.
- Adding `isPermaLink="false"` on `guid`, since the ids are not...permalinks...
- Removing whitespace between lines if no author exists.