### PR TITLE
Wrap xml string array elements

### DIFF
--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -84,8 +84,15 @@
         {{ range $key, $_ := $exampleObj }}
           {{ if eq (lower $objName) (lower $key) }}
             {{ range . }}
-              {{ $xmlArrayPart := partial "api/oas/json-to-xml.html" (dict "schemaObj" $schemaObj.items "name" $key "components" $components "exampleObj" . "lev" $lev) }}
-              {{ $xmlArray = printf "%s%s" $xmlArray $xmlArrayPart }}
+              {{ $xmlArrayEl := partial "api/oas/json-to-xml.html" (dict "schemaObj" $schemaObj.items "name" $key "components" $components "exampleObj" . "lev" $lev) }}
+              {{/*  If items type is string (and not object) wrap each array element on a new line  */}}
+              {{ if eq $schemaObj.items.type "string" }}
+                {{ with $schemaObj.items.xml.name }}
+                  {{ $key = . }}
+                {{ end }}
+                {{ $xmlArrayEl = printf "%s  <%s>%s</%s>\n" $indent $key $xmlArrayEl $key }}
+              {{ end }}
+              {{ $xmlArray = printf "%s%s" $xmlArray $xmlArrayEl }}
             {{ end }}
           {{ end }}
         {{ end }}

--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -45,8 +45,9 @@
     {{ if lt (len $objName) 1 }}
       {{ $xmlObject = "<!-- Example cannot be generated; root element name is undefined -->" }}
     {{ else }}
+      {{/*  Obj/arr start tag  */}}
       {{ $xmlObject = printf "%s<%s" $xmlObject $name }}
-      {{/*  in case it’s an object with children as attributes  */}}
+      {{/*  In case of children as attributes  */}}
       {{ range $schemaKey, $schemaVal := $schemaObj.properties }}
         {{ range $exampleKey, $exampleVal := $exampleObj }}
           {{ if eq (lower $schemaKey) (lower $exampleKey) }}
@@ -98,7 +99,7 @@
         {{ end }}
         {{ $xmlObject = printf "%s%s" $xmlObject $xmlArray }}
       {{ end }}
-
+      {{/*  Obj/arr end tag  */}}
       {{ $xmlObject = println (printf "%s%s</%s>" $xmlObject $indent $name) }}
     {{ end }}
     {{ $XML = printf "%s%s" $XML $xmlObject }}
@@ -114,7 +115,7 @@
       {{ if reflect.IsSlice $value }}
         {{ range $value }}
           {{ $value = . }}
-          {{ $xmlLine = printf "%s<%s>%s</%s>" $indent $name (string $value) $name  }}
+          {{ $xmlLine = printf "%s<%s>%s</%s>" $indent $name (string $value) $name }}
           {{ $XML = println (printf "%s%s" $XML $xmlLine) }}
         {{ end }}
       {{ else }}


### PR DESCRIPTION
The arrays that had string elements was just outputted as a row of text. From booking (List customer numbers and services):

<img width="454" alt="Screenshot 2023-08-11 at 11 09 58" src="https://github.com/bring/developer-site/assets/9307503/7ca90f15-d268-461d-b6e8-5ee15a4b5a97">

Wrapping them each in a tag with their wrapping xml named element.

<img width="422" alt="Screenshot 2023-08-11 at 11 09 35" src="https://github.com/bring/developer-site/assets/9307503/a3789a87-f699-408e-aafc-3aa06daa94d4">

Renamed xmlArrayPart to xmlArrayEl as items in arrays are "elements".