### PR TITLE
Remove api from algolia search result and add more info

### DIFF
--- a/content/api/warehousing3/index.html
+++ b/content/api/warehousing3/index.html
@@ -12,9 +12,9 @@ weight: 2
 apiArea: Warehousing
 
 introduction:
-  Order information/update from Bring.<br>
-  Bring Warehousing can send order information to you or you can pull the data from us.<br>
-  How often you want order lifestyle updates is up to you.<br>
+  Order information/update from Bring.
+  Bring Warehousing can send order information to you or you can pull the data from us.
+  How often you want order lifestyle updates is up to you.
   Bring Warehousing can also send you Inventory reports (full overview over all articles) and Inventory adjustment reports (update per article after an adjustment is made).
 
 information:

--- a/js/search/ResultItem.jsx
+++ b/js/search/ResultItem.jsx
@@ -1,9 +1,9 @@
 export function ResultItem({ hit, components }) {
   return (
     <a href={hit.relpermalink} className="hitlink lh-tight">
-        {hit.section && (hit.section !== "API" || hit.parent) && (
+        {hit.section && (
         <span className="mb-badge">
-          {hit.section !== "API" && hit.section}
+          {!hit.parent && hit.section}
           {hit.parent && `${hit.parent}`}
         </span>
         )}

--- a/js/search/ResultItem.jsx
+++ b/js/search/ResultItem.jsx
@@ -3,8 +3,8 @@ export function ResultItem({ hit, components }) {
     <a href={hit.relpermalink} className="hitlink lh-tight">
         {hit.section && (
         <span className="mb-badge">
-          {hit.section}
-          {hit.parent && ` – ${hit.parent}`}
+          {hit.section !== "API" && hit.section}
+          {hit.parent && `${hit.parent}`}
         </span>
         )}
         <span className="hitlink__title">

--- a/js/search/ResultItem.jsx
+++ b/js/search/ResultItem.jsx
@@ -1,7 +1,7 @@
 export function ResultItem({ hit, components }) {
   return (
     <a href={hit.relpermalink} className="hitlink lh-tight">
-        {hit.section && (
+        {hit.section && (hit.section !== "API" || hit.parent) && (
         <span className="mb-badge">
           {hit.section !== "API" && hit.section}
           {hit.parent && `${hit.parent}`}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -33,11 +33,16 @@
     {{- end -}}
 
     {{- $parentTitle := "" -}}
-    {{- with .Params.menu -}}
-      {{- $parentName := .apidocs.parent -}}
+    {{- if .Params.menu.apidocs.parent -}}
+      {{- $parent := .Params.menu.apidocs.parent -}}
+      {{- if eq .Parent.Parent.Params.menu.apidocs.identifier .Parent.Params.menu.apidocs.parent -}}
+        {{- $parentTitle = .Parent.Parent.Title -}}
+      {{- else if eq .Parent.Params.menu.apidocs.identifier $parent -}}
+        {{- $parentTitle = .Parent.Title -}}
+      {{- end -}}
       {{- range $.Site.Menus.apidocs -}}
-        {{- if (eq $parentName .Identifier) -}}
-          {{- $parentTitle = .Title -}}
+        {{- if eq $parent .Identifier -}}
+          {{- $parentTitle = cond (eq .Title "Warehousing") "Warehousing API" "" -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -42,7 +42,7 @@
       {{- end -}}
       {{- range $.Site.Menus.apidocs -}}
         {{- if eq $parent .Identifier -}}
-          {{- $parentTitle = cond (eq .Title "Warehousing") "Warehousing API" "" -}}
+          {{- $parentTitle = .Title -}}
         {{- end -}}
       {{- end -}}
     {{- end -}}


### PR DESCRIPTION
- Results now have API info if it’s from an API in the label in the search results, so it’s easier to see which API a page belongs to:
<img width="407" alt="image" src="https://github.com/user-attachments/assets/6f8da989-ebf9-4263-9c82-42175ff7d734">

- Removed “API - “ at start of the label if there is a parent, since most of them include "API" at the end. But keeping it when there is no parent because of the services pages.

- Removed br tag from warehouse page since it showed up in search results