### PR TITLE
Hide irrelevant parties params in booking API docs

### DIFF
--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -1,5 +1,7 @@
 {{- $schemaObj := .schemaObj -}}
 {{- $name := .name -}}
+{{- $objName := .objName -}}
+{{- $contactParent := .contactParent -}}
 {{- $required := .required -}}
 {{- $components := .components -}}
 {{- $endpointId := .endpointId -}}
@@ -27,9 +29,10 @@
 {{- range $key, $_ := $schemaObj -}}
 {{- if eq $key "$ref" -}}
   {{- $isRef = true -}}
+    {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
+    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
   {{- end -}}
 {{- end -}}
 
@@ -42,6 +45,7 @@
   {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
   {{- $uniqueId = slicestr $generateId 0 15 -}}
   {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
+  {{- $objName = $name -}}
 
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $isOf "radio" -}}
@@ -64,6 +68,14 @@
     {{- end -}}
   {{- else -}}
     {{/*  Render first level isOf without visible dt  */}}
+    {{/*  Only show contact details element for sender party (booking API docs)  */}}
+    {{- if and
+      (or (ne $name "contact") (ne $contactParent "consignee"))
+      (or (ne $name "contact") (ne $contactParent "consignor"))
+      (or (ne $name "contact") (ne $contactParent "importer"))
+      (or (ne $name "contact") (ne $contactParent "returnTo"))
+      (or (ne $name "contact") (ne $contactParent "recipient"))
+    -}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>
@@ -95,7 +107,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -149,6 +161,7 @@
         </dd>
       {{- end -}}
     </div>
+    {{- end -}}
   {{- end -}}
 
 {{/*  If neither obj, arr or ref, render the item */}}
@@ -156,6 +169,18 @@
   {{- with $schemaObj.xml.name -}}
     {{- $name = . -}}
   {{- end -}}
+  {{/*  Hide irrelevant params for specific parties (booking API docs)  */}}
+  {{- if and
+    (or (ne $name "additionalAddressInfo") (ne $objName "consignee"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "consignor"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "importer"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "returnTo"))
+    (or (ne $name "reference") (ne $objName "consignee"))
+    (or (ne $name "reference") (ne $objName "consignor"))
+    (or (ne $name "reference") (ne $objName "importer"))
+    (or (ne $name "reference") (ne $objName "returnTo"))
+    (or (ne $name "vatNumber") (ne $objName "returnTo"))
+  -}}
   <div class="mb-border bb bw1 mbs pbs pls">
     <div class="flex flex-wrap align-ifs">
       <dt>
@@ -191,4 +216,5 @@
       </dd>
     </div>
   </div>
+  {{- end -}}
 {{- end -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -1,5 +1,7 @@
 {{- $schemaObj := .schemaObj -}}
 {{- $name := .name -}}
+{{- $objName := .objName -}}
+{{- $contactParent := .contactParent -}}
 {{- $components := .components -}}
 {{- $required := .required -}}
 {{- $endpointId := .endpointId -}}
@@ -27,9 +29,10 @@
 {{- range $key, $_ := $schemaObj -}}
   {{- if eq $key "$ref" -}}
     {{- $isRef = true -}}
+    {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
+    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
   {{- end -}}
 {{- end -}}
 
@@ -47,6 +50,7 @@
   {{- $generateId := delimit (shuffle (split (md5 $name) "" )) "" -}}
   {{- $uniqueId = slicestr $generateId 0 15 -}}
   {{- $levelId := printf "%s-%s" $levelName $uniqueId -}}
+  {{- $objName = $name -}}
 
   {{/*  Render oneOf radio inputs  */}}
   {{- if eq $isOf "radio" -}}
@@ -69,6 +73,14 @@
     {{- end -}}
   {{- else -}}
     {{/*  Render first level isOf without visible dt  */}}
+    {{/*  Only show contact details element for sender party (booking API docs)  */}}
+    {{- if and
+      (or (ne $name "contact") (ne $contactParent "consignee"))
+      (or (ne $name "contact") (ne $contactParent "consignor"))
+      (or (ne $name "contact") (ne $contactParent "importer"))
+      (or (ne $name "contact") (ne $contactParent "returnTo"))
+      (or (ne $name "contact") (ne $contactParent "recipient"))
+    -}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
         <dt>
@@ -97,7 +109,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -160,6 +172,7 @@
         </dd>
       {{- end -}}
     </div>
+    {{- end -}}
   {{- end -}}
 
 {{/*  If array, render and pass items  */}}
@@ -276,6 +289,18 @@
 
 {{/*  If neither obj, arr or ref, render the item */}}
 {{- else if and (ne $schemaObj.type "object") (ne $schemaObj.type "array") (ne $isRef true) -}}
+  {{/*  Hide irrelevant params for specific parties (booking API docs)  */}}
+  {{- if and
+    (or (ne $name "additionalAddressInfo") (ne $objName "consignee"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "consignor"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "importer"))
+    (or (ne $name "additionalAddressInfo") (ne $objName "returnTo"))
+    (or (ne $name "reference") (ne $objName "consignee"))
+    (or (ne $name "reference") (ne $objName "consignor"))
+    (or (ne $name "reference") (ne $objName "importer"))
+    (or (ne $name "reference") (ne $objName "returnTo"))
+    (or (ne $name "vatNumber") (ne $objName "returnTo"))
+  -}}
   <div class="mb-border bb bw1 mbs pbs pls">
     <div class="flex flex-wrap align-ifs">
       <dt>
@@ -308,4 +333,5 @@
       </dd>
     </div>
   </div>
+  {{- end -}}
 {{- end -}}


### PR DESCRIPTION
The `parties` element contains `consignor`, `consignee`, `importer`, `sender`, `recipient` and `returnTo`, which are all implemented by the same DTO ([DtoParty](https://github.com/bring/booking-api/blob/master/src/main/java/no/bring/booking/api/dto/request/DtoParty.java)), so if we add a description for a param in `DtoParty`, said description is shown for all parties. However, not all params/descriptions are relevant for all parties, so we want to hide specific params depending on the party. It doesn't look like it's possible to do this with Swagger (on the `booking-api` side), so doing the changes here. 

@halvorsanden Let me know if there's a better (less hackish) way of achieving this 😛 

Preview of `consignee` party **before:**

<img width="669" alt="consignee before" src="https://github.com/bring/developer-site/assets/78538590/a93cbd64-7eeb-459c-8075-d9a63168f8a7">


**After:**

<img width="587" alt="consignee after" src="https://github.com/bring/developer-site/assets/78538590/45f9cc24-c91f-4fd6-9427-f82997fbfbce">

