### PR TITLE
Edit Event Cast doc

### DIFF
--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -99,20 +99,18 @@ documentation:
   - title: Payload
     content: |
 
-      ### Payload delivery headers
+      ### Delivery headers
 
-      `HTTP POST` payloads that are delivered to your Webhook's configured URL endpoint contains several Bring specific headers:
+      `HTTP POST` payloads that are delivered to your webhook's configured URL endpoint contains several Bring specific headers:
 
       | Header | Description |
       |:-------|:--------|
       | `X-Bring-Application` | Identifies the application that sent the request to your endpoint |
-      | `X-bring-Correlation` | Correlation Id can be used whilst contacting Bring on error cases |
-      | `X-bring-Version` | Indicates the version of application |
-      | `<your headers>` | Any headers that were specified in the Webhook configuration will also be appended |
+      | `X-bring-Correlation` | Correlation ID can be used when contacting Bring on error cases |
+      | `X-bring-Version` | Indicates the application version |
+      | `<your headers>` | Any headers you specified in the webhook configuration |
 
       ### Example
-
-      Requests issued from Bring to your endpoint will look similar to this:
 
       ```json
       POST /callback/Webhook HTTP/1.1

--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -22,8 +22,6 @@ information:
     content: |
       Maximum _50 concurrent requests_ per user is allowed. Maximum _10 concurrent requests_ per user is allowed on the test endpoint. Maximum 100 shipments can be batch created per request. But there is no limitation on how many webhooks you can have in total.
 
-      Wildcard events and event groups like `*` and `ALL` are not supported.
-
       The current version doesn’t support event history, you can use the [Tracking API](/api/tracking) to get a shipment’s full history.
 
       Webhooks cannot be edited after they have been created.
@@ -43,7 +41,7 @@ documentation:
     content: |
       We recommend subscribing only to events relevant to you. By keeping the list of events (`event_groups`) as small as possible, you will not get more updates than you need and your server will not get unnecessary HTTP requests from Bring.
 
-      Events are defined as an array with comma separated strings.
+      Events are defined as an array with comma separated strings. Wildcards like `*` and `ALL` are not supported.
 
       ### Example
 

--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -11,7 +11,7 @@ menu:
 weight: 32
 
 introduction: |
-  The Event Cast API can be used to subscribe to tracking events for a given shipment using webhooks. Event notifications are automatically pushed to the subscriber as they happen, which makes it unnecessary to repeatedly poll statuses calling the Tracking API. You define an endpoint that accepts HTTP POST, and whenever an event is registered for a subscribed shipment, we send it to the URL.
+  The Event Cast API can be used to subscribe to tracking events for a given shipment by registering webhooks. Event notifications are automatically pushed to the subscriber as they happen, avoiding repeatedly poll statuses calling the Tracking API. You define an endpoint that accepts HTTP POST, and whenever an event is registered for a subscribed shipment, we send it to the URL.
 
 information:
   - title: Authentication
@@ -20,7 +20,19 @@ information:
 
   - title: Limitations
     content: |
-      The API allows a maximum of _50 concurrent requests_ per user. The maximum amount of shipments that can be batch created is limited to _100 per request_. The test endpoint allows a maximum of _10 concurrent requests_ per user.
+      Maximum _50 concurrent requests_ per user is allowed. Maximum _10 concurrent requests_ per user is allowed on the test endpoint. Maximum 100 shipments can be batch created per request. But there is no limitation on how many webhooks you can have in total.
+
+      Wildcard events and event groups like `*` and `ALL` are not supported.
+
+      The current version doesn’t support event history, you can use the [Tracking API](/api/tracking) to get a shipment’s full history.
+
+      Webhooks cannot be edited after they have been created.
+
+      Expiration duration and retry timing are fixed and cannot be configured.
+
+      Expired webhooks are not available.
+
+      Multiple webhooks for one shipment can only be registered as long as they subscribe to different events.
 
   - title: Formats
     content: |
@@ -132,41 +144,12 @@ documentation:
         "pushed": "2019-03-16T14:58:49+0000"
       }
       ```
-  - title: Q & A
+
+  - title: Retries and shipments not yet registered
     content: |
+      If your endpoint is down and a callback is sent, the API will try to send a request two times with 30 minutes between and a third and final time after another hour.
 
-      **Can I have multiple Webhooks for the same parcel?**<br>
-      You can register for multiple Webhooks on the same parcel/shipment, as long as the event groups are different for each registration.
-
-      **How many active Webhooks can I have simultaneously?**<br>
-      Currently there is no limitation.
-
-      **Is the expiration duration configurable?**<br>
-      No.
-
-      **Can I get a history of events that were sent for a subscription?**<br>
-      Not in this version. It may be available in the future. Please note that you may use the [Tracking API](/api/tracking) if you'd like the entire list of events that has happened for a lifecycle related to a shipment.
-
-      **Will I be able to see my previous/expired Webhooks (active and inactive)?**<br>
-      No.
-
-      **What happens if our endpoint is down and a callback is being sent?**<br>
-      We'll try issuing a request to your defined endpoint up to three - 3 - times with a delay on 30 minutes for the two first, then wait an hour for the last retry.
-      After this, callbacks will not be retried.
-
-      **Do you support wildcard events/event groups (e.g `*` or `ALL`)?**<br>
-      No.
-
-      **Do you support modifying existing active webhooks?**<br>
-      No.
-
-      **My shipment is not yet registered with Bring, will registering for Webhook work related to that tracking number?**<br>
-      Yes.
-
-      When you subscribe for a parcel that does not yet exist in Bring' systems, a retry mechanism will try for up to two - 2 - days to ensure that the Webhook will be registered when the parcel is found internally.
-      Eventually, if the package was not found with Bring within this timeframe - a notification will be sent on the callback URL configured for that Webhook which notifies this.
-
-      **Note**: Retry-timing is non-configurable.
+      If you subscribe to a shipment that hasn’t been registered with Bring, we will retry for up to two days. A notification will be sent on the webhook’s callback URL if the shipment isn’t registered in this timeframe.
 
 oas: https://api.qa.bring.com/event-cast/api-docs
 ---

--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -41,64 +41,54 @@ information:
 documentation:
   - title: Events
     content: |
-      When registering for a Webhook you can choose between a range of different event groups that you can subscribe for.
-      It is recommended to limit the amount of events to subscribe for. Bring will send an event on each of the events occurred which in result may send quite a few HTTP-requests to your server.
-      So, as a good practise, keep the list of event groups as small as possible.
+      We recommend subscribing only to events relevant to you. By keeping the list of events (`event_groups`) as small as possible, you will not get more updates than you need and your server will not get unnecessary HTTP requests from Bring.
 
-      Each of the event groups corresponds to a certain set of actions that can happen to the package/shipment you subscribe for. For instance, if you subscribe to `DELIVERED`, all internal Bring-events
-      will trigger a request to your defined callback URL.
+      Events are defined as an array with comma separated strings.
 
-      ### Event groups
+      ### Example
 
-      Default set of subscribable event groups. Notice that this list is subject for change.
+      ```
+      "event_groups": ['IN_TRANSIT', 'NOTIFICATION_SENT', 'TERMINAL']
+      ```
+
+      ### Default events
+      The list is subject to change.
 
       | Event | Description |
       |:-------|:--------|
-      | `ATTEMPTED_DELIVERY` | The package has been attempted delivered at the door. Depending on the service it will be tried again or sent to closest pickup point. |
+      | `ATTEMPTED_DELIVERY` | Package has been attempted delivered at the door. Depending on the service it will be tried again or sent to closest pickup point. |
       | `CUSTOMS` | Package is in customs clearance. |
-      | `COLLECTED` | The parcel has been collected at pickup address. |
+      | `COLLECTED` | Package has been collected at pickup address. |
       | `DELIVERED` | Package has been delivered. |
-      | `DELIVERED_SENDER` | Package has been returned to the sender |
+      | `DELIVERED_SENDER` | Package has been returned to the sender. |
       | `DELIVERY_CANCELLED` | Home delivery has been cancelled by the customer. |
       | `DELIVERY_CHANGED` | Date for Home delivery has been changed by customer. |
-      | `DELIVERY_ORDERED` | Home delivery has been ordered |
+      | `DELIVERY_ORDERED` | Home delivery has been ordered. |
       | `DEVIATION` | Deviation in production. Something wrong has happened and there is a probability for delay. |
       | `HANDED_IN` | Package has been handed in to Bring. |
       | `INTERNATIONAL` | Package has been sent from origin country or arrived at destination country. |
       | `IN_TRANSIT` | Package is in transit. |
-      | `NOTIFICATION_SENT` | Notification for this package has been sent by sms, push and/or mail. This can be informational notifications and action notification like pickup notice. |
+      | `NOTIFICATION_SENT` | Notification for this package has been sent by sms, push and/or mail. This can be informational and action notifications like pickup notice. |
       | `PRE_NOTIFIED` | EDI message for the package has been received by Bring. |
       | `READY_FOR_PICKUP` | Package has arrived at pickup point. |
-      | `RETURN` | The package is on its way back to the sender. |
+      | `RETURN` | Package is on its way back to the sender. |
       | `TRANSPORT_TO_RECIPIENT` | Package has been loaded for delivery to the recipient. |
-      | `TERMINAL` | The package is now registered/arrived at inbound/outbound storage terminal |
+      | `TERMINAL` | Package is now registered/arrived at inbound/outbound storage terminal. |
 
-      There is also a specific set of events that will be sent if something deviates from the normal event flow:
+      ### Deviation events
 
       | Event | Description |
       |:-------|:--------|
-      | `NOT_REGISTERED` | Webhook not registered. This might be due to the parcel-/shipment-number not being found with Bring' systems and can trigger after up to two - 2 - days |
-      | `EXPIRED` | Webhook expired |
+      | `NOT_REGISTERED` | Webhook not registered. This is typically triggered if the package hasn’t been handed in to Bring within two days. |
+      | `EXPIRED` | Webhook expired. |
 
-      #### Subscribing to multiple event groups
-
-      The Webhook API supports the possibility to subscribe to multiple event groups at the same time.
-      Doing so requires that groups are separated with comma and is defined as an array.
-      Example:
-
-      ```
-      ['IN_TRANSIT', 'NOTIFICATION_SENT', 'TERMINAL', .., ..]
-      ```
-
-      Need more examples? See the "Create Webhook" section below.
-
-  - title: Receiving Callbacks
+  - title: Callbacks
     content: |
       In order to receive requests from Bring, your callback URL must be accessible on the internet and able to receive requests from Bring IPs.
-      Additionally, to minimize risk, you should also provide HTTPS-enabled endpoints and use some kind of authentication mechanism.
-      For HTTPS, please do not use self-signed certificates, as requests may fail from Bring' side and you'll receive no requests.
+      You should also provide HTTPS-enabled endpoints and use some kind of authentication mechanism to minimize risk.
+      Do not use self-signed certificates for HTTPS, such requests may fail.
 
-      If you need a simple authentication whilst receiving requests from Bring, we recommend utilizing the header functionality provided by the Webhook configuration.
+      If you need simple authentication while receiving requests from Bring, we recommend using the header functionality provided by the webhook configuration.
 
       All received callbacks from Bring will be using UTC as its current timezone and is based on the following format (Java):
 

--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -39,18 +39,15 @@ information:
 documentation:
   - title: Events
     content: |
-      We recommend subscribing only to events relevant to you. By keeping the list of events (`event_groups`) as small as possible, you will not get more updates than you need and your server will not get unnecessary HTTP requests from Bring.
-
-      Events are defined as an array with comma separated strings. Wildcards like `*` and `ALL` are not supported.
-
-      ### Example
+      Specify the events (`event_groups`) you want to subscribe to as an array with comma separated strings.
 
       ```
       "event_groups": ['IN_TRANSIT', 'NOTIFICATION_SENT', 'TERMINAL']
       ```
 
-      ### Default events
-      The list is subject to change.
+      We recommend keeping your list as short as possible. By subscribing only to events relevant to you, your server will not get unnecessary HTTP requests from Bring. Wildcards like `*` and `ALL` are not supported.
+
+      The list of events is subject to change.
 
       | Event | Description |
       |:-------|:--------|
@@ -72,7 +69,6 @@ documentation:
       | `RETURN` | Package is on its way back to the sender. |
       | `TRANSPORT_TO_RECIPIENT` | Package has been loaded for delivery to the recipient. |
       | `TERMINAL` | Package is now registered/arrived at inbound/outbound storage terminal. |
-
 
   - title: Callbacks
     content: |

--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -73,12 +73,6 @@ documentation:
       | `TRANSPORT_TO_RECIPIENT` | Package has been loaded for delivery to the recipient. |
       | `TERMINAL` | Package is now registered/arrived at inbound/outbound storage terminal. |
 
-      ### Deviation events
-
-      | Event | Description |
-      |:-------|:--------|
-      | `NOT_REGISTERED` | Webhook not registered. This is typically triggered if the package hasn’t been handed in to Bring within two days. |
-      | `EXPIRED` | Webhook expired. |
 
   - title: Callbacks
     content: |

--- a/content/api/reports/index.md
+++ b/content/api/reports/index.md
@@ -32,7 +32,7 @@ information:
     content: |
       REST XML/JSON over HTTP.
 
-oas: https://qa.mybring.com/reports/v3/api-docs
+oas: https://www.mybring.com/reports/v3/api-docs
 
 documentation:
   - title: Fetching reports


### PR DESCRIPTION
- Incorporates Q & A into topic sections, most of which could be categorised as limitations. FAQ/Q&A tend to lead to scattered documentation making it difficult to find topics and cases. 
- Tries to limit the use of package, shipment and parcel for the same thing, at least within the same area.
- Uses more active language to be clearer and shorter.
- Uses "events" instead of both "events" and "event groups", as they seem to be the same thing, but keeps the reference to the event_groups array name of course.

See two comments about events