### PR TITLE
Rename E-commerce solutions to Checkout resources

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -131,7 +131,7 @@ important:
 </div>
 
 <div class="mbxl">
-  <h2>E-commerce solutions</h2>
+  <h2>Checkout resources</h2>
   <div class="flex flex-wrap gaxs mbm">
     <a href='{{< relref "norway" >}}' class="mb-card bg-green1 bn pam flex flex-dir-col start__col">
       <div class="flex mlxs align-ic">
@@ -163,7 +163,7 @@ important:
     </a>
   </div>
   <a href='{{< relref "e-commerce-solutions" >}}' class="text-heading">
-    E-commerce solutions &RightArrow;
+    Checkout resources &RightArrow;
   </a>
 </div>
 

--- a/content/api/e-commerce-solutions/_index.html
+++ b/content/api/e-commerce-solutions/_index.html
@@ -1,11 +1,11 @@
 ---
-title: E-commerce solutions
+title: Checkout resources
 layout: api
 notanapi: true
 menu:
   api:
     identifier: e-commerce-solutions
-    title: E-commerce solutions
+    title: Checkout resources
     url: e-commerce-solutions
 weight: 4
 ---


### PR DESCRIPTION
Renaming "E-commerce solutions" to "Checkout resources". The url and identifier are still kept as "e-commerce-solutions", but we can later see if this should also be renamed and add alias (redirect) for the old url.