### PR TITLE
Add support for important API updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,16 @@ message is added in each folder (API area) of the affected API.
 - If the message is general and should reach all subscribers, this is added in
 the main folder - `content/api/revision-history`.
 
+- Messages that are important can appear on the API page by setting the parameter
+`isImportant: true` and including the full API name in the message title.
+This can be useful when a message should stay visible for an upcoming or breaking
+API change for instance. By changing the publish date and rewriting the message,
+or adding another update message when the API change occurs, a new email will be
+sent to the subscribers.
+Even though the important messages are separated out and presented on their own,
+they are still part of the normal RSS feed, that is used for distributing API
+updates to subscribers.
+
 The messages are added with the following frontmatter:
 
 ```
@@ -90,6 +100,7 @@ The messages are added with the following frontmatter:
 title: {API name}
 publishDate: yyyy-mm-dd
 layout: api
+isImportant: true (boolean) - optional
 ---
 ```
 

--- a/content/api/revision-history/_index.html
+++ b/content/api/revision-history/_index.html
@@ -7,4 +7,5 @@ menu:
   api:
     title: API updates
 weight: 6
+apiArea: Common
 ---

--- a/content/api/warehousing/index.html
+++ b/content/api/warehousing/index.html
@@ -9,6 +9,7 @@ menu:
     url: /api/warehousing
     parent: warehouse
 weight: 1
+apiArea: Warehousing
 
 introduction:
   The Warehousing API is used to submit order and article information to Bring’s warehouses. Users are also able to extract/subscribe for detailed order information from our warehouses while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.

--- a/content/api/warehousing3/index.html
+++ b/content/api/warehousing3/index.html
@@ -9,6 +9,7 @@ menu:
     url: /api/warehousing
     parent: warehouse
 weight: 2
+apiArea: Warehousing
 
 introduction:
   Order information/update from Bring.<br>

--- a/content/api/warehousing4/index.md
+++ b/content/api/warehousing4/index.md
@@ -9,6 +9,7 @@ menu:
     url: /api/warehousing
     parent: warehouse
 weight: 3
+apiArea: Warehousing
 
 introduction:
       You are able to extract detailed order information from our warehouse while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -192,7 +192,7 @@ p a:not(.btn-link--dark, .btn-link) {
 }
 
 .changelog-small {
-  flex: 1 1 24rem;
+  flex: 1 1 20rem;
 }
 
 .btn-link--copy {

--- a/css/updates.css
+++ b/css/updates.css
@@ -1,11 +1,9 @@
 .updates__sub {
- flex: 1 1 18rem;
- max-width: 28rem;
+  flex: 0 1 28rem;
 }
 
 .updates__log {
- flex: 1 1 18rem;
- max-width: 32rem;
+ flex: 1 1 24rem;
 }
 
 @media screen and (max-width: 48em) {

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -1,6 +1,41 @@
+{{- $pageSubTitle := "Important API changes" -}}
+{{- if .Params.apiArea -}}
+  {{- $pageSubTitle = (printf "%s %s" .Params.apiArea "APIs") -}}
+{{- end -}}
+{{- $pctx := . -}}
+{{- if (in .CurrentSection "revision-history/_") -}}
+  {{- $pctx = .Site -}}
+{{- end -}}
+{{- $mergedPages := slice -}}
+{{/* Get entries from the main folder when in context of a sub-section */}}
+{{- if (eq $pctx .) -}}
+  {{- $generalPage := .Site.GetPage "revision-history" -}}
+  {{- $generalPages := $generalPage.RegularPages -}}
+  {{- range $generalPages -}}
+    {{- $mergedPages = $mergedPages | append (dict "pagePath" . "pubDate" .Params.publishdate) -}}
+  {{- end -}}
+{{- end -}}
+{{- $pages := slice -}}
+{{- $pages = $pctx.RegularPages -}}
+{{/* Get all sections from revision-history */}}
+{{- range $pages -}}
+  {{- if (in .CurrentSection "revision-history") -}}
+    {{- $mergedPages = $mergedPages | append (dict "pagePath" . "pubDate" .Params.publishdate) -}}
+  {{- end -}}
+{{- end -}}
+{{/* Make a new array and rearrange the data based on publish date */}}
+{{- $rearrangedPages := slice -}}
+{{- range sort $mergedPages "pubDate" "desc" -}}
+  {{- $rearrangedPages = $rearrangedPages | append .pagePath -}}
+{{- end -}}
+
 <section class="dev-docscontent__section">
-  <div class="gaxl flex flex-wrap flex-dir-row-rev justify-cfe">
-    <div class="updates__sub align-sfs">
+  <div class="gaxl flex flex-wrap flex-dir-row-rev justify-cfe maxw80r">
+    <div class="updates__sub owlm mbl">
+
+      <h2>Important updates</h2>
+      {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $pctx) -}}
+
       <div class="mbm">
         {{- partial "subscribe.html" -}}
       </div>
@@ -8,45 +43,14 @@
         You can also subscribe to our <a href='{{ "api/revision-history/index.xml" | relURL }}'>RSS feed</a>.
       </p>
     </div>
-
-    <div class="updates__log">
-      {{- $pageSubTitle := "Important API changes" -}}
-      {{- if .Params.apiArea -}}
-        {{- $pageSubTitle = (printf "%s %s" .Params.apiArea "APIs") -}}
-      {{- end -}}
-      {{- $pctx := . -}}
-      {{- if (in .CurrentSection "revision-history/_") -}}
-        {{- $pctx = .Site -}}
-      {{- end -}}
+    <div class="updates__log maxw60r w100p">
       <h2 class="mbm">{{$pageSubTitle}}</h2>
-      {{- $mergedPages := slice -}}
-      {{/* Get entries from the main folder when in context of a sub-section */}}
-      {{- if (eq $pctx .) -}}
-        {{- $generalPage := .Site.GetPage "revision-history" -}}
-        {{- $generalPages := $generalPage.RegularPages -}}
-        {{- range $generalPages -}}
-          {{- $mergedPages = $mergedPages | append (dict "pagePath" . "pubDate" .Params.publishdate) -}}
-        {{- end -}}
-      {{- end -}}
-      {{- $pages := slice -}}
-      {{- $pages = $pctx.RegularPages -}}
-      {{/* Get all sections from revision-history */}}
-      {{- range $pages -}}
-        {{- if (in .CurrentSection "revision-history") -}}
-          {{- $mergedPages = $mergedPages | append (dict "pagePath" . "pubDate" .Params.publishdate) -}}
-        {{- end -}}
-      {{- end -}}
-      {{/* Make a new array and rearrange the data based on publish date */}}
-      {{- $rearrangedPages := slice -}}
-      {{- range sort $mergedPages "pubDate" "desc" -}}
-        {{- $rearrangedPages = $rearrangedPages | append .pagePath -}}
-      {{- end -}}
       <label class="form__label" for="filterChangelogInput">Filter API updates</label>
       <input type="text" class="form__control maxw16r" id="filterChangelogInput" />
       {{/* Set $pages to the rearranged structure */}}
       <div aria-busy="false" aria-atomic="true" aria-live="polite" data-live-region>
         {{- $pages = $rearrangedPages -}}
-        {{- range first 5 $pages -}}
+        {{- range where (first 5 $pages) ".Params.isImportant" "ne" true -}}
           {{- $parentFolder := path.Base (path.Dir .) -}}
           <article class="mbl" data-changelog-parent="{{$parentFolder}}">
             <header class="flex flex-dir-col-rev">
@@ -61,29 +65,30 @@
           </article>
         {{- end -}}
       </div>
-    </div>
-  </div>
-  {{- if (gt (len $pages) 5) -}}
-  <details class="mb-disclosure" id="olderApiUpdates">
-    <summary class="pam maxw32r bg-gray1">Older updates</summary>
-    <div class="flex flex-wrap" aria-busy="true" aria-atomic="true" aria-live="polite" data-live-region>
-      {{- range after 5 $pages -}}
-        {{- $parentFolder := path.Base (path.Dir .) -}}
-        <article class="changelog-small bg-gray1 pal mbxs" data-changelog-parent="{{$parentFolder}}">
-          <header class="flex flex-dir-col-rev">
-            <h2 class="text-basic fw600 mb0">{{ .Title }}</h2>
-            <time
-              class="mrm text-note fw600"
-              datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
-              >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
-            >
-          </header>
-          {{ .Content }}
-        </article>
+
+      {{- if (gt (len $pages) 5) -}}
+      <details class="mb-disclosure" id="olderApiUpdates">
+        <summary class="pam bg-gray1">Older updates</summary>
+        <div class="flex flex-wrap" aria-busy="true" aria-atomic="true" aria-live="polite" data-live-region>
+          {{- range where (after 5 $pages) ".Params.isImportant" "ne" true -}}
+            {{- $parentFolder := path.Base (path.Dir .) -}}
+            <article class="changelog-small bg-gray1 pal mbxs" data-changelog-parent="{{$parentFolder}}">
+              <header class="flex flex-dir-col-rev">
+                <h2 class="text-basic fw600 mb0">{{ .Title }}</h2>
+                <time
+                  class="mrm text-note fw600"
+                  datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                  >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
+                >
+              </header>
+              {{ .Content }}
+            </article>
+          {{- end -}}
+        </div>
+      </details>
       {{- end -}}
     </div>
-  </details>
-  {{- end -}}
+  </div>
 </section>
 
 <script type="text/javascript">

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -9,8 +9,8 @@
       <article>
         <h1>{{ .title }}</h1>
         <section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
-          {{- with $.Params.important -}}
-            <div class="grid__messages">
+          <div class="grid__messages">
+            {{- with $.Params.important -}}
               <div class="mbl">
                 {{- range . -}}
                   <div class="message--{{ .type }} pal mbs">
@@ -21,8 +21,12 @@
                   </div>
                 {{- end -}}
               </div>
-            </div>
-          {{- end -}}
+            {{- end -}}
+
+            {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $.Site "title" .title) -}}
+          </div>
+
+
           <div class="dev-docscontent__main maxw64r mbm grid__intro">
             {{- with $.Params.introduction -}}
               {{- if in (string .) "\n\n" -}}

--- a/layouts/partials/api/importantupdates.html
+++ b/layouts/partials/api/importantupdates.html
@@ -1,0 +1,41 @@
+{{- $apiArea := .apiArea -}}
+{{- $pageTitle := "" -}}
+{{- if .title -}}
+  {{- $pageTitle = .title -}}
+{{- end -}}
+{{- $pctx := .pctx -}}
+{{- $pages := slice -}}
+{{- $pages = $pctx.RegularPages -}}
+{{- $mergedPages := slice -}}
+{{/* Get all sections from revision-history */}}
+{{- range $pages -}}
+  {{- if (in .CurrentSection "revision-history") -}}
+    {{- $mergedPages = $mergedPages | append . -}}
+  {{- end -}}
+{{- end -}}
+{{- $pages = $mergedPages -}}
+{{- $isImportant := false -}}
+{{- range where $pages ".Params.isImportant" true -}}
+  {{- if or (strings.Contains (lower (replace .Title " " "")) (lower (replace $pageTitle " " ""))) (eq .Parent.Params.apiArea $apiArea) (eq .Parent.Params.apiArea "Common") -}}
+    {{- $isImportant = true -}}
+  {{- end -}}
+{{- end -}}
+
+{{- if eq $isImportant true -}}
+  <div class="grid__sticky-updates owls mbl">
+    {{- range where $pages ".Params.isImportant" true -}}
+      {{- if or (strings.Contains (lower (replace .Title " " "")) (lower (replace $pageTitle " " ""))) (eq .Parent.Params.apiArea $apiArea) (eq .Parent.Params.apiArea "Common") -}}
+      {{- $isImportant = true -}}
+      <div class="message--warn pal">
+        <h3 class="text-basic">
+          <time
+            datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+            >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
+          >: {{ .Title }}
+        </h3>
+        {{ .Content }}
+      </div>
+      {{- end -}}
+    {{- end -}}
+  </div>
+{{- end -}}

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -1,19 +1,21 @@
 <h1>{{ .Title }}</h1>
 <section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
-  {{- with $.Params.important -}}
-    <div class="grid__messages">
-      <div class="mbl">
-        {{- range . -}}
-          <div class="message--{{ .type }} pal mbs">
-            {{- with .title -}}
-              <strong class="db mbxs">{{ . }}</strong>
-            {{- end -}}
-            {{ .message | markdownify }}
-          </div>
-        {{- end -}}
-      </div>
-    </div>
-  {{- end -}}
+  <div class="grid__messages">
+    {{- with $.Params.important -}}
+        <div class="mbl">
+          {{- range . -}}
+            <div class="message--{{ .type }} pal mbs">
+              {{- with .title -}}
+                <strong class="db mbxs">{{ . }}</strong>
+              {{- end -}}
+              {{ .message | markdownify }}
+            </div>
+          {{- end -}}
+        </div>
+    {{- end -}}
+    {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $.Site "title" .Title) -}}
+  </div>
+
   <div class="dev-docscontent__main maxw64r mbm grid__intro">
     {{- with $.Params.introduction -}}
       {{- if in (string .) "\n\n" -}}


### PR DESCRIPTION
Adding support for important API updates. By setting `isImportant: true` on the message and including the full API name in the message title, the message will be presented on the right hand side, both on the API page it belongs to, but also on the "API updates" page.

Even though these messages are presented separately from "normal" API updates on the dev-site, they are still part of the regular RSS feed, that is used for distributing the messages by email to the API updates subscribers.

The use case for these are mainly the possibility to flag some messages that should not loose focus for a while, that are of an important nature, and risking of drowning in other API updates that might come in between.

Some examples:
![Skjermbilde 2023-11-29 kl  16 45 47](https://github.com/bring/developer-site/assets/65193388/f8f47879-616e-4c1f-ad79-74bfd6e6e847)

![Skjermbilde 2023-11-29 kl  16 53 49](https://github.com/bring/developer-site/assets/65193388/98219481-65ab-4fe0-87c6-3d3a1fcd6fc1)

![Skjermbilde 2023-11-29 kl  16 55 12](https://github.com/bring/developer-site/assets/65193388/42c97b09-2b63-4f89-b16b-c924f5533ebd)
