### PR TITLE
Bring back contact details element for recipient party

### DIFF
--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -68,13 +68,12 @@
     {{- end -}}
   {{- else -}}
     {{/*  Render first level isOf without visible dt  */}}
-    {{/*  Only show contact details element for sender party (booking API docs)  */}}
+    {{/*  Only show contact details element for sender and recipient parties (booking API docs)  */}}
     {{- if and
       (or (ne $name "contact") (ne $contactParent "consignee"))
       (or (ne $name "contact") (ne $contactParent "consignor"))
       (or (ne $name "contact") (ne $contactParent "importer"))
       (or (ne $name "contact") (ne $contactParent "returnTo"))
-      (or (ne $name "contact") (ne $contactParent "recipient"))
     -}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
@@ -107,7 +106,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName) -}}
+              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -190,8 +189,13 @@
         {{- end -}}
       </dt>
       <dd class="pls">
-        {{- with $schemaObj.description -}}
-          {{ safeHTML (replace . "<p>" "<p class='mb0'>") }}
+        {{- if and
+          (or (ne $name "email") (ne $objName "contact") (ne $contactParent "recipient") )
+          (or (ne $name "phoneNumber") (ne $objName "contact") (ne $contactParent "recipient"))
+        -}}
+          {{- with $schemaObj.description -}}
+            {{ safeHTML (replace . "<p>" "<p class='mb0'>") }}
+          {{- end -}}
         {{- end -}}
         <div class="gray text-note flex flex-wrap gcs">
           <span>{{- $schemaObj.type -}}</span>

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -73,13 +73,12 @@
     {{- end -}}
   {{- else -}}
     {{/*  Render first level isOf without visible dt  */}}
-    {{/*  Only show contact details element for sender party (booking API docs)  */}}
+    {{/*  Only show contact details element for sender and recipient parties (booking API docs)  */}}
     {{- if and
       (or (ne $name "contact") (ne $contactParent "consignee"))
       (or (ne $name "contact") (ne $contactParent "consignor"))
       (or (ne $name "contact") (ne $contactParent "importer"))
       (or (ne $name "contact") (ne $contactParent "returnTo"))
-      (or (ne $name "contact") (ne $contactParent "recipient"))
     -}}
     <div class="{{ if not $isFirstLevelOf }}mb-border bb bw1{{ end }} mbs">
       <div class="flex flex-wrap align-ifs pbs {{ if $isFirstLevelOf }}screen-reader-text{{ end }}">
@@ -109,7 +108,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName) -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -310,8 +309,13 @@
         {{- end -}}
       </dt>
       <dd class="pls">
-        {{- with $schemaObj.description -}}
-          {{ safeHTML (replace . "<p>" "<p class='mb0'>") }}
+        {{- if and
+          (or (ne $name "email") (ne $objName "contact") (ne $contactParent "recipient") )
+          (or (ne $name "phoneNumber") (ne $objName "contact") (ne $contactParent "recipient"))
+        -}}
+          {{- with $schemaObj.description -}}
+            {{ safeHTML (replace . "<p>" "<p class='mb0'>") }}
+          {{- end -}}
         {{- end -}}
         <div class="gray text-note flex flex-wrap gcs">
           <span>{{- $schemaObj.type -}}</span>


### PR DESCRIPTION
...and instead hide the param descriptions for email and phone number, which are only relevant for sender party.

This is a follow-up of [this PR](https://github.com/bring/developer-site/pull/1579).

**Recipient party before (without contact details element visible):**
<img width="762" alt="recipient party before" src="https://github.com/bring/developer-site/assets/78538590/7ef2cb4a-5b4c-4172-836f-57360a56e829">

**Recipient party after (with contact details element visible and hidden param descriptions):**
<img width="762" alt="recipient party after" src="https://github.com/bring/developer-site/assets/78538590/a19cb7d2-ee6d-4208-991a-e33291b46f66">

**Sender party (where we show the contact details element with param descriptions that are relevant for the sender party):**
<img width="706" alt="sender party" src="https://github.com/bring/developer-site/assets/78538590/7dec9262-372b-472e-98c1-430121879e75">
