### PR TITLE
Use dashes instead of underscore in job names

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
+++ b/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
 
 jobs:
-  build_and_deploy_job:
+  build-and-deploy:
     if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     runs-on: ubuntu-latest
-    name: Build and Deploy Job
+    name: Build and Deploy
     env:
       ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
       ALGOLIA_INDEX: ${{ github.ref == 'refs/heads/master' && 'devsite_prod' || 'devsite_qa' }}
@@ -55,7 +55,7 @@ jobs:
         run: |
           curl -sX POST -H "Content-type: application/json" -d "$SLACK_MESSAGE" ${{ secrets.SLACK_WEBHOOK }}
 
-  close_pull_request_job:
+  close-pull-request:
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
     runs-on: ubuntu-latest
     name: Close Pull Request Job


### PR DESCRIPTION
It’s possible that Terraform has issues when referring to things with underscore – at least the new branch protection doesn’t catch the job name reference.
