### PR TITLE
Add XML namespace to booking request examples

### DIFF
--- a/layouts/partials/api/oas/json-to-xml.html
+++ b/layouts/partials/api/oas/json-to-xml.html
@@ -6,6 +6,7 @@
 {{/*  objName doesn’t change  */}}
 {{ $objName := .name }}
 {{ $components := .components }}
+{{ $bookingXmlNamespace := "xmlns=\"http://www.bring.no/booking/\"" }}
 
 {{ $lev := add .lev 1 }}
 {{ $indentChar := "  " }}
@@ -55,8 +56,13 @@
               {{ with $schemaVal.xml.name }}
                 {{ $exampleKey = . }}
               {{ end }}
-              {{ $attribute := printf " %s=\"%s\"" $exampleKey (string $exampleVal) }}
-              {{ $xmlObject = printf "%s%s" $xmlObject $attribute }}
+                {{ if eq $name "bookingRequest" }}
+                  {{ $attribute := printf " %s %s=\"%s\"" $bookingXmlNamespace $exampleKey (string $exampleVal) }}
+                  {{ $xmlObject = printf "%s%s" $xmlObject $attribute }}
+                {{ else }}
+                  {{ $attribute := printf " %s=\"%s\"" $exampleKey (string $exampleVal) }}
+                  {{ $xmlObject = printf "%s%s" $xmlObject $attribute }}
+                {{ end }}
             {{ end }}
           {{ end }}
         {{ end }}


### PR DESCRIPTION
We noticed we were missing `xmlns="http://www.bring.no/booking/"` in the booking API XML request examples, which makes the requests fail. I haven’t found a way of fixing this on the `booking-api` side, so doing the change here. 

**Before:**
<img width="666" alt="xml request before" src="https://github.com/bring/developer-site/assets/78538590/07fff7cf-1ae4-4586-9f0a-7457567177a1">

**After:**
<img width="655" alt="xml request after" src="https://github.com/bring/developer-site/assets/78538590/0ab3f19f-ba4e-4147-9dbf-2768b93d45a0">

@halvorsanden It’s not the first time I’m doing ugly “hacks” in these beautiful templates, so please let us know if there’s a more elegant way of achieving this 😛 