### PR TITLE
Fix aria label for algolia search input

### DIFF
--- a/js/search/AlgoSearch.jsx
+++ b/js/search/AlgoSearch.jsx
@@ -29,12 +29,6 @@ const searchClient = {
 
 const AlgoSearch = () => (
   <>
-    <label
-      htmlFor="autocomplete-0-label"
-      className="form__label white screen-reader-text"
-    >
-    Search the documentation
-    </label>
     <Autocomplete
       detachedMediaQuery='none'
       getSources={({ query }) => [

--- a/js/search/Autocomplete.jsx
+++ b/js/search/Autocomplete.jsx
@@ -11,7 +11,6 @@ export function Autocomplete(props) {
     if (!containerRef.current) {
       return undefined;
     }
-
     const search = autocomplete({
       container: containerRef.current,
       renderer: { createElement, Fragment, render: () => {} },
@@ -27,6 +26,15 @@ export function Autocomplete(props) {
       },
       ...props,
     });
+
+    const labelValue = "Search documentation";
+    // change value of aria-label provided by algolia
+    containerRef.current.querySelector(".aa-Label").setAttribute('aria-label', labelValue);
+
+    // removed aria-labelledby provided by algolia which doesn't work
+    containerRef.current.querySelector(".aa-Autocomplete").removeAttribute("aria-labelledby");
+    // add aria-label to the combo-box in order to get info about the search before entering it as well
+    containerRef.current.querySelector(".aa-Autocomplete").setAttribute("aria-label", labelValue);
 
     return () => {
       search.destroy();

--- a/js/search/Autocomplete.jsx
+++ b/js/search/Autocomplete.jsx
@@ -11,6 +11,7 @@ export function Autocomplete(props) {
     if (!containerRef.current) {
       return undefined;
     }
+
     const search = autocomplete({
       container: containerRef.current,
       renderer: { createElement, Fragment, render: () => {} },
@@ -27,14 +28,14 @@ export function Autocomplete(props) {
       ...props,
     });
 
-    const labelValue = "Search documentation";
-    // change value of aria-label provided by algolia
-    containerRef.current.querySelector(".aa-Label").setAttribute('aria-label', labelValue);
-
-    // removed aria-labelledby provided by algolia which doesn't work
-    containerRef.current.querySelector(".aa-Autocomplete").removeAttribute("aria-labelledby");
+    const labelValue = "Search documentation"
+   
     // add aria-label to the combo-box in order to get info about the search before entering it as well
-    containerRef.current.querySelector(".aa-Autocomplete").setAttribute("aria-label", labelValue);
+    containerRef.current.querySelector(".aa-Autocomplete").setAttribute("aria-label", labelValue)
+    
+    // change value of aria-label provided by algolia
+    containerRef.current.querySelector(".aa-Label").setAttribute('aria-label', labelValue)
+
 
     return () => {
       search.destroy();


### PR DESCRIPTION
- Replaced existing aria-label value provided by Algolia by using query selectors, removed label element added previously. Solves Wave orphaned label alert
- The combo-box around the input field got “No accessible text found” in Silktide, and in screen reader it doesn’t indicate what the input is about at all, so I added aria-label to that as well 