### PR TITLE
Replace PR template with PR comment function 

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-- [ ] [API update message](https://github.com/bring/developer-site#tips-for-writing-an-api-update-message) (changelog entry) has been reviewed by Mybring Experience.

--- a/.github/workflows/api-update-message-help-comment.yml
+++ b/.github/workflows/api-update-message-help-comment.yml
@@ -1,0 +1,21 @@
+name: API updates check
+
+on:
+  pull_request_target:
+    types: [opened, reopened]
+    paths:
+      - 'content/api/revision-history/**'
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'It looks like you have committed an API update message. It will be emailed to hundreds of people, so a certain quality level is important. There’s a <a href="https://www.mybring.com/design-system/guidelines/writing-information/">formula and checklist</a> that streamlines the writing, and you can ask <a href="https://posten.slack.com/archives/C77MHF7K9">Mybring Experience on Slack</a> for a text review.'
+            })

--- a/README.md
+++ b/README.md
@@ -97,20 +97,7 @@ In most cases, publish date is the same as the date of the change, but if the
 message is about an upcoming change, the change date should be mentioned in the
 body text.
 
-### Tips for writing an API update message
-
-- Get the names right. ("Pickup Point API", not "PickuppointAPI". "Mybring" not
-  "MyBring".)
-- Use complete service names ("Pakke i Postkassen" instead of "PiP").
-- Avoid using internal names, too technical jargon and uncommon abbreviations
-  ("XML" is ok, "PuP" is not).
-- Domain specific content like service code lists and code examples are fine.
-- Be clear about which users/customers are affected.
-- Describe what action users must take (if any).
-- Put yourself in the shoes of the user; is there anything that they might
-  misunderstand, have questions about or otherwise start worrying about?
-- Check typos and facts.
-- Try keeping it short.
+Consult the [formula and guide](https://www.mybring.com/design-system/guidelines/writing-information/) to writing these messages.
 
 ## Adding an important message to the frontpage
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ In most cases, publish date is the same as the date of the change, but if the
 message is about an upcoming change, the change date should be mentioned in the
 body text.
 
-Consult the [formula and guide](https://www.mybring.com/design-system/guidelines/writing-information/) to writing these messages.
+Consult the [formula and guide](https://www.mybring.com/design-system/guidelines/writing-information/) to writing these messages. You will also get a comment on your PR with the same link when there are additions in the revision-history folder.
 
 ## Adding an important message to the frontpage
 


### PR DESCRIPTION
The template appeared on every PR, but the comment appears when there are changes in the revision-history folder.
The guidelines in the readme are replaced with a link to MDS (which is updated in https://github.com/bring/mybring-design-system/pull/795)