### PR TITLE
Make filtering on API updates page

### DIFF
--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -41,27 +41,29 @@
       <label class="form__label" for="filterChangelogInput">Filter API updates</label>
       <input type="text" class="form__control maxw16r" id="filterChangelogInput" />
       {{/* Set $pages to the rearranged structure */}}
-      {{- $pages = $rearrangedPages -}}
-      {{- range first 5 $pages -}}
-        {{- $parentFolder := path.Base (path.Dir .) -}}
-        <article class="mbl" data-changelog-parent="{{$parentFolder}}">
-          <header class="flex flex-dir-col-rev">
-            <h2 class="text-heading fw600 mb0">{{ .Title }}</h2>
-            <time
-              class="mrm text-note fw600"
-              datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
-              >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
-            >
-          </header>
-          {{ .Content }}
-        </article>
-      {{- end -}}
+      <div aria-busy="false" aria-atomic="true" aria-live="polite" data-live-region>
+        {{- $pages = $rearrangedPages -}}
+        {{- range first 5 $pages -}}
+          {{- $parentFolder := path.Base (path.Dir .) -}}
+          <article class="mbl" data-changelog-parent="{{$parentFolder}}">
+            <header class="flex flex-dir-col-rev">
+              <h2 class="text-heading fw600 mb0">{{ .Title }}</h2>
+              <time
+                class="mrm text-note fw600"
+                datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                >{{ .PublishDate.Format "2. January 2006" | safeHTML }}</time
+              >
+            </header>
+            {{ .Content }}
+          </article>
+        {{- end -}}
+      </div>
     </div>
   </div>
   {{- if (gt (len $pages) 5) -}}
   <details class="mb-disclosure" id="olderApiUpdates">
     <summary class="pam maxw32r bg-gray1">Older updates</summary>
-    <div class="flex flex-wrap">
+    <div class="flex flex-wrap" aria-busy="true" aria-atomic="true" aria-live="polite" data-live-region>
       {{- range after 5 $pages -}}
         {{- $parentFolder := path.Base (path.Dir .) -}}
         <article class="changelog-small bg-gray1 pal mbxs" data-changelog-parent="{{$parentFolder}}">
@@ -89,21 +91,46 @@
     const olderApiUpdates = document.getElementById('olderApiUpdates');
     let filterInputVal = e.target.value.trim();
 
+    const resetAriaBusy = (regions) => {
+      let articleVisible = false;
+      setTimeout(() => {
+        regions.forEach((el) => {
+          const articles = el.querySelectorAll('article');
+          for (let i = 0; i < articles.length; i++) {
+            if(!articles[i].classList.contains('dn') && regions[0] === el) {
+              articleVisible = true;
+            }
+          }
+          if(articleVisible && regions[0] === el) {
+            el.setAttribute('aria-busy', 'false');
+          } else if(!articleVisible && regions[1] === el) {
+            el.setAttribute('aria-busy', 'false');
+          }
+        });
+      }, 2000);
+    }
+
     const filterByInput = (changelog) => {
+      const ariaLiveRegions = document.querySelectorAll('[data-live-region]');
       if (filterInputVal.length >= 2 && filterInputVal !== '') {
         const changelogText = changelog.innerText;
         const changelogDataAttr = changelog.dataset.changelogParent;
         let regEx = new RegExp(filterInputVal,'i');
 
         changelog.classList.add('dn');
+        ariaLiveRegions.forEach((el) => {
+          el.setAttribute('aria-busy', 'true');
+        });
 
         if (regEx.test(changelogText) || regEx.test(changelogDataAttr)) {
           olderApiUpdates.setAttribute('open', true);
           changelog.classList.remove('dn');
         }
+        resetAriaBusy(ariaLiveRegions);
       } else {
         olderApiUpdates.removeAttribute('open');
         changelog.classList.remove('dn');
+        resetAriaBusy(ariaLiveRegions);
       }
     }
     if (changelogList && changelogList.length > 0) {

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -93,7 +93,7 @@
       if (filterInputVal.length >= 2 && filterInputVal !== '') {
         const changelogText = changelog.innerText;
         const changelogDataAttr = changelog.dataset.changelogParent;
-        let regEx = new RegExp(`${filterInputVal}`,'i');
+        let regEx = new RegExp(filterInputVal,'i');
 
         changelog.classList.add('dn');
 

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -15,7 +15,7 @@
       {{- if (in .CurrentSection "revision-history/_") -}}
         {{- $pctx = .Site -}}
       {{- end -}}
-      <h2 class="mbl">{{$pageSubTitle}}</h2>
+      <h2 class="mbm">{{$pageSubTitle}}</h2>
       {{- $mergedPages := slice -}}
       {{/* Get entries from the main folder when in context of a sub-section */}}
       {{- if (eq $pctx .) -}}
@@ -38,10 +38,13 @@
       {{- range sort $mergedPages "pubDate" "desc" -}}
         {{- $rearrangedPages = $rearrangedPages | append .pagePath -}}
       {{- end -}}
+      <label class="form__label" for="filterChangelogInput">Filter API updates</label>
+      <input type="text" class="form__control maxw16r" id="filterChangelogInput" />
       {{/* Set $pages to the rearranged structure */}}
       {{- $pages = $rearrangedPages -}}
       {{- range first 5 $pages -}}
-        <article class="mbl">
+        {{- $parentFolder := path.Base (path.Dir .) -}}
+        <article class="mbl" data-changelog-parent="{{$parentFolder}}">
           <header class="flex flex-dir-col-rev">
             <h2 class="text-heading fw600 mb0">{{ .Title }}</h2>
             <time
@@ -56,11 +59,12 @@
     </div>
   </div>
   {{- if (gt (len $pages) 5) -}}
-  <details class="mb-disclosure">
+  <details class="mb-disclosure" id="olderApiUpdates">
     <summary class="pam maxw32r bg-gray1">Older updates</summary>
     <div class="flex flex-wrap">
       {{- range after 5 $pages -}}
-        <article class="changelog-small bg-gray1 pal mbxs">
+        {{- $parentFolder := path.Base (path.Dir .) -}}
+        <article class="changelog-small bg-gray1 pal mbxs" data-changelog-parent="{{$parentFolder}}">
           <header class="flex flex-dir-col-rev">
             <h2 class="text-basic fw600 mb0">{{ .Title }}</h2>
             <time
@@ -76,3 +80,34 @@
   </details>
   {{- end -}}
 </section>
+
+<script type="text/javascript">
+  const filterInput = document.getElementById('filterChangelogInput');
+
+  filterInput.addEventListener('keyup', (e) => {
+    const changelogList = document.querySelectorAll('[data-changelog-parent]');
+    const olderApiUpdates = document.getElementById('olderApiUpdates');
+    let filterInputVal = e.target.value.trim();
+
+    const filterByInput = (changelog) => {
+      if (filterInputVal.length >= 2 && filterInputVal !== '') {
+        const changelogText = changelog.innerText;
+        const changelogDataAttr = changelog.dataset.changelogParent;
+        let regEx = new RegExp(`${filterInputVal}`,'i');
+
+        changelog.classList.add('dn');
+
+        if (regEx.test(changelogText) || regEx.test(changelogDataAttr)) {
+          olderApiUpdates.setAttribute('open', true);
+          changelog.classList.remove('dn');
+        }
+      } else {
+        olderApiUpdates.removeAttribute('open');
+        changelog.classList.remove('dn');
+      }
+    }
+    if (changelogList && changelogList.length > 0) {
+      changelogList.forEach(filterByInput);
+    }
+  });
+</script>


### PR DESCRIPTION
Adding a text input field for filtering on API updates page. This will search through **all** the text of each API update + the API area the update belongs to on `keyup` event. If the input matches the whole, or part of a string, the relevant API updates will be displayed. All others will be hidden.

This could be handled with `includes()` function as well, but using this function things become case-sensitive, so would need to throw some other function on stuff, like `toLowerCase()`, in order to make sure that the input matches parts of the text of each API update. 
I decided therefore to make use of `RegExp` that has a built-in flag for case-insensitivity named `i`, and just `test()` the input value with the API update content and the API area the update belongs to, and then display the relevant API updates.

**Aria-live:**
There are 2 live regions that need to be handled with the `aria-live`, `aria-busy`, `aria-atomic` attributes. If both regions are updated and `aria-busy` is set to `false`, only the last live region was announced with the voice-over tool. Therefore it got a bit trickier to make the logic where the aria-busy is set to false only if there are visible articles in the first region, not the second, and vice versa. 
Setting the `aria-atomic` to `true` is for making sure the whole live region gets announced from start, and not continuing reading out where it left of previously.

**Page:**
https://developer.bring.com/api/revision-history/

<img width="657" alt="Skjermbilde 2023-04-20 kl  13 10 31" src="https://user-images.githubusercontent.com/65193388/233348924-cd3f394f-cbf9-4604-9718-2990f3b8d571.png">
