### PR TITLE
Show OpenAPI Spec link

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -62,7 +62,7 @@
           {{- $oasData := getJSON $.Params.oas -}}
           {{- with $oasData -}}
             {{- $sortedPaths := partial "api/oas/sort-paths.html" (dict "paths" .paths) -}}
-            {{- partial "api/oas/endpoints-table.html" (dict "oas" . "sortedPaths" $sortedPaths) -}}
+            {{- partial "api/oas/endpoints-table.html" (dict "oas" . "sortedPaths" $sortedPaths "oasUrl" $.Params.oas ) -}}
             {{- partial "api/oas/endpoint.html" (dict "servers" .servers "components" .components "sortedPaths" $sortedPaths) -}}
           {{- end -}}
           {{- if and (eq (getenv "HUGO_ENV") "production") (isset $.Params "disqus_identifier") -}}

--- a/layouts/partials/api/oas/endpoints-table.html
+++ b/layouts/partials/api/oas/endpoints-table.html
@@ -3,6 +3,7 @@
   {{- $soapArr = . -}}
 {{- end -}}
 {{- $sortedPaths := .sortedPaths -}}
+{{- $oasUrl := .oasUrl -}}
 
 {{- with .oas -}}
   <section class="dev-docscontent__section maxw96r">
@@ -93,5 +94,6 @@
         {{- end -}}
       {{- end -}}
     </table>
+    {{- partial "api/oas/openapi-source.html" (dict "oasUrl" $oasUrl) -}}
   </section>
 {{- end -}}

--- a/layouts/partials/api/oas/openapi-source.html
+++ b/layouts/partials/api/oas/openapi-source.html
@@ -1,6 +1,6 @@
 {{- if .oasUrl -}}
   <h2 class="dev-anchored mbm" id="openapispec">
-    OpenAPI Document
+    OpenAPI document
   </h2>
   <a href="{{.oasUrl}}" target="_blank" rel="noopener noreferrer">
     {{.oasUrl}}

--- a/layouts/partials/api/oas/openapi-source.html
+++ b/layouts/partials/api/oas/openapi-source.html
@@ -1,6 +1,6 @@
 {{- if .oasUrl -}}
   <h2 class="dev-anchored mbm" id="openapispec">
-    OpenAPI Specification
+    OpenAPI Document
   </h2>
   <a href="{{.oasUrl}}" target="_blank" rel="noopener noreferrer">
     {{.oasUrl}}

--- a/layouts/partials/api/oas/openapi-source.html
+++ b/layouts/partials/api/oas/openapi-source.html
@@ -1,0 +1,8 @@
+{{- if .oasUrl -}}
+  <h2 class="dev-anchored mbm" id="openapispec">
+    OpenAPI Specification
+  </h2>
+  <a href="{{.oasUrl}}" target="_blank" rel="noopener noreferrer">
+    {{.oasUrl}}
+  </a>
+{{- end -}}

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -13,7 +13,7 @@
       {{- end -}}
     {{- end -}}
     {{- $sortedPaths := partial "api/oas/sort-paths.html" (dict "paths" $oasData.paths) -}}
-    {{- partial "api/oas/endpoints-table.html" (dict "oas" $oasData "soapArr" $soapEndpoints "sortedPaths" $sortedPaths) -}}
+    {{- partial "api/oas/endpoints-table.html" (dict "oas" $oasData "soapArr" $soapEndpoints "sortedPaths" $sortedPaths "oasUrl" $.Params.oas) -}}
 
     {{- with $oasData -}}
       {{- partial "api/oas/endpoint.html" (dict "servers" .servers "components" .components "paths" .paths "sortedPaths" $sortedPaths) -}}


### PR DESCRIPTION
Exposing the OpenAPI Specification link publicly, just below the "Endpoints" table in each OAS based template.

<img width="1121" alt="Skjermbilde 2024-06-20 kl  13 01 01" src="https://github.com/bring/developer-site/assets/65193388/73553ddc-0b7c-4e56-b52a-2b8fd42d55ef">
