### PR TITLE
Update Label free/ QR-code to open for all customers in Sweden & Denmark

### DIFF
--- a/content/api/booking/examples/vas/1288.json
+++ b/content/api/booking/examples/vas/1288.json
@@ -1,5 +1,14 @@
-"additionalServices": [
-  {
-    "id": "1288"
-  }
-]
+{
+  "consignments": [
+    {
+      "generateQrCodes": true,
+      "product": {
+        "additionalServices": [
+          {
+            "id": "1288"
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/content/api/booking/examples/vas/1288.xml
+++ b/content/api/booking/examples/vas/1288.xml
@@ -1,5 +1,12 @@
-<additionalServices>
-  <additionalService>
-    <id>1288</id>
-  </additionalService>
-</additionalServices>
+<consignments>
+  <consignment>
+    <generateQrCodes>true</generateQrCodes>
+    <product>
+      <additionalServices>
+        <additionalService>
+          <id>1288</id>
+        </additionalService>
+      </additionalServices>
+    </product>
+  </consignment>
+</consignments>

--- a/content/api/booking/labels/label-free.md
+++ b/content/api/booking/labels/label-free.md
@@ -1,5 +1,5 @@
 ---
-title: Label free codes
+title: Label free codes (Sweden & Denmark)
 layout: api-sub
 menu:
   apidocs:
@@ -9,11 +9,31 @@ menu:
 weight: 2
 ---
 
-Label free provides the ability to send parcels without a label, and is useful for senders who do not have access to a printer. The label free code, as well as the recipient’s name and address, is written on the parcel before it is handed in.
+Label free provides the ability to send parcels without a label, and is useful for senders who do not have access to a printer.
 
-A unique code in the format `BRING-1234-5678` is returned as part of the API response, and is sent to the sender by e-mail after the booking is completed. 
+In Sweden & Denmark, with Label free one can send and return packages without a label at our pickup and drop off points.
+
+Label free solution for Sweden & Denmark contains two elements.
+
+
+
+### 1. Label Free code
+
+With Label free, a unique code in the format `BRING-1234-5678` is returned as part of the API response, and is sent to the sender by e-mail after the booking is completed.
+
 The label free code, as well as the recipient's name and address, is written on the parcel before it is handed in.
 
-The API response will contain one label free code per package. Order of packages and the corresponding label free codes in the booking response will resemble order of packages in the API request.
+### 2. QR-code
 
-See [Service portfolio](https://developer.bring.com/api/services/#label-free) for how to request this Value Added Service and when it can be ordered.
+Available as a supplement with Label free, a `QR-code` is also generated.
+This QR-code can be scanned by the staff at pickup and drop-off point to print a label which is then attached to the parcel.
+
+
+#
+To get the label free code and QR-code for your booking, your booking request needs to contain Value Added Service(VAS) `1288` and `generateQrCodes`.
+
+The API response will contain one label free code/ QR-code per package. Order of packages and the corresponding label free codes/ QR-codes in the booking response will resemble order of packages in the API request.
+
+
+
+See [Service portfolio](https://developer.bring.com/api/services/#label-free) for how to request this VAS/ QR-Code and when it can be ordered.

--- a/content/api/booking/labels/qr.md
+++ b/content/api/booking/labels/qr.md
@@ -1,5 +1,5 @@
 ---
-title: Generating QR Codes
+title: Generating QR Codes (Norway)
 layout: api-sub
 menu:
   apidocs:
@@ -23,4 +23,4 @@ The following services support QR codes:
 - 0341
 - 0343
 
-If a confirmation email to sender is wanted (that includes the requested QR code), add sender's e-mail address in the booking request.
+Sender's email address in the booking request is required to receive the requested QR code.

--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -893,7 +893,7 @@
 }, {
   "vasName" : "Label free",
   "vasNameNorwegian" : "Label Free",
-  "description" : "Label free makes provides the ability to send parcels without a label, and is useful for senders who do not have access to a printer.  A unique code in the format BRING-1234-5678 is sent to the sender by e-mail after the booking is completed. This code, as well as the recipient`s name and address, is written on the parcel before it is handed in.",
+  "description" : "Label free provides the ability to send parcels without a label, and is useful for senders who do not have access to a printer. A unique code in the format BRING-1234-5678 is sent to the sender by e-mail after the booking is completed. This code, as well as the recipient's name and address, is written on the parcel before it is handed in. A supplement QR-code is also requested along with the label free code. This QR-code can be scanned by the staff to print a label which is attached to the parcel.",
   "shippingGuideCode" : "1288",
   "shippingGuideNpbCode" : "1288",
   "bookingCode" : "1288",


### PR DESCRIPTION
- Open 'Label free'/ 'QR-code' for all customers in Sweden & Denmark.
- Modify 'Generating QR codes' description.
<img width="738" alt="image" src="https://github.com/user-attachments/assets/39cd8b5f-9eac-4687-a31d-3c20ad6b68ff">
<img width="906" alt="image" src="https://github.com/user-attachments/assets/26965a17-698a-464d-a842-e14d3776d353">
<img width="944" alt="image" src="https://github.com/user-attachments/assets/dd7917d3-dd6b-42ab-8123-ba5f037773f6">
<img width="513" alt="image" src="https://github.com/user-attachments/assets/2ce7e714-a0e6-4335-9637-7b85add9d1df">

