### PR TITLE
Place api updates messages before important ones

### DIFF
--- a/css/documentation.css
+++ b/css/documentation.css
@@ -99,7 +99,7 @@ p a:not(.btn-link--dark, .btn-link) {
 
 .dev-docscontent__grid {
   display: grid;
-  gap: 0 2rem;
+  gap: 1rem 2rem;
   grid-template-areas:
     "intro messages"
     "intro signup";

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -31,7 +31,7 @@
 
 <section class="dev-docscontent__section">
   <div class="gaxl flex flex-wrap flex-dir-row-rev justify-cfe maxw80r">
-    <div class="updates__sub owlm mbl">
+    <div class="updates__sub owls">
       
       {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $pctx "heading" "Important updates") -}}
 

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -9,21 +9,18 @@
       <article>
         <h1>{{ .title }}</h1>
         <section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
-          <div class="grid__messages">
-            {{- with $.Params.important -}}
-              <div class="mbl">
-                {{- range . -}}
-                  <div class="message--{{ .type }} pal mbs">
-                    {{- with .title -}}
-                      <strong class="db mbxs">{{ . }}</strong>
-                    {{- end -}}
-                    {{ .message | markdownify }}
-                  </div>
-                {{- end -}}
-              </div>
-            {{- end -}}
-
+          <div class="grid__messages owls">
             {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $.Site "title" .title) -}}
+            {{- with $.Params.important -}}
+              {{- range . -}}
+                <div class="message--{{ .type }} pal mbs">
+                  {{- with .title -}}
+                    <strong class="db mbxs">{{ . }}</strong>
+                  {{- end -}}
+                  {{ .message | markdownify }}
+                </div>
+              {{- end -}}
+            {{- end -}}
           </div>
 
 

--- a/layouts/partials/api/importantupdates.html
+++ b/layouts/partials/api/importantupdates.html
@@ -27,7 +27,6 @@
   {{- if and .heading $showHeading -}}
     <h2>{{.heading}}</h2>
   {{- end -}}
-  <div class="owls mbl">
     {{- range where $pages ".Params.isImportant" true -}}
       {{- if or (strings.Contains (lower (replace .Title " " "")) (lower (replace $pageTitle " " ""))) (eq .Parent.Params.apiArea $apiArea) (eq .Parent.Params.apiArea "Common") -}}
       {{- $isImportant = true -}}
@@ -42,5 +41,4 @@
       </div>
       {{- end -}}
     {{- end -}}
-  </div>
 {{- end -}}

--- a/layouts/partials/api/oas/section-intro.html
+++ b/layouts/partials/api/oas/section-intro.html
@@ -1,19 +1,17 @@
 <h1>{{ .Title }}</h1>
 <section id="api-documentation" class="dev-docscontent__section dev-docscontent__grid">
-  <div class="grid__messages">
-    {{- with $.Params.important -}}
-        <div class="mbl">
-          {{- range . -}}
-            <div class="message--{{ .type }} pal mbs">
-              {{- with .title -}}
-                <strong class="db mbxs">{{ . }}</strong>
-              {{- end -}}
-              {{ .message | markdownify }}
-            </div>
-          {{- end -}}
-        </div>
-    {{- end -}}
+  <div class="grid__messages owls">
     {{- partial "api/importantupdates.html" (dict "apiArea" $.Params.apiArea "pctx" $.Site "title" .Title) -}}
+    {{- with $.Params.important -}}
+      {{- range . -}}
+        <div class="message--{{ .type }} pal">
+          {{- with .title -}}
+            <strong class="db mbxs">{{ . }}</strong>
+          {{- end -}}
+          {{ .message | markdownify }}
+        </div>
+      {{- end -}}
+    {{- end -}}
   </div>
 
   <div class="dev-docscontent__main maxw64r mbm grid__intro">


### PR DESCRIPTION
This makes the updates and important messages more chronological. We want the new update messages to appear first since the important message solution is not for news anymore and its content will be older.

Did some simplification of the spacing and structure between those elements as well.

This leads to changes on the API updates page and the individual API pages, the Booking API has an example of both message types if you want to compare prod and staging.