### PR TITLE
Added pageRef for language menu items in config

### DIFF
--- a/config.json
+++ b/config.json
@@ -13,15 +13,36 @@
     },
     "no": {
       "staticDir": ["static"],
-      "languageName": "Norsk"
+      "languageName": "Norsk",
+      "menus": {
+        "main": [
+          {
+            "pageRef": "/api/e-commerce-solutions/best-practice-checkout/norway"
+          }
+        ]
+      }
     },
     "se": {
       "staticDir": ["static"],
-      "languageName": "Svensk"
+      "languageName": "Svensk",
+      "menus": {
+        "main": [
+          {
+            "pageRef": "/api/e-commerce-solutions/best-practice-checkout/sweden"
+          }
+        ]
+      }
     },
     "da": {
       "staticDir": ["static"],
-      "languageName": "Dansk"
+      "languageName": "Dansk",
+      "menus": {
+        "main": [
+          {
+            "pageRef": "/api/e-commerce-solutions/best-practice-checkout/denmark"
+          }
+        ]
+      }
     }
   },
   "paginate": 12,


### PR DESCRIPTION
Fixes issue where countries under Checkout resources > Best practice checkout guide didn't always show up. 