### PR TITLE
Move modify delivery to the tracking tile on the front page

### DIFF
--- a/content/_index.html
+++ b/content/_index.html
@@ -43,12 +43,11 @@ important:
       <h3 class="mlxs fwn">Booking</h3>
     </div>
     <p class="mhxs pll">
-      Create shipments and generate shipment number, tracking link, EDI-prenotification, label and other transport documents. Modify certain shipments that are on their way, and order pickup.
+      Create shipments and generate shipment numbers, tracking links, EDI-prenotifications, labels and other transport documents.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/booking/">Booking API</a>
       <a class="btn-link--dark" href="/api/shipment/">Shipment API</a>
-      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 
@@ -63,11 +62,12 @@ important:
       <h3 class="mlxs fwn">Tracking</h3>
     </div>
     <p class="mhxs pll">
-      Look up tracking events of your shipments, or subscribe to them, and make them proactively available to your customers through webhooks.
+      Track your shipments’ events or subscribe to them, and proactively share updates with your customers through webhooks. Modify or stop shipments that are already in transit.
     </p>
     <div class="flex flex-wrap gas pll mlxs">
       <a class="btn-link--dark" href="/api/tracking/">Tracking API</a>
       <a class="btn-link--dark" href="/api/event-cast/">Event Cast API</a>
+      <a class="btn-link--dark" href="/api/modify-delivery/">Modify Delivery API</a>
     </div>
   </div>
 


### PR DESCRIPTION
We decided to move the Modify Delivery API to the tracking tile:

- Tracking team is responsible for the application
- To find Modify Delivery on Mybring, you have to go to Tracking, not Booking. Now it is reflected on the developer site.
- Modifications can only be done to an existing shipment, if you needed to stop and return a shipment while booking it, you would just not book the shipment.
- Although the developer site is publicly available, it is also used internally, and it can confuse the ownership of Modify Delivery
- Having it under Tracking might help guide external questions to the right point of contact.