### PR TITLE
Add mb-docs class name to blog content

### DIFF
--- a/layouts/_default/post.html
+++ b/layouts/_default/post.html
@@ -11,7 +11,7 @@
           </h1>
           {{ partial "blog-meta.html" . }}
         </header>
-        <div class="dev-blog__content mbxl">
+        <div class="dev-blog__content mbxl mb-docs">
           {{ .Content }}
         </div>
       </article>


### PR DESCRIPTION
Adding the class `mb-docs` to blog content parent `div`, where the same spacing and list styling can be used the same way as for the rest of the site.