### PR TITLE
Replace getJSON

### DIFF
--- a/layouts/_default/api.html
+++ b/layouts/_default/api.html
@@ -59,7 +59,7 @@
       <main id="main" class="dev-docscontent w100p {{ replace .Title "API" "" | anchorize }}">
         <article>
           {{- partial "api/oas/section-intro.html" . -}}
-          {{- $oasData := getJSON $.Params.oas -}}
+          {{- $oasData := resources.GetRemote $.Params.oas | transform.Unmarshal -}}
           {{- with $oasData -}}
             {{- $sortedPaths := partial "api/oas/sort-paths.html" (dict "paths" .paths) -}}
             {{- partial "api/oas/endpoints-table.html" (dict "oas" . "sortedPaths" $sortedPaths "oasUrl" $.Params.oas ) -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -28,7 +28,7 @@
 
     {{- $api := dict -}}
     {{- with .Params.oas -}}
-      {{- $oasdata := getJSON . -}}
+      {{- $oasdata := resources.GetRemote . | transform.Unmarshal -}}
       {{- $api = $oasdata.components -}}
     {{- end -}}
 

--- a/layouts/partials/api/oas/restsoap.html
+++ b/layouts/partials/api/oas/restsoap.html
@@ -2,7 +2,7 @@
   <article>
     {{- partial "api/oas/section-intro.html" . -}}
 
-    {{- $oasData := getJSON $.Params.oas -}}
+    {{- $oasData := resources.GetRemote $.Params.oas | transform.Unmarshal -}}
     {{- $ramlData := .Site.Data.api -}}
     {{- $soapEndpoints := slice -}}
     {{- $soapUri := "" -}}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
     href="https://www.mybring.com/design-system/css/main.min.css?ts={{ now.Unix }}"
   />
   {{ if not hugo.IsServer }}
-    {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
+    {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" -}}
     {{- with index $jsManifest "js/main.js" -}}
       {{- range .css -}}
         <link

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
     href="https://www.mybring.com/design-system/css/main.min.css?ts={{ now.Unix }}"
   />
   {{ if not hugo.IsServer }}
-    {{- $jsManifest := getJSON "static/assets/.vite/manifest.json" -}}
+    {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
     {{- with index $jsManifest "js/main.js" -}}
       {{- range .css -}}
         <link

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,7 +29,7 @@
     href="https://www.mybring.com/design-system/css/main.min.css?ts={{ now.Unix }}"
   />
   {{ if not hugo.IsServer }}
-    {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" -}}
+    {{- $jsManifest := readFile "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
     {{- with index $jsManifest "js/main.js" -}}
       {{- range .css -}}
         <link

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,7 +1,7 @@
 {{ if hugo.IsServer }}
   <script type="module" src="http://localhost:5173/js/main.js"></script>
 {{ else }}
-  {{- $jsManifest := getJSON "static/assets/.vite/manifest.json" -}}
+  {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
   <script nomodule src="{{ print "/assets/" (index $jsManifest "vite/legacy-polyfills-legacy" "file") | relURL }}"></script>
   <script nomodule src="{{ print "/assets/" (index $jsManifest "js/main-legacy.js" "file") | relURL }}"></script>
   <script type="module" src="{{ print "/assets/" (index $jsManifest "js/main.js" "file") | relURL }}"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,7 +1,7 @@
 {{ if hugo.IsServer }}
   <script type="module" src="http://localhost:5173/js/main.js"></script>
 {{ else }}
-  {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" -}}
+  {{- $jsManifest := readFile "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
   <script nomodule src="{{ print "/assets/" (index $jsManifest "vite/legacy-polyfills-legacy" "file") | relURL }}"></script>
   <script nomodule src="{{ print "/assets/" (index $jsManifest "js/main-legacy.js" "file") | relURL }}"></script>
   <script type="module" src="{{ print "/assets/" (index $jsManifest "js/main.js" "file") | relURL }}"></script>

--- a/layouts/partials/scripts.html
+++ b/layouts/partials/scripts.html
@@ -1,7 +1,7 @@
 {{ if hugo.IsServer }}
   <script type="module" src="http://localhost:5173/js/main.js"></script>
 {{ else }}
-  {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" | transform.Unmarshal -}}
+  {{- $jsManifest := resources.Get "static/assets/.vite/manifest.json" -}}
   <script nomodule src="{{ print "/assets/" (index $jsManifest "vite/legacy-polyfills-legacy" "file") | relURL }}"></script>
   <script nomodule src="{{ print "/assets/" (index $jsManifest "js/main-legacy.js" "file") | relURL }}"></script>
   <script type="module" src="{{ print "/assets/" (index $jsManifest "js/main.js" "file") | relURL }}"></script>

--- a/layouts/partials/sidemenuanchors.html
+++ b/layouts/partials/sidemenuanchors.html
@@ -1,7 +1,7 @@
 {{ $ctx := .ctx }}
 {{- $oasData := "" -}}
 {{- with $ctx.Params.oas -}}
-  {{- $oasData = getJSON . -}}
+  {{- $oasData = resources.GetRemote . | transform.Unmarshal -}}
 {{- end -}}
 {{- $apiData := "" -}}
 {{- with .apiData -}}


### PR DESCRIPTION
Replacing `getJSON` with `readFile` and `resources.GetRemote` in conjuction with `transform.Unmarshal`, as getJSON is deprecated.

[https://gohugo.io/functions/data/getjson/](https://gohugo.io/functions/data/getjson/)