### PR TITLE
Broken link fixes

### DIFF
--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -214,7 +214,7 @@ aliases:
   <h2 class="dev-anchored" id="formats">Formats</h2>
   <p>
     All our APIs are REST APIs supporting JSON and XML.
-    <a class="nowrap" href="./order-management/">Order Management</a> and
-    <a class="nowrap" href="./warehousing/">Warehousing</a> are also SOAP APIs.
+    <a class="nowrap" href="order-management/">Order Management</a> and
+    <a class="nowrap" href="warehousing/">Warehousing</a> are also SOAP APIs.
   </p>
 </section>

--- a/content/api/booking/authorization.md
+++ b/content/api/booking/authorization.md
@@ -9,7 +9,7 @@ menu:
 weight: 2
 ---
 
-In addition to [authentication](/api/#authentication), you need to be authorized with the _booking_ right in order to perform bookings. This is done in [customer administration in Mybring](https://www.mybring.com/useradmin/external/administration):
+In addition to [authentication](/api/#authentication), you need to be authorized with the _booking_ right in order to perform bookings. This is done in [customer administration in Mybring](https://www.mybring.com/useradmin-external/users):
 
 ![Authorized for booking](./../booking_authorization.png)
 

--- a/content/api/reports/index.md
+++ b/content/api/reports/index.md
@@ -10,14 +10,6 @@ menu:
     parent: rni
 weight: 51
 
-important:
-  - type: info
-    title: API changes after your company is converted to use new services
-    message: |
-      Bring is revising the service portfolio. Some of our services have been given new service names, service codes and pricing models.
-
-      If you are an existing user of Reports API, you will need to make some <a href="/api/reports/agreement_conversion">changes after your company is converted</a> to use new services.
-
 introduction: |
   The Reports API can be used as a tool for analyzing your logistics with Bring. The API lets you generate reports within the categories _status_, _quality and deviation_, _economy_ and _environment_. Supported report formats are XML and Excel.
 


### PR DESCRIPTION
- Broken link in info box at Reports API page. Apparently all customers are converted now so the info is outdated and the entire box can be removed
- Updated broken link in booking/authorization page
- Was getting broken link errors in SiteImprove for the Order and Warehousing link at the bottom of Getting Started page, even though they seem to work for me. Removing ./ in the href to see if resolves the issue