### PR TITLE
Convert custom made modals in web components to `<dialog>`

### DIFF
--- a/js/webcomponent/api-updates-subscribe/main.js
+++ b/js/webcomponent/api-updates-subscribe/main.js
@@ -44,11 +44,7 @@ class ApiSubscribe extends HTMLElement {
 
   open() {
     this.loadExternalScripts()
-    this.querySelector(".api-updates").classList.add("open")
-    const closeModalBtn = this.querySelector("[data-close-modal]")
-    if (closeModalBtn) {
-      closeModalBtn.focus()
-    }
+    this.querySelector(".api-updates").showModal()
 
     // Log to SiteImprove when opening the modal
     if(typeof SiteImprove !== 'undefined'){
@@ -61,11 +57,7 @@ class ApiSubscribe extends HTMLElement {
   }
 
   close() {
-    const openModalBtn = document.querySelector("[data-api-updates-open]")
-    this.querySelector(".api-updates").classList.remove("open")
-    if (openModalBtn) {
-      openModalBtn.focus()
-    }
+    this.querySelector(".api-updates").close()
   }
 
   bindOpenModalClickHandler() {
@@ -174,13 +166,15 @@ class ApiSubscribe extends HTMLElement {
     signupForm.addEventListener("submit", (e) => validateInputs(e))
 
     if (this.isModal) {
-      const closeModalAttr = document.querySelectorAll("[data-close-modal]")
+      const modal = this.querySelector(".api-updates")
+      const closeModalAttr = modal.querySelectorAll("[data-close-modal]")
+      
       closeModalAttr.forEach((closeModal) => {
         closeModal.addEventListener("click", () => this.close())
       })
 
-      this.addEventListener("keydown", (e) => {
-        if (e.key === "Escape" || e.key === "Esc" || e.keyCode === 27) {
+      modal.addEventListener("click", (event) => {
+        if (event.target === modal) {
           this.close()
         }
       })

--- a/js/webcomponent/api-updates-subscribe/style.js
+++ b/js/webcomponent/api-updates-subscribe/style.js
@@ -1,60 +1,22 @@
 export default function apiUpdatesStyle(isModal) {
   return `<style>
+    :root[data-theme="dark"] {
+      & .api-updates {
+        color: var(--green-86);
+        & label:has(input[type="checkbox"],input[type="radio"]):hover {
+          color: var(--green-60);
+        }
+      }
+    }
+    
     .api-updates {
-      ${isModal ?
-      `display: none;
-      height: 100vh;
-      width: 100vw;
-      position: fixed;
-      top: 0;
-      left: 0;
-      z-index: 5000;`
-      : 'display:flex;'}
-      justify-content: center;
-      align-items: center;
+      width: 100%;
+      max-width: 28rem;
     }
 
     .api-updates h2 {
       padding-left: 0;
       margin-bottom: 0;
-    }
-
-    .api-updates.open {
-      display: flex;
-    }
-
-    .api-updates-wrapper {
-      padding: 0;
-      position: relative;
-      max-width: 28rem;
-      ${isModal ?
-      `border-radius: 3px;
-      width: 96vw;
-      height: auto;
-      max-height: 80vh;
-      overflow-y: auto;
-      box-shadow: 0 2px 2px 0 rgb(0 0 0 / 10%), 0 1px 5px 0 rgb(0 0 0 / 12%);
-      z-index: 5002;`
-      : 'width: 100%;'}
-    }
-
-    .api-updates-header {
-      background: var(--green-lighter);
-      height: 3rem;
-      display: flex;
-      align-items: center;
-      position: sticky;
-      top: 0;
-    }
-
-    .api-updates-content {
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      ${isModal ?
-      `height: calc(100% - 3rem);
-      overflow-y: auto;`
-      : ''}
     }
 
     .api-area-checkboxes.hidden {
@@ -83,17 +45,5 @@ export default function apiUpdatesStyle(isModal) {
     .clever_form_error {
       border-color: var(--red) !important;
     }
-
-    ${isModal ?
-      `.api-updates-backdrop {
-        position: fixed;
-        height: 100vh;
-        width: 100vw;
-        background: hsla(0,0%,10%,0.5);
-        top: 0;
-        left: 0;
-        z-index:5001;
-      }`
-    : ''}
   </style>`;
 }

--- a/js/webcomponent/api-updates-subscribe/template.js
+++ b/js/webcomponent/api-updates-subscribe/template.js
@@ -1,17 +1,16 @@
 export default function apiUpdatesTemplate(isModal, includeButton, buttonText, buttonClass) {
   return `${isModal && includeButton ? `<button class="${buttonClass}" data-api-updates-open>${buttonText}</button>` : ''}
 
-<div class="api-updates" ${isModal ? 'role="dialog" aria-modal="true"' : ''}>
-  <div class="api-updates-wrapper bg-green1">
-    ${isModal ? `<div class="api-updates-header justify-cfe ptm prm">
-      <button class="btn-link--dark" aria-label="Close modal" data-close-modal>
-        <svg class="icon-ui" viewBox="0 0 352 512">
-        <path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
-      </button>
-    </div>` : ''}
-
-    <div class="api-updates-content pal${isModal ? ` pt0` : ``}">
-      <h2>Subscribe</h2>
+${isModal ? '<dialog class="mb-modal api-updates bg-green1">' : '<div class="api-updates bg-green1">'}
+  <div class="api-updates-wrapper">
+    <div class="flex flex-dir-col gam${isModal ? '': ' pal'}">
+      <div class="flex gal justify-csb align-ic">
+        <h2>Subscribe</h2>
+        ${isModal ? `<button class="btn-link--dark" aria-label="Close modal" data-close-modal>
+            <svg class="icon-ui" viewBox="0 0 352 512">
+            <path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
+          </button>` : ''}
+      </div>
       <p class="mb0">Get API updates via email.</p>
       <form class="cr_form cr_font" action="https://seu2.cleverreach.com/f/362555-365663/wcs/" method="post" id="cr-subscribe-form" target="_blank">
         <div class="cr_font">
@@ -22,7 +21,7 @@ export default function apiUpdatesTemplate(isModal, includeButton, buttonText, b
 
           <div class="flex flex-dir-col mbs">
             <fieldset class="flex flex-dir-col">
-              <legend className="mbs">API areas</legend>
+              <legend class="mbs">API areas</legend>
               <div id="8265204" rel="radio" class="cr_ipe_item musthave flex gam" >
           
                 <label class="form__radio">
@@ -103,6 +102,5 @@ export default function apiUpdatesTemplate(isModal, includeButton, buttonText, b
       </form>
     </div>
   </div>
-  ${isModal ? '<div class="api-updates-backdrop" data-close-modal></div>' : ''}
-</div>`;
+  ${isModal ? '</dialog>' : '</div>'}`;
 }

--- a/js/webcomponent/bring-env/main.js
+++ b/js/webcomponent/bring-env/main.js
@@ -4,8 +4,8 @@ import bringEnvTemplate from "./template.js";
 
 class BringEnv extends HTMLElement {
   constructor() {
-    super()
-    this.attachShadow({mode: "open"})
+    super();
+    this.attachShadow({mode: "open"});
 
     let modalAttr = this.attributes.modal;
     let isModal = false;
@@ -17,7 +17,7 @@ class BringEnv extends HTMLElement {
       }
     }
 
-    this.render(isModal)
+    this.render(isModal);
   }
 
   render(isModal) {

--- a/js/webcomponent/bring-env/main.js
+++ b/js/webcomponent/bring-env/main.js
@@ -31,27 +31,26 @@ class BringEnv extends HTMLElement {
 
     this.shadowRoot.innerHTML = `${style} ${template}`;
     
-    const openModalBtn = document.querySelector('[data-bring-env-open]');
-
     if(isModal) {
+      const modal = this.shadowRoot.querySelector(".bring-env");
+      const openModalBtn = document.querySelector('[data-bring-env-open]');
+
       if(openModalBtn) {
         openModalBtn.addEventListener('click', () => {
           open();
         });
       }
 
-      const closeModalAttr = this.shadowRoot.querySelectorAll('[data-close-modal]');
-      closeModalAttr.forEach((closeModal) => {
-        closeModal.addEventListener('click', () => {
-          close();
-        });
+      const closeModalBtn = modal.querySelector('[data-close-modal]');
+      closeModalBtn.addEventListener('click', () => {
+        close();
       });
 
-      this.shadowRoot.addEventListener('keydown', (e) => {
-        if (e.keyCode == 27) {
+      modal.addEventListener("click", (event) => {
+        if (event.target === modal) {
           close();
         }
-      });
+      })
     }
 
     //Make some animation
@@ -77,16 +76,11 @@ class BringEnv extends HTMLElement {
     }
 
     const open = () => {
-      this.shadowRoot.querySelector('.bring-env').classList.add('open');
-      const closeModalBtn = this.shadowRoot.querySelector('.close-modal-btn');
-      if(closeModalBtn) {
-        closeModalBtn.focus();
-      }
+      this.shadowRoot.querySelector('.bring-env').showModal();
     }
 
     const close = () => {
-      this.shadowRoot.querySelector('.bring-env').classList.remove('open');
-      openModalBtn.focus();
+      this.shadowRoot.querySelector('.bring-env').close();
     }
   }
 }

--- a/js/webcomponent/bring-env/style.js
+++ b/js/webcomponent/bring-env/style.js
@@ -32,50 +32,45 @@ export default function bringEnvStyle(isModal) {
     }
 
     .bring-env {
+      background: #ffffff;
       ${isModal ?
-      `display: none;
-      height: 100vh;
-      width: 100vw;
+      `height: 100vh;
+      width: 46rem;
+      max-width: 94vw;
+      max-height: 80vh;
       position: fixed;
       top: 0;
       left: 0;
-      z-index: 5000;`
+      z-index: 5000;
+      border: none;
+      border-radius: 3px;
+      margin: auto;
+      box-shadow: 0 2px 2px 0 rgb(0 0 0 / 10%), 0 1px 5px 0 rgb(0 0 0 / 12%);`
       : 'display:flex;'}
       justify-content: center;
       align-items: center;
-    }
 
-    .bring-env.open {
-      display: flex;
-    }
-
-    .bring-env-wrapper {
-      padding: 0;
-      position: relative;
-      ${isModal ?
-      `background: #ffffff;
-      border-radius: 3px;
-      width: 46rem;
-      max-width: 94vw;
-      height: 100%;
-      max-height: 80vh;
-      overflow: hidden;
-      box-shadow: 0 2px 2px 0 rgb(0 0 0 / 10%), 0 1px 5px 0 rgb(0 0 0 / 12%);
-      z-index: 5002;`
-      : 'width: 100%;'}
+      &::backdrop {
+        background-color: rgba(0, 0, 0, 0.6);
+      }
     }
 
     .bring-env-header {
-      height: 5rem;
-      display: flex;
-      align-items: center;
       ${isModal ?
-        `padding: 0 2rem;`
+        `height: 5rem;
+        display: flex;
+        align-items: center;
+        background: #ffffff;
+        padding: 0 2rem;
+        position: sticky;
+        top: 0;
+        z-index: 1;
+        justify-content: space-between;`
       : 'padding: 0;'}
     }
 
     .bring-env-header-logo {
-      width: 125px;
+      width: 120px;
     }
     
     .close-modal {
@@ -109,10 +104,6 @@ export default function bringEnvStyle(isModal) {
       display: flex;
       flex-direction: column;
       gap: 2rem;
-      ${isModal ?
-      `height: calc(100% - 5rem);
-      overflow-y: auto;`
-      : ''}
     }
 
     .bring-env section {
@@ -124,17 +115,7 @@ export default function bringEnvStyle(isModal) {
     }
 
     ${isModal ?
-      `.bring-env-backdrop {
-        position: fixed;
-        height: 100vh;
-        width: 100vw;
-        background: hsla(0,0%,10%,0.5);
-        top: 0;
-        left: 0;
-        z-index:5001;
-      }
-
-      @media only screen and (max-width: 38em) {
+      `@media only screen and (max-width: 38em) {
         .bring-env section {
           padding: 0 2rem;
         }
@@ -143,7 +124,10 @@ export default function bringEnvStyle(isModal) {
       .bring-env section:last-child {
         margin-bottom: 4rem;
       }`
-    : ''}
+    : `.bring-env-wrapper {
+        padding: 2rem;
+      }
+    `}
 
     .bring-env-text ul {
       padding: 0;

--- a/js/webcomponent/bring-env/template.js
+++ b/js/webcomponent/bring-env/template.js
@@ -8,15 +8,14 @@ import {train} from "./svgs/train.js";
 import {uploadingTruck} from "./svgs/uploading-truck.js";
 
 export default function bringEnvTemplate(isModal) {
-  return `<div class="bring-env" ${isModal ? 'role="dialog" aria-modal="true" aria-labelledby="modalTitle"' : ''}>
+  return `${isModal ? '<dialog class="mb-modal bring-env">' : '<div class="bring-env">'}
     <div class="bring-env-wrapper">
       <div class="bring-env-header">
         ${postenLogo}
-        ${isModal ? `<div class="close-modal"><button class="close-modal-btn" aria-label="Close modal" data-close-modal>
+        ${isModal ? `<button class="close-modal-btn" aria-label="Close modal" data-close-modal>
             <svg width="16" height="16" viewBox="0 0 352 512">
             <path d="M242.72 256l100.07-100.07c12.28-12.28 12.28-32.19 0-44.48l-22.24-22.24c-12.28-12.28-32.19-12.28-44.48 0L176 189.28 75.93 89.21c-12.28-12.28-32.19-12.28-44.48 0L9.21 111.45c-12.28 12.28-12.28 32.19 0 44.48L109.28 256 9.21 356.07c-12.28 12.28-12.28 32.19 0 44.48l22.24 22.24c12.28 12.28 32.2 12.28 44.48 0L176 322.72l100.07 100.07c12.28 12.28 32.2 12.28 44.48 0l22.24-22.24c12.28-12.28 12.28-32.19 0-44.48L242.72 256z"></path></svg>
-          </button>
-        </div>` : ''}
+          </button>` : ''}
       </div>
       <div class="bring-env-content">
         <section>
@@ -85,7 +84,6 @@ export default function bringEnvTemplate(isModal) {
           </div>
         </section>
       </div>
-    </div>
-    ${isModal ? '<div class="bring-env-backdrop" data-close-modal></div>' : ''}
+    ${isModal ? '</dialog>' : '</div>'}
   </div>`;
 }


### PR DESCRIPTION
Converting the custom made modals that are developed as web components with this PR. By using the `<dialog>` element, we get some functionality and accessibility for free. Because of that we can reduce some amount of code.