### PR TITLE
Turn a long string of utilities into custom class

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -322,9 +322,26 @@ div.response {
   flex: 1 1 8rem;
 }
 
-.schema__header:has(+ .schema__container .param-toggle-btn)
-  button[data-toggle-all] {
+.schema__header {
+  border-bottom: 2px solid var(--gray-86);
   display: flex;
+  align-items: first baseline;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+  padding-bottom: 0.25rem;
+
+  > div {
+    display: flex;
+    flex-flow: row wrap;
+    align-items: first baseline;
+    column-gap: 1rem;
+    row-gap: 0.5rem;
+    margin-right: auto;
+  }
+
+  &:has(+ .schema__container .param-toggle-btn) button[data-toggle-all] {
+    display: flex;
+  }
 }
 
 .maxw50r {

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -41,21 +41,21 @@
                 {{- if gt (len .) 1 -}}
                   {{- $multiSchema = true -}}
                 {{- end -}}
-                <div class="mb-border bb flex align-ib gas mbm pbxs schema__header">
-                  <div class="flex flex-wrap align-ib gcm grs mr-auto">
+                <div class="schema__header">
+                  <div>
                     <h4 class="fw600 mb0">Body schema</h4>
                     {{- if $multiSchema -}}
-                    <div class="flex flex-wrap align-ib gcxs">
-                      <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
-                      <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control schematype__select" name="formats">
-                        {{- range $applicationType, $_ := . -}}
-                          {{- $typeClean := lower (anchorize $applicationType) -}}
-                          <option value="{{ $typeClean }}">
-                            {{ $applicationType }}
-                          </option>
-                        {{- end -}}
-                      </select>
-                    </div>
+                      <div class="flex flex-wrap align-ib gcxs">
+                        <label class="form__label text-basic" for="{{ $endpointId }}-reqschema">Media type:</label>
+                        <select id="{{ $endpointId }}-reqschema" data-sub-of="{{ $endpointId }}-reqschema" class="form__control schematype__select" name="formats">
+                          {{- range $applicationType, $_ := . -}}
+                            {{- $typeClean := lower (anchorize $applicationType) -}}
+                            <option value="{{ $typeClean }}">
+                              {{ $applicationType }}
+                            </option>
+                          {{- end -}}
+                        </select>
+                      </div>
                     {{- else -}}
                       {{- range $applicationType, $_ := . -}}
                         <p class="mb0">Media type: {{ $applicationType }}</p>


### PR DESCRIPTION
I found out I had done this several months ago but never committed it.

We already had a custom class for it, so I put all the properties in there and used nesting.

Hopefully, we can remove the JS fallback for the has() function next year. Firefox is one or two versions away from supporting it now 🐌 