### PR TITLE
Removed mb-disclosure--arrow class

### DIFF
--- a/js/webcomponent/api-updates-subscribe/template.js
+++ b/js/webcomponent/api-updates-subscribe/template.js
@@ -76,7 +76,7 @@ export default function apiUpdatesTemplate(isModal, includeButton, buttonText, b
             </fieldset>
           </div>
 
-          <details class="mb-disclosure mb-disclosure--arrow bg-green1 mbm">
+          <details class="mb-disclosure bg-green1 mbm">
             <summary>
               <span
                 data-mybicon="mybicon-arrow-right"

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -67,7 +67,14 @@
 
       {{- if (gt (len $pages) 5) -}}
       <details class="mb-disclosure" id="olderApiUpdates">
-        <summary class="pam bg-gray1">Older updates</summary>
+        <summary class="pam bg-gray1">
+          <span
+            data-mybicon="mybicon-arrow-right"
+            data-mybicon-width="16"
+            data-mybicon-height="16"
+          ></span>
+          Older updates
+        </summary>
         <div class="flex flex-wrap" aria-busy="true" aria-atomic="true" aria-live="polite" data-live-region>
           {{- range where (after 5 $pages) ".Params.isImportant" "ne" true -}}
             {{- $parentFolder := path.Base (path.Dir .) -}}

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -40,7 +40,7 @@
             {{- with $.Params.information -}}
               <div class="dev-docscontent__info mvl owlxs">
                 {{- range . -}}
-                  <details class="mb-disclosure mb-disclosure--arrow bg-green1">
+                  <details class="mb-disclosure bg-green1">
                     {{- with .title }}
                       <summary class="text-heading">
                         <span

--- a/layouts/partials/api/oas/endpoint.html
+++ b/layouts/partials/api/oas/endpoint.html
@@ -116,12 +116,12 @@
                   {{- if gt (len .) 1 -}}
                     {{- $multiSchema = true -}}
                   {{- end -}}
-                  <details class="mb-disclosure mb-disclosure--arrow {{ $responseColorBg }} mbxs">
+                  <details class="mb-disclosure {{ $responseColorBg }} mbxs">
                     <summary class="{{ $responseColorTxt }}">
                       <span
-                      data-mybicon="mybicon-arrow-right"
-                      data-mybicon-width="16"
-                      data-mybicon-height="16"
+                        data-mybicon="mybicon-arrow-right"
+                        data-mybicon-width="16"
+                        data-mybicon-height="16"
                       ></span>
                       <span class="fw600">{{ $response }}</span> {{ $description }}
                     </summary>

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -29,7 +29,7 @@
     {{- with $.Params.information -}}
       <div class="dev-docscontent__info mvl owlxs">
         {{- range . -}}
-          <details class="mb-disclosure mb-disclosure--arrow bg-green1">
+          <details class="mb-disclosure bg-green1">
             {{- with .title -}}
               <summary class="text-heading">
                 <span

--- a/layouts/partials/api/oas/tips-and-guides.html
+++ b/layouts/partials/api/oas/tips-and-guides.html
@@ -5,7 +5,7 @@
   </h2>
     <div class="dev-docscontent__info owlxs">
       {{- range . -}}
-        <details class="mb-disclosure mb-disclosure--arrow bg-green1">
+        <details class="mb-disclosure bg-green1">
             <summary class="text-heading">
               <span
                 data-mybicon="mybicon-arrow-right"

--- a/layouts/partials/services/vas.html
+++ b/layouts/partials/services/vas.html
@@ -45,7 +45,7 @@
 
 <div class="flex flex-dir-col gas" id="all-vas">
   {{- range $index, $vas := (sort .data "vasName") -}}
-    <details class="mb-disclosure mb-disclosure--arrow bg-gray1 vas-item">
+    <details class="mb-disclosure bg-gray1 vas-item">
       <summary class="dev-anchored" id="{{ .vasName|anchorize }}">
         <span
           data-mybicon="mybicon-arrow-right"


### PR DESCRIPTION
The basic disclosure component is being replaced by the animated arrow disclosure component. 

mb-disclosure--arrow class has therefore been removed as it's being replaced by mb-disclosure. Until https://github.com/bring/mybring-design-system/pull/882 has been merged, it will display two icons in the disclosure. 

Also added mybicon-arrow-right icon to the only disclosure component which didn't use the icon already. 