### PR TITLE
Broken link fixes

### DIFF
--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -214,7 +214,7 @@ aliases:
   <h2 class="dev-anchored" id="formats">Formats</h2>
   <p>
     All our APIs are REST APIs supporting JSON and XML.
-    <a class="nowrap" href="order-management/">Order Management</a> and
-    <a class="nowrap" href="warehousing/">Warehousing</a> are also SOAP APIs.
+    <a class="nowrap" href="/api/order-management/">Order Management</a> and
+    <a class="nowrap" href="/api/warehousing/">Warehousing</a> are also SOAP APIs.
   </p>
 </section>

--- a/content/api/_index.html
+++ b/content/api/_index.html
@@ -214,7 +214,7 @@ aliases:
   <h2 class="dev-anchored" id="formats">Formats</h2>
   <p>
     All our APIs are REST APIs supporting JSON and XML.
-    <a class="nowrap" href="/api/order-management/">Order Management</a> and
-    <a class="nowrap" href="/api/warehousing/">Warehousing</a> are also SOAP APIs.
+    <a class="nowrap" href="./order-management/">Order Management</a> and
+    <a class="nowrap" href="./warehousing/">Warehousing</a> are also SOAP APIs.
   </p>
 </section>

--- a/content/api/order-management/index.md
+++ b/content/api/order-management/index.md
@@ -9,6 +9,8 @@ menu:
     url: /api/order-management
     parent: om
 weight: 61
+aliases:
+  - ../order-management/
 
 introduction: |
   Order Management is a solution that lets integrated customers, their suppliers and Bring exchange order level information across the life cycle of customers' orders. Suppliers can use the API to fetch order details, and to create packaging lists with transport details. Bring collects, structures and enriches the order information with transport and event details, and makes it available to the customer.

--- a/content/api/revision-history/2023-01-11.md
+++ b/content/api/revision-history/2023-01-11.md
@@ -6,7 +6,6 @@ notanapi: true
 ---
 
 From 19 January 2023, APIs hosted on api-new.bring.com will stop working.
-It was already mentioned in [dns bring updates](https://developer.bring.com/api/dns-api-bring-com/).
 Please start using api.bring.com instead of api-new.bring.com.
 
 For more queries contact to integrasjon.norge@bring.com (Norway) or edi@bring.com (outside Norway).

--- a/content/api/revision-history/booking/2023-01-08.md
+++ b/content/api/revision-history/booking/2023-01-08.md
@@ -6,5 +6,4 @@ notanapi: true
 ---
 
 Starting 1 February 2023, maximum weight for a pickup order for cargo shipments in Norway will be set to **9999 kg chargeable weight**. This limit corresponds to the existing chargeable weight limit for a groupage shipment. Shipments above 9999kg are handled as a door-to-door direct transport service (partload) and, hence, are not eligible for the pickup order service.
-More information about our service terms and conditions can be found in our [Transport Guide](https://www.bring.no/tjenester/pakker-og-gods/Transportguiden_01122022.pdf)
 

--- a/content/api/revision-history/booking/2023-01-09.md
+++ b/content/api/revision-history/booking/2023-01-09.md
@@ -6,4 +6,3 @@ notanapi: true
 ---
 
 Starting 1 February 2023, minimum shipment weight for **5300 Partigods til bedrift (Partload)** will be set to 3500 kg. API requests for 5300 service with a lower total shipment weight will **not be accepted**.
-This API update is aligned with service terms and conditions described in our [Transport Guide](https://www.bring.no/tjenester/pakker-og-gods/Transportguiden_01122022.pdf) 

--- a/content/api/revision-history/checkout/2023-01-09.md
+++ b/content/api/revision-history/checkout/2023-01-09.md
@@ -6,4 +6,3 @@ notanapi: true
 ---
 
 Starting 1 February 2023, minimum shipment weight for **5300 Partigods til bedrift (Partload)** will be set to 3500 kg. API requests for 5300 service with a lower total shipment weight will **not be accepted**.
-This API update is aligned with service terms and conditions described in our [Transport Guide](https://www.bring.no/tjenester/pakker-og-gods/Transportguiden_01122022.pdf) 

--- a/content/api/revision-history/checkout/2023-03-20.md
+++ b/content/api/revision-history/checkout/2023-03-20.md
@@ -7,4 +7,4 @@ notanapi: true
 
 Going forward Leadtimes will vary depending on whether you have a pickup agreement with Bring.  
 
-More details on how pickup agreement affects your leadtime can be found here [Leadtime](https://developer.bring.com/api/shipping-guide_2/leadtime/)
+More details on how pickup agreement affects your leadtime can be found here [Leadtime](https://developer.bring.com/api/shipping-guide_2/lead-time/)

--- a/content/api/warehousing/index.html
+++ b/content/api/warehousing/index.html
@@ -10,6 +10,8 @@ menu:
     parent: warehouse
 weight: 1
 apiArea: Warehousing
+aliases:
+  - ../warehousing/
 
 introduction:
   The Warehousing API is used to submit order and article information to Bring’s warehouses. Users are also able to extract/subscribe for detailed order information from our warehouses while the orders are being processed. Further, the API provides information about articles in stock, with methods for retrieving information about single items or configurable list of items.


### PR DESCRIPTION
- Added aliases to order-management and warehousing to avoid broken links if missing trailing slash in url when accessing through links in Getting Started page. Also changed hrefs back to what they were before.
- Replaced broken link in api update with correct link
- Removed remaining broken links from old API updates which had no replacements