### PR TITLE
Issue with Bring Logo for Sweden in Best Practise Checkout Guide

### DIFF
--- a/data/checkout/sweden.json
+++ b/data/checkout/sweden.json
@@ -100,7 +100,7 @@
         "tags": ["Shipping Guide API"],
         "downloadLinks": [
           {
-            "href": "assets/bring/Bring_logo.svg",
+            "href": "/images/checkout/bring/Bring_logo.svg",
             "linkText": "Bring logo",
             "name": "bring_logo"
           },


### PR DESCRIPTION
This PR means to resolve the Bring Logo which was not working for Sweden in the Best Practise Checkout Guide.