### PR TITLE
Frontpage api updates set max length and add important badge

### DIFF
--- a/css/frontpage.css
+++ b/css/frontpage.css
@@ -29,3 +29,20 @@
 .start__col {
   flex: 1 1 20rem;
 }
+
+/* Truncate API updates text content on frontpage */
+.full-content {
+  display: none;
+}
+
+.full-content {
+  display: none;
+}
+
+.update-content.expanded .full-content {
+  display: block;
+}
+
+.update-content.expanded .truncated-content {
+  display: none;
+}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -55,7 +55,17 @@
                     <span class="mb-badge mb-badge--yellow">Important</span>
                   {{- end -}}
                   <h3 class="text-basic">{{ .Title }}</h3>
-                  {{ .Content }}
+                  <div class="update-content">
+                    <div class="truncated-content">
+                      {{ .Content | truncate 300 }}
+                    </div>
+                    <div class="full-content">
+                      {{ .Content }}
+                    </div>
+                    {{- if gt (len .Content) 300 -}}
+                      <button class="read-more btn-link--dark">Show more</button>
+                    {{- end -}}
+                  </div>
                 </div>
               {{- end -}}
               <div class="w100p">
@@ -68,4 +78,18 @@
       </div>
     </div>
   </main>
+
+  <script type="text/javascript">
+    var readMoreLinks = document.querySelectorAll(".read-more");
+    readMoreLinks.forEach(function(link) {
+      link.addEventListener("click", function() {
+        var postContent = link.closest(".update-content");
+        if (postContent) {
+          postContent.classList.toggle("expanded");
+          console.log(postContent)
+          link.textContent = postContent.classList.contains("expanded") ? "Show less" : "Show more";
+        }
+      })
+    })
+  </script>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,7 +47,7 @@
               {{- $pages = $mergedPages -}}
               {{- range first 3 $pages -}}
                 <div class="bg-gray1 bshadow pal rad-a2px">
-                  <time class="mrs"
+                  <time class="mrs text-note"
                     datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
                     >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
                   >

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -47,12 +47,14 @@
               {{- $pages = $mergedPages -}}
               {{- range first 3 $pages -}}
                 <div class="bg-gray1 bshadow pal rad-a2px">
-                  <h3 class="text-basic">
-                    <time
-                      datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
-                      >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
-                    >: {{ .Title }}
-                  </h3>
+                  <time class="mrs"
+                    datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                    >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
+                  >
+                  {{- if (.Params.isImportant) -}}
+                    <span class="mb-badge mb-badge--yellow">Important</span>
+                  {{- end -}}
+                  <h3 class="text-basic">{{ .Title }}</h3>
                   {{ .Content }}
                 </div>
               {{- end -}}


### PR DESCRIPTION
Added important badge to API updates on the frontpage. Moved title to be below the date and important badge, as done in API updates page. 

Added a “Show more” button if text length is more than 300 (can change to less). Considered using a link instead but there’s not any links given in the params, so would need to search the text for links or link to Event cast etc based on it having Event cast in the title. I also think it’s nice being able to read the entire update on the frontpage if wanted, since there are links in the posts if relevant and a Show all updates link underneath as well 🤔 