### PR TITLE
fix algolia search results without padding

### DIFF
--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -44,21 +44,14 @@
 
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText | urlize -}}
-    {{- $anchorUrl := (printf "#%s" $anchorUrlText) -}}
-    {{- $permalink := .Permalink }}
-    {{- $relpermalink := .RelPermalink }}
-    {{- if .Parent -}}
-      {{- $permalink = (printf .Parent.Permalink $anchorUrl) -}}
-      {{- $relpermalink = (printf .Parent.RelPermalink $anchorUrl) -}}
-    {{- end -}}
 
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
-          "permalink" $permalink
-          "relpermalink" $relpermalink
-          "title" .Title
+          "permalink" .Parent.Permalink
+          "relpermalink" .Parent.RelPermalink
+          "title" $anchorUrlText
           "section" (.Section | upper)
           "parent" $parentTitle
           "introduction" $introduction

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,17 +42,11 @@
       {{- end -}}
     {{- end -}}
 
-    {{- $anchorUrlText := .Title -}}
-    {{- $anchorUrlText = $anchorUrlText | urlize -}}
-    {{- $anchorUrl := printf "#%s" (string $anchorUrlText) -}}
-    {{- $permalink := .Permalink }}
-    {{- $relpermalink := .RelPermalink }}
-    {{- if .Parent -}}
-      {{- $permalink = (printf "%s%s" .Parent.Permalink $anchorUrl) -}}
-      {{- $relpermalink = (printf "%s%s" .Parent.RelPermalink $anchorUrl) -}}
-    {{- end -}}
-
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
+      {{- $anchorUrlText := .Title | urlize -}}
+      {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
+      {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}
+      {{- $relpermalink := (printf "%s%s" .Parent.RelPermalink $anchorUrl) -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
@@ -60,7 +54,7 @@
           "relpermalink" $relpermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" $anchorUrl
+          "parent" $parentTitle
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -32,18 +32,17 @@
       {{- $api = $oasdata.components -}}
     {{- end -}}
 
-    {{- $parent := "" -}}
+    {{- $parentTitle := "" -}}
     {{- with .Params.menu -}}
       {{- $parentName := .apidocs.parent -}}
       {{- range $.Site.Menus.apidocs -}}
         {{- if (eq $parentName .Identifier) -}}
-          {{- $parent = .Title -}}
+          {{- $parentTitle = .Title -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}
 
-    {{- $parent := .Parent -}}
-    {{- if and $parent (eq $parent.Title "sgleadtime") -}}
+    {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
@@ -51,7 +50,7 @@
           "relpermalink" .Parent.RelPermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" $parent.Title
+          "parent" $parentTitle
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")
@@ -64,7 +63,7 @@
           "relpermalink" .RelPermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" $parent.Title
+          "parent" $parentTitle
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,16 +42,13 @@
       {{- end -}}
     {{- end -}}
 
-    {{- $anchorUrlText := .Title -}}
-    {{- $anchorUrlText | urlize -}}
-
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
           "permalink" .Parent.Permalink
           "relpermalink" .Parent.RelPermalink
-          "title" $anchorUrlText
+          "title" .Title
           "section" (.Section | upper)
           "parent" $parentTitle
           "introduction" $introduction

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -56,9 +56,9 @@
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
-          "permalink" .Parent.Permalink
-          "relpermalink" .Parent.RelPermalink
-          "title" $anchorUrlText
+          "permalink" $permalink
+          "relpermalink" $relpermalink
+          "title" .Title
           "section" (.Section | upper)
           "parent" $parentTitle
           "introduction" $introduction

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and .Parent (or(eq .Parent.Title "Lead time")(eq .Parent.Title "Using Shipping Guide API")) -}}
+    {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $anchorUrlText := .Title | urlize -}}
       {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
       {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -44,14 +44,14 @@
 
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText | urlize -}}
-    {{- $anchorUrl := (printf "#%s" $anchorUrl) -}}
+    {{- $anchorUrl := (printf "#%s" $anchorUrlText) -}}
     {{- $permalink := .Permalink }}
     {{- $relpermalink := .RelPermalink }}
     {{- if .Parent -}}
       {{- $permalink = (printf .Parent.Permalink $anchorUrl) -}}
       {{- $relpermalink = (printf .Parent.RelPermalink $anchorUrl) -}}
     {{- end -}}
-    
+
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -45,9 +45,13 @@
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText | urlize -}}
     {{- $anchorUrl := (printf "#%s" $anchorUrl) -}}
-    {{- $permalink := (printf .Parent.Permalink $anchorUrl) -}}
-    {{- $relpermalink := (printf .Parent.RelPermalink $anchorUrl) -}}
-
+    {{- $permalink := .Permalink }}
+    {{- $relpermalink := .RelPermalink }}
+    {{- if .Parent -}}
+      {{- $permalink = (printf .Parent.Permalink $anchorUrl) -}}
+      {{- $relpermalink = (printf .Parent.RelPermalink $anchorUrl) -}}
+    {{- end -}}
+    
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and .Parent (eq .Parent.Params.menu.apidocs.identifier "sgleadtime") -}}
+    {{- if and .Parent (or (eq .Parent.Params.menu.apidocs.identifier "sgleadtime") (eq .Parent.Params.menu.apidocs.identifier "sgusing")) -}}
       {{- $anchorUrlText := .Title | urlize -}}
       {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
       {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -41,19 +41,35 @@
         {{- end -}}
       {{- end -}}
     {{- end -}}
-    
-    {{- $.Scratch.Add "index" 
-      (dict
-        "objectID" .File.UniqueID
-        "permalink" .Permalink
-        "relpermalink" .RelPermalink
-        "title" .Title
-        "section" (.Section | upper)
-        "parent" $parent
-        "introduction" $introduction
-        "api" $api
-        "documentation" ($.Scratch.Get "documentation")
-        "content" .Plain) -}}
+
+    {{- $parent := .Parent -}}
+    {{- if and $parent (eq $parent.Title "sgleadtime") -}}
+      {{- $.Scratch.Add "index"
+        (dict
+          "objectID" .File.UniqueID
+          "permalink" .Parent.Permalink
+          "relpermalink" .Parent.RelPermalink
+          "title" .Title
+          "section" (.Section | upper)
+          "parent" $parent.Title
+          "introduction" $introduction
+          "api" $api
+          "documentation" ($.Scratch.Get "documentation")
+          "content" .Plain) -}}
+    {{- else -}}
+      {{- $.Scratch.Add "index" 
+        (dict
+          "objectID" .File.UniqueID
+          "permalink" .Permalink
+          "relpermalink" .RelPermalink
+          "title" .Title
+          "section" (.Section | upper)
+          "parent" $parent.Title
+          "introduction" $introduction
+          "api" $api
+          "documentation" ($.Scratch.Get "documentation")
+          "content" .Plain) -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -44,7 +44,13 @@
 
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText = $anchorUrlText | urlize -}}
-
+    {{- $anchorUrl := (printf "#%s" $anchorUrlText) -}}
+    {{- $permalink := .Permalink }}
+    {{- $relpermalink := .RelPermalink }}
+    {{- if .Parent -}}
+      {{- $permalink = (printf .Parent.Permalink $anchorUrl) -}}
+      {{- $relpermalink = (printf .Parent.RelPermalink $anchorUrl) -}}
+    {{- end -}}
 
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -44,7 +44,7 @@
 
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText = $anchorUrlText | urlize -}}
-    {{- $anchorUrl := (printf "#%s" $anchorUrlText) -}}
+    {{- $anchorUrl := printf "#%s" (string $anchorUrlText) -}}
     {{- $permalink := .Permalink }}
     {{- $relpermalink := .RelPermalink }}
     {{- if .Parent -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -48,8 +48,8 @@
     {{- $permalink := .Permalink }}
     {{- $relpermalink := .RelPermalink }}
     {{- if .Parent -}}
-      {{- $permalink = (printf (string .Parent.Permalink) $anchorUrl) -}}
-      {{- $relpermalink = (printf (string .Parent.RelPermalink) $anchorUrl) -}}
+      {{- $permalink = (printf "%s%s" .Parent.Permalink $anchorUrl) -}}
+      {{- $relpermalink = (printf "%s%s" .Parent.RelPermalink $anchorUrl) -}}
     {{- end -}}
 
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,13 +42,16 @@
       {{- end -}}
     {{- end -}}
 
+    {{- $anchorUrlText := .Title -}}
+    {{- $anchorUrlText = $anchorUrlText | urlize -}}
+
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
           "permalink" .Parent.Permalink
           "relpermalink" .Parent.RelPermalink
-          "title" .Title
+          "title" .anchorUrlText
           "section" (.Section | upper)
           "parent" $parentTitle
           "introduction" $introduction

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -48,8 +48,8 @@
     {{- $permalink := .Permalink }}
     {{- $relpermalink := .RelPermalink }}
     {{- if .Parent -}}
-      {{- $permalink = (printf .Parent.Permalink $anchorUrl) -}}
-      {{- $relpermalink = (printf .Parent.RelPermalink $anchorUrl) -}}
+      {{- $permalink = (printf (string .Parent.Permalink) $anchorUrl) -}}
+      {{- $relpermalink = (printf (string .Parent.RelPermalink) $anchorUrl) -}}
     {{- end -}}
 
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
@@ -60,7 +60,7 @@
           "relpermalink" $relpermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" $parentTitle
+          "parent" $anchorUrl
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and .Parent (eq .Parent.Title "Lead time") -}}
+    {{- if and .Parent (eq .Parent.Params.menu.apidocs.identifier "sgleadtime") -}}
       {{- $anchorUrlText := .Title | urlize -}}
       {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
       {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}
@@ -54,7 +54,7 @@
           "relpermalink" $relpermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" .Parent.Params.menu.apidocs.identifier
+          "parent" $parentTitle
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -45,13 +45,14 @@
     {{- $anchorUrlText := .Title -}}
     {{- $anchorUrlText = $anchorUrlText | urlize -}}
 
+
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
           "permalink" .Parent.Permalink
           "relpermalink" .Parent.RelPermalink
-          "title" .anchorUrlText
+          "title" $anchorUrlText
           "section" (.Section | upper)
           "parent" $parentTitle
           "introduction" $introduction

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and .Parent (eq .Parent.Title "Lead time") -}}
+    {{- if and .Parent or(eq .Parent.Title "Lead time")(eq .Parent.Title "Using Shipping Guide API")) -}}
       {{- $anchorUrlText := .Title | urlize -}}
       {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
       {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}
@@ -54,7 +54,7 @@
           "relpermalink" $relpermalink
           "title" .Title
           "section" (.Section | upper)
-          "parent" $parentTitle
+          "parent" .Parent.Params.menu.apidocs.identifier
           "introduction" $introduction
           "api" $api
           "documentation" ($.Scratch.Get "documentation")

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
     {{- end -}}
 
-    {{- if and .Parent or(eq .Parent.Title "Lead time")(eq .Parent.Title "Using Shipping Guide API")) -}}
+    {{- if and .Parent (or(eq .Parent.Title "Lead time")(eq .Parent.Title "Using Shipping Guide API")) -}}
       {{- $anchorUrlText := .Title | urlize -}}
       {{- $anchorUrl := printf "#%s" $anchorUrlText -}}
       {{- $permalink := (printf "%s%s" .Parent.Permalink $anchorUrl) -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,12 +42,18 @@
       {{- end -}}
     {{- end -}}
 
+    {{- $anchorUrlText := .Title -}}
+    {{- $anchorUrlText | urlize -}}
+    {{- $anchorUrl := (printf "#%s" $anchorUrl) -}}
+    {{- $permalink := (printf .Parent.Permalink $anchorUrl) -}}
+    {{- $relpermalink := (printf .Parent.RelPermalink $anchorUrl) -}}
+
     {{- if and .Parent (eq .Parent.Title "Lead time") -}}
       {{- $.Scratch.Add "index"
         (dict
           "objectID" .File.UniqueID
-          "permalink" .Parent.Permalink
-          "relpermalink" .Parent.RelPermalink
+          "permalink" $permalink
+          "relpermalink" $relpermalink
           "title" .Title
           "section" (.Section | upper)
           "parent" $parentTitle


### PR DESCRIPTION
In shipping guide API there are some algolia results which get zero padding, for example it happens if you search Get alternative expected delivery dates, which has Lead Time page as parent. It also happens for sites which has Using Shipping Guide API as parent. 

In order to avoid these pages with zero padding when searching, I am instead linking to the parent component, but adding anchor link so it scrolls down to the correct place. 

Since the anchor tags are made from the titles, I am creating anchor urls from the titles using urlize and adding # infront in the list.algolia.json file. I then add this anchor url to the permalink and relpermalink url of the parent, and then use it for the permalink and relpermalink if the site has these specific parents (Lead Time and Get Alternative Expected Delivery Dates). Using identifiers (sgleadtime and sgusing) of the parent instead of title incase it changes in the future.

Didn’t find any more cases than for pages with Lead Time and pages with Get alternative expected delivery dates as parent.