### PR TITLE
Use api-docs from production to generate event-cast documentation

### DIFF
--- a/content/api/event-cast/index.md
+++ b/content/api/event-cast/index.md
@@ -143,5 +143,5 @@ documentation:
 
 
 
-oas: https://api.qa.bring.com/event-cast/api-docs
+oas: https://api.bring.com/event-cast/api-docs
 ---


### PR DESCRIPTION
Looks like [this PR](https://github.com/bring/mybring-events-cast/pull/719) did the trick. The api-docs should be available here now: https://api.bring.com/event-cast/api-docs