### PR TITLE
removed firefox fallback js for toggle all buttons

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -15,28 +15,6 @@ paramToggleBtn.forEach((btn) => {
   })
 })
 
-// Firefox fallback because it lacks of support for css has()
-// Show toggle all on pageload if there’s more than one toggle button in schema
-function showToggleAll() {
-  const schemaContainerArr = document.querySelectorAll('.schema__container')
-  if (schemaContainerArr) {
-    schemaContainerArr.forEach((schemaContainer) => {
-      const schemaToggles = schemaContainer.querySelectorAll(
-        '.param-toggle-btn'
-      )
-      if (schemaToggles.length > 1) {
-        const toggleAllContainer = schemaContainer.previousElementSibling,
-          toggleAllPair = toggleAllContainer.querySelectorAll(
-            'button[data-toggle-all]'
-          )
-        toggleAllPair.forEach((toggleAllBtn) => {
-          toggleAllBtn.classList.remove('dn')
-        })
-      }
-    })
-  }
-}
-
 // Toggle all within a schema
 const toggleAllArr = document.querySelectorAll('button[data-toggle-all]')
 


### PR DESCRIPTION
Removed firefox fallback js for toggle all buttons, since firefox now supports has(). Tested in latest firefox version (122.0)