### PR TITLE
Update Modify Delivery API documentation

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -43,11 +43,12 @@ important:
       <h3 class="mlxs fwn">Booking</h3>
     </div>
     <p class="mhxs pll">
-      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents and order pickup.
+      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Modify certain shipments that are on their way, and order pickup.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/booking/">Booking API</a>
       <a class="btn-link--dark" href="/api/shipment/">Shipment API</a>
+      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 
@@ -62,12 +63,11 @@ important:
       <h3 class="mlxs fwn">Tracking</h3>
     </div>
     <p class="mhxs pll">
-      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks. Stop, reroute or modify shipments in transit.
+      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/tracking/">Tracking API</a>
       <a class="btn-link--dark" href="/api/event-cast/">Event Cast API</a>
-      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -43,12 +43,11 @@ important:
       <h3 class="mlxs fwn">Booking</h3>
     </div>
     <p class="mhxs pll">
-      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Modify certain shipments that are on their way, and order pickup.
+      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents and order pickup.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/booking/">Booking API</a>
       <a class="btn-link--dark" href="/api/shipment/">Shipment API</a>
-      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 
@@ -63,11 +62,12 @@ important:
       <h3 class="mlxs fwn">Tracking</h3>
     </div>
     <p class="mhxs pll">
-      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks.
+      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks. Stop, reroute or modify shipments in transit.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/tracking/">Tracking API</a>
       <a class="btn-link--dark" href="/api/event-cast/">Event Cast API</a>
+      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -44,7 +44,7 @@ documentation:
         - In transit (to final destination)
         - Home Delivery ordered
 
-      Any of the following value added services shout not already be present on the shipment:
+      Any of the following value added services should not already be present on the shipment:
         - Optional pickup point (0010)
         - Parcel locker (0011)
         - Home delivery from pickup point (1158)
@@ -53,7 +53,7 @@ documentation:
         - Ibox Sweden (1337)
         - Parcel locker same day (1373)
 
-  - title: Supported services in Norway
+  - title: Supported services
     content: |
       These services are available only for domestic Norway shipments, meaning shipments that are going from and to an address in Norway.
       <table>
@@ -137,19 +137,63 @@ documentation:
              <td>Yes</td>
              <td>Yes</td>
           </tr>
+          <tr>
+             <td>Business parcel</td>
+             <td>0330</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Business parcel bulk</td>
+             <td>0332</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Business pallet</td>
+             <td>0336</td>
+             <td>Yes</td>
+             <td>No</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Pickup parcel</td>
+             <td>0340</td>
+             <td>Yes</td>
+             <td>No</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Pickup parcel bulk</td>
+             <td>0342</td>
+             <td>Yes</td>
+             <td>No</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Home delivery parcel</td>
+             <td>0349</td>
+             <td>Yes</td>
+             <td>No</td>
+             <td>No</td>
+          </tr>
         </tbody>
       </table>
 
-  - title: Supported services outside Norway
+  - title: Limitations
     content: |
-      Outside Norway we support stop shipment and change address, but with limitations.
-      Please see the detailed overview below for each of the Modify Delivery
-      services and when they are available.
+      When ordering stop shipment there may be some scenarios we do not
+      support given the _from_ and _to_ country of the shipment. These scenarios are
+      listed below. Likewise, there are some limitations on change
+      address too - this is only available when the recipient country is Norway.
+      We do not allow changing the delivery address for shipments going to Sweden or Denmark.
+      Please note that all service codes not starting with **03XX**
+      are **only** available in Norway and the supported services can be seen in the table above.
 
-  - title: Stop shipment outside Norway
+  - title: Valid stop shipment scenarios
     content: |
-      These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
-      Please verify in the table below the service and from - to country is valid for your shipments.
       <table>
         <thead>
          <tr>
@@ -248,26 +292,5 @@ documentation:
         </tbody>
       </table>
 
-  - title: Change address outside Norway
-    content: |
-      These services are available **only** on shipments being sent to Norway from Sweden or Denmark.
-      <table>
-        <thead>
-         <tr>
-           <th>Service</th>
-           <th>Service Code</th>
-         </tr>
-        </thead>
-        <tbody>
-          <tr>
-             <td>Business parcel</td>
-             <td>0330</td>
-          </tr>
-          <tr>
-             <td>Business parcel bulk</td>
-             <td>0332</td>
-          </tr>
-        </tbody>
-      </table>
 oas: https://www.qa.mybring.com/modify-delivery/api-docs
 ---

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -15,10 +15,9 @@ introduction:
   their way to the recipient. Shipments can be stopped and returned to
   the sender, they can be rerouted to a new delivery address or it is
   possible to change the cash on delivery amount. We support
-  domestic and cross border services in Norway, Sweden and Denmark, but
+  domestic and cross border shipments in Norway, Sweden and Denmark, but
   please note that there are limitations to our services in Sweden and Denmark and that
-  Modify COD currently is not supported outside Norway. For full overview of valid service
-  and route combinations, see below.
+  Modify COD is not supported outside Norway. Detailed overview for our services can be found below.
 
 information:
   - title: Authentication

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -7,8 +7,8 @@ menu:
     identifier: modifydelivery
     title: Modify Delivery API
     url: /api/modify-delivery
-    parent: track
-weight: 33
+    parent: book
+weight: 23
 
 introduction:
   The Modify Delivery API can be used to modify shipments that are on

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -145,12 +145,12 @@ documentation:
     content: |
       Outside Norway we support stop shipment and change address, but with limitations.
       Please see the detailed overview below for each of the Modify Delivery
-      services and when they are available.g
+      services and when they are available.
 
   - title: Stop shipment outside Norway
     content: |
       These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
-      Please verify in the table below the service and to - from country is valid for your shipments.
+      Please verify in the table below the service and from - to country is valid for your shipments.
       <table>
         <thead>
          <tr>

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -30,8 +30,10 @@ information:
       REST XML/JSON over HTTP.
 
 documentation:
-  - title: Invalid events
+  - title: Common criteria
     content: |
+      There are some events or value added services that will make Modify Delivery services unavailable.
+
       Any of the following events should not already be present on the shipment:
         - Damaged
         - Deviation
@@ -41,6 +43,16 @@ documentation:
         - Partly delivered
         - Stop shipment
         - In transit (to final destination)
+        - Home Delivery ordered
+
+      Any of the following value added services shout not already be present on the shipment:
+        - Optional pickup point (0010)
+        - Parcel locker (0011)
+        - Home delivery from pickup point (1158)
+        - Home delivery redirect (1159)
+        - Parcel locker Norway (1298)
+        - Ibox Sweden (1337)
+        - Parcel locker same day (1373)
 
   - title: Supported services in Norway
     content: |

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -16,8 +16,8 @@ introduction:
   the sender, they can be rerouted to a new delivery address or it is
   possible to change the cash on delivery amount. We support
   domestic and cross border shipments in Norway, Sweden and Denmark, but
-  please note that there are limitations to our services in Sweden and Denmark and that
-  Modify COD is not supported outside Norway. Detailed overview for our services can be found below.
+  please note that there are limitations to our services in Sweden and Denmark.
+  Detailed overview for our services can be found below.
 
 information:
   - title: Authentication
@@ -184,13 +184,13 @@ documentation:
 
   - title: Limitations
     content: |
-      When ordering stop shipment there may be some scenarios we do not
+      - All service codes not starting with **03XX** are **only** available in Norway, and the supported services can be seen in the table above.
+      - When ordering stop shipment there may be some scenarios we do not
       support given the _from_ and _to_ country of the shipment. These scenarios are
-      listed below. Likewise, there are some limitations on change
-      address too - this is only available when the recipient country is Norway.
-      We do not allow changing the delivery address for shipments going to Sweden or Denmark.
-      Please note that all service codes not starting with **03XX**
-      are **only** available in Norway and the supported services can be seen in the table above.
+      shown in the table _Valid stop shipment scenarios_ below.
+      - Change address is available only when the recipient country is Norway.
+      - We do not allow changing the delivery address for shipments going to Sweden or Denmark.
+      - Modify cash on delivery is only available in Norway.
 
   - title: Valid stop shipment scenarios
     content: |

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -131,13 +131,14 @@ documentation:
 
   - title: Supported services outside Norway
     content: |
-      There are limitations on shipments that are either sent domestically
-      in Sweden and Denmark, or cross border between Norway, Sweden and Denmark.
-      Please see the detailed overview of the allowed service and to - from address
-      combinations below for stop shipment and change address. Currently, Modify COD is not supported on shipments outside of Norway.
+      Outside Norway we support stop shipment and change address, but with limitations.
+      Please see the detailed overview below for each of the Modify Delivery
+      services and when they are available.g
 
+  - title: Stop shipment outside Norway
+    content: |
       These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
-      Please verify in the table below if your to - from country is valid for the service on your shipments.
+      Please verify in the table below the service and to - from country is valid for your shipments.
       <table>
         <thead>
          <tr>
@@ -236,6 +237,8 @@ documentation:
         </tbody>
       </table>
 
+  - title: Change address outside Norway
+    content: |
       These services are available **only** on shipments being sent to Norway from Sweden or Denmark.
       <table>
         <thead>

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -8,7 +8,7 @@ menu:
     title: Modify Delivery API
     url: /api/modify-delivery
     parent: track
-weight: 23
+weight: 33
 
 introduction:
   The Modify Delivery API can be used to modify shipments that are on

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -12,11 +12,13 @@ weight: 23
 
 introduction:
   The Modify Delivery API can be used to modify shipments that currently are on
-  their way to the recipient. Shipments can either be stopped and returned to
-  the sender, or they can be rerouted to a new delivery address. It is also
-  possible to change the cash on delivery amount. At the moment, Parcel Norway
-  domestic services (with the exception of Pakke i postkassen and return
-  services) are supported.
+  their way to the recipient. Shipments can be stopped and returned to
+  the sender, they can be rerouted to a new delivery address or it
+  possible to change the cash on delivery amount. We support
+  domestic and cross border services in Norway, Sweden and Denmark, but
+  please note that there are limitations to our services in Sweden and Denmark.
+  Modify COD currently is not supported outside Norway at all.
+  For full overview of valid service and route combinations, see below.
 
 information:
   - title: Authentication
@@ -28,9 +30,9 @@ information:
       REST XML/JSON over HTTP.
 
 documentation:
-  - title: Common criteria
+  - title: Invalid events
     content: |
-      The shipment must have both sender and recipient address located in Norway. Additionally, any of the following events should not already be present on the shipment:
+      Any of the following events should not already be present on the shipment:
         - Damaged
         - Deviation
         - Returned
@@ -39,8 +41,9 @@ documentation:
         - Partly delivered
         - Stop shipment
 
-  - title: Supported services
+  - title: Supported domestic services
     content: |
+      These services are available only for domestic Norway shipments, meaning shipments that are going from and to an address in Norway.
       <table>
         <thead>
          <tr>
@@ -53,14 +56,14 @@ documentation:
         </thead>
         <tbody>
           <tr>
-             <td>Bedriftspakke Dør - Dør Innland</td>
+             <td>Bedriftspakke dør - dør innland</td>
              <td>1000</td>
              <td>Yes</td>
              <td>Yes</td>
              <td>Yes</td>
           </tr>
           <tr>
-             <td>Bedriftspakke ekspress over natten</td>
+             <td>Bedriftspakke Ekspress over natten</td>
              <td>1002</td>
              <td>Yes</td>
              <td>Yes</td>
@@ -74,14 +77,21 @@ documentation:
              <td>Yes</td>
           </tr>
           <tr>
-             <td>På Døren</td>
+             <td>På døren</td>
              <td>1736</td>
              <td>Yes</td>
              <td>Yes</td>
              <td>Yes</td>
           </tr>
           <tr>
-             <td>Bedriftspakke Standard</td>
+             <td>Bedriftspakke flerkolli</td>
+             <td>1988</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+          <tr>
+             <td>Bedriftspakke standard</td>
              <td>3500</td>
              <td>Yes</td>
              <td>Yes</td>
@@ -114,6 +124,137 @@ documentation:
              <td>Yes</td>
              <td>Yes</td>
              <td>Yes</td>
+          </tr>
+        </tbody>
+      </table>
+
+  - title: Supported services outside Norway
+    content: |
+      There are limitations on shipments that are either sent domestically
+      in Sweden and Denmark, or cross border between Norway, Sweden and Denmark.
+      Please see the detailed overview of the allowed service and to/from address
+      combinations below for Stop Shipment and Change Address. Currently, Modify COD is not supported.
+
+  - title: Valid services and combinations for Stop shipment
+    content: |
+      These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
+      Please verify in the table below if your to - from country is valid for the service on your shipments.
+      <table>
+        <thead>
+         <tr>
+           <th>Service</th>
+           <th>Service Code</th>
+           <th>NO - NO</th>
+           <th>NO - SE</th>
+           <th>NO - DK</th>
+           <th>SE - NO</th>
+           <th>SE - SE</th>
+           <th>SE - DK</th>
+           <th>DK - NO</th>
+           <th>DK - SE</th>
+           <th>DK - DK</th>
+         </tr>
+        </thead>
+        <tbody>
+          <tr>
+             <td>Business parcel</td>
+             <td>0330</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+          <tr>
+             <td>Business parcel bulk</td>
+             <td>0332</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Business pallet</td>
+             <td>0336</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+          <tr>
+             <td>Pickup parcel</td>
+             <td>0340</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+          <tr>
+             <td>Pickup parcel bulk</td>
+             <td>0342</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>No</td>
+          </tr>
+          <tr>
+             <td>Home delivery parcel</td>
+             <td>0349</td>
+             <td>No</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+        </tbody>
+      </table>
+
+  - title: Valid services and combinations for Change Address
+    content: |
+      These services are available **only** on parcels being sent to Norway from Sweden or Denmark.
+      <table>
+        <thead>
+         <tr>
+           <th>Service</th>
+           <th>Service Code</th>
+         </tr>
+        </thead>
+        <tbody>
+          <tr>
+             <td>Business parcel</td>
+             <td>0330</td>
+          </tr>
+          <tr>
+             <td>Business parcel bulk</td>
+             <td>0332</td>
           </tr>
         </tbody>
       </table>

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -136,7 +136,6 @@ documentation:
       Please see the detailed overview of the allowed service and to - from address
       combinations below for stop shipment and change address. Currently, Modify COD is not supported on shipments outside of Norway.
 
-      |
       These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
       Please verify in the table below if your to - from country is valid for the service on your shipments.
       <table>
@@ -237,7 +236,6 @@ documentation:
         </tbody>
       </table>
 
-     |
       These services are available **only** on shipments being sent to Norway from Sweden or Denmark.
       <table>
         <thead>

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -15,9 +15,9 @@ introduction:
   their way to the recipient. Shipments can be stopped and returned to
   the sender, they can be rerouted to a new delivery address or it is
   possible to change the cash on delivery amount. We support
-  domestic and cross border shipments in Norway, Sweden and Denmark, but
-  please note that there are limitations to our services in Sweden and Denmark.
-  Detailed overview for our services can be found below.
+  domestic and cross border shipments in Norway, Sweden and Denmark. Do note however,
+  that there are limitations to our services in Sweden and Denmark.
+  Detailed overview of our services can be found below.
 
 information:
   - title: Authentication
@@ -33,7 +33,7 @@ documentation:
     content: |
       There are some events or value added services that will make Modify Delivery services unavailable.
 
-      Any of the following events should not already be present on the shipment:
+      Any of the following events should **not** already be present on the shipment:
         - Damaged
         - Deviation
         - Returned
@@ -44,7 +44,7 @@ documentation:
         - In transit (to final destination)
         - Home Delivery ordered
 
-      Any of the following value added services should not already be present on the shipment:
+      Any of the following value added services (VAS) should **not** already be present on the shipment:
         - Optional pickup point (0010)
         - Parcel locker (0011)
         - Home delivery from pickup point (1158)

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -7,7 +7,7 @@ menu:
     identifier: modifydelivery
     title: Modify Delivery API
     url: /api/modify-delivery
-    parent: book
+    parent: track
 weight: 23
 
 introduction:
@@ -183,7 +183,7 @@ documentation:
 
   - title: Limitations
     content: |
-      - All service codes not starting with **03XX** are **only** available in Norway, and the supported services can be seen in the table above.
+      - Service codes 03XX is **not** supported for shipments addressed within Norway (domestic Norway shipments).
       - When ordering stop shipment there may be some scenarios we do not
       support given the _from_ and _to_ country of the shipment. These scenarios are
       shown in the table _Valid stop shipment scenarios_ below.

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -55,7 +55,6 @@ documentation:
 
   - title: Supported services
     content: |
-      These services are available only for domestic Norway shipments, meaning shipments that are going from and to an address in Norway.
       <table>
         <thead>
          <tr>

--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -11,14 +11,14 @@ menu:
 weight: 23
 
 introduction:
-  The Modify Delivery API can be used to modify shipments that currently are on
+  The Modify Delivery API can be used to modify shipments that are on
   their way to the recipient. Shipments can be stopped and returned to
-  the sender, they can be rerouted to a new delivery address or it
+  the sender, they can be rerouted to a new delivery address or it is
   possible to change the cash on delivery amount. We support
   domestic and cross border services in Norway, Sweden and Denmark, but
-  please note that there are limitations to our services in Sweden and Denmark.
-  Modify COD currently is not supported outside Norway at all.
-  For full overview of valid service and route combinations, see below.
+  please note that there are limitations to our services in Sweden and Denmark and that
+  Modify COD currently is not supported outside Norway. For full overview of valid service
+  and route combinations, see below.
 
 information:
   - title: Authentication
@@ -40,8 +40,9 @@ documentation:
         - Lost
         - Partly delivered
         - Stop shipment
+        - In transit (to final destination)
 
-  - title: Supported domestic services
+  - title: Supported services in Norway
     content: |
       These services are available only for domestic Norway shipments, meaning shipments that are going from and to an address in Norway.
       <table>
@@ -132,11 +133,10 @@ documentation:
     content: |
       There are limitations on shipments that are either sent domestically
       in Sweden and Denmark, or cross border between Norway, Sweden and Denmark.
-      Please see the detailed overview of the allowed service and to/from address
-      combinations below for Stop Shipment and Change Address. Currently, Modify COD is not supported.
+      Please see the detailed overview of the allowed service and to - from address
+      combinations below for stop shipment and change address. Currently, Modify COD is not supported on shipments outside of Norway.
 
-  - title: Valid services and combinations for Stop shipment
-    content: |
+      |
       These services are available on domestic shipments in Sweden and Denmark, and cross border shipments for Norway, Sweden and Denmark.
       Please verify in the table below if your to - from country is valid for the service on your shipments.
       <table>
@@ -237,9 +237,8 @@ documentation:
         </tbody>
       </table>
 
-  - title: Valid services and combinations for Change Address
-    content: |
-      These services are available **only** on parcels being sent to Norway from Sweden or Denmark.
+     |
+      These services are available **only** on shipments being sent to Norway from Sweden or Denmark.
       <table>
         <thead>
          <tr>


### PR DESCRIPTION
Changes to Modify Delivery API

- Added text that we support Sweden and Denmark
- Expanded on list of events that should not be on a shipment
- Added list of VAScodes that should not be on a shipment
- Expanded table of service codes to include the SE/DK ones + one new NO service code
- Added list of limitations to the API (Routes for 03XX service codes, change address only being available on shipments going to norway)
- Added table showing Stop delivery valid routes