### PR TITLE
Add subscription info on getting started page

### DIFF
--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -129,7 +129,16 @@ aliases:
 </section>
 
 <section class="dev-docscontent__section">
-  <h2 class="dev-anchored" id="status-and-support">Status and support</h2>
+  <h2 class="dev-anchored" id="status-and-support">
+    Updates, status and support
+  </h2>
+  <p>
+    Stay up to date on changes and new features by subscribing to
+    <a
+      href='{{< relref "revision-history">}}'
+      >API updates</a
+    >. You can subscribe to all or pick the areas relevant to you.
+  </p>
   <p>
     We continuously monitor our APIs with health checks to measure uptime.
     Real-time and historical status can be found on the

--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -150,7 +150,6 @@ aliases:
   <h2 class="dev-anchored" id="formats">Formats</h2>
   <p>
     All our APIs are REST APIs supporting JSON and XML.
-    <a class="nowrap" href="./booking/">Booking</a>,
     <a class="nowrap" href="./order-management/">Order Management</a> and
     <a class="nowrap" href="./warehousing/">Warehousing</a> are also SOAP APIs.
   </p>

--- a/content/api/pickup-point/svalbard.md
+++ b/content/api/pickup-point/svalbard.md
@@ -4,7 +4,7 @@ layout: api
 notanapi: true
 menu:
   apidocs:
-    identifier: svalbard
+    identifier: pupsvalbard
     title: Svalbard
     parent: pickuppoint
 weight: 5

--- a/content/api/shipping-guide_2/svalbard.md
+++ b/content/api/shipping-guide_2/svalbard.md
@@ -4,7 +4,7 @@ layout: api
 notanapi: true
 menu:
   apidocs:
-    identifier: svalbard
+    identifier: sgsvalbard
     title: Svalbard
     parent: shippingguide_2
 weight: 17
@@ -17,5 +17,5 @@ For returns you still have to contact you forwarder for booking at tromso.suppor
 
 ## Surcharge Svalbard
 
-This surcharge applies to all parcel products sent from/to Svalbard. More details can be found [here](https://www.bring.no/tjenester/pakker-og-gods/pristillegg-til-svalbard)
+This surcharge applies to all parcel products sent from/to Svalbard. More details about [Svalbard surcharges](https://www.bring.no/tjenester/pakker-og-gods/pristillegg-til-svalbard)
 


### PR DESCRIPTION
- Adding a link instead of the whole signup thing since that’s how that page operates.
- Fixing a couple of small unrelated things.