### PR TITLE
feat: add revision about CORS limitations in tracking api

### DIFF
--- a/content/api/revision-history/tracking/2024-03-25.md
+++ b/content/api/revision-history/tracking/2024-03-25.md
@@ -1,0 +1,22 @@
+---
+title: Tracking API – Starting from 2nd of May, 2024, we will reject browser calls associated with a customer number to enhance security.
+publishDate: 2024-03-25
+layout: api
+notanapi: false
+isImportant: true
+---
+
+We have discovered some API users exposing username and API key openly in the source code of their website.
+This means that this information is accessible to anyone with a certain level of technical expertise.
+This poses a security risk as it allows unauthorized access to information about agreements with Posten Bring,
+as well as GDPR-sensitive customer data.
+
+To address this, we strongly recommend that you call our Tracking API from the backend instead of via the browser.
+This way, this information will not be exposed. We advise you to promptly delete the current API key and generate a new one here:
+https://www.mybring.com/useradmin/account/settings/api
+
+If it is not feasible to call our APIs from the backend and you are entirely dependent on doing so via the browser,
+we recommend creating a new user account not associated with your customer numbers.
+You can create such an account here: https://www.mybring.com/useradmin/account/settings/api
+
+**Please note that starting from May 2, 2024, we will reject browser calls associated with a customer number to enhance security.**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6928,6 +6928,12 @@
       "integrity": "sha512-0s+oAmw9zLl1V1cS9BtZN7JAd0cW5e0QH4W3LWEK6a4LaLEA2OTpGYWDY+6XasBLtz6wkm3u1xRw95mRuJ59WA==",
       "dev": true
     },
+    "node_modules/search-insights": {
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.13.0.tgz",
+      "integrity": "sha512-Orrsjf9trHHxFRuo9/rzm0KIWmgzE8RMlZMzuhZOJ01Rnz3D0YBAe+V6473t6/H6c7irs6Lt48brULAiRWb3Vw==",
+      "peer": true
+    },
     "node_modules/seek-bzip": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/seek-bzip/-/seek-bzip-1.0.6.tgz",


### PR DESCRIPTION
These look fine:

<img width="1973" alt="image" src="https://github.com/bring/developer-site/assets/14058300/398a3cd3-d3e0-406f-b9fb-13a90e201544">
<img width="2245" alt="image" src="https://github.com/bring/developer-site/assets/14058300/70581191-423f-4c7d-a3e9-2ed34f523305">

But for some reason, on the tracking API page, it does not show up at the top. Anyone have any idea why this might be? 😕 
<img width="1979" alt="image" src="https://github.com/bring/developer-site/assets/14058300/5e7a4cd0-5bda-4991-92fd-d3e407f0d625">
