### PR TITLE
Use safeHTML function to mark urls separated by <br> tags as safe html.

### DIFF
--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -179,7 +179,7 @@
                   {{- partial "api/oas/endpoint-type" (dict "type" .method) -}}
                   <span class="flex-auto">
                     <pre class="flex align-ic pas mb0 wrap-text">
-                      <span>{{ delimit $urlOutput "<br>" }}</span>
+                      <span>{{ delimit $urlOutput "<br>" | safeHTML }}</span>
                     </pre>
                   </span>
                 </div>


### PR DESCRIPTION
- This ensures that the <br> tag is not escaped in the output.