### PR TITLE
Remove 5800, 0340 and 0342 as valid product codes for change address

### DIFF
--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -133,7 +133,7 @@ documentation:
              <td>5800</td>
              <td>Yes</td>
              <td>Yes</td>
-             <td>Yes</td>
+             <td>No</td>
           </tr>
           <tr>
              <td>Business parcel</td>
@@ -161,14 +161,14 @@ documentation:
              <td>0340</td>
              <td>Yes</td>
              <td>No</td>
-             <td>Yes</td>
+             <td>No</td>
           </tr>
           <tr>
              <td>Pickup parcel bulk</td>
              <td>0342</td>
              <td>Yes</td>
              <td>No</td>
-             <td>Yes</td>
+             <td>No</td>
           </tr>
           <tr>
              <td>Home delivery parcel</td>


### PR DESCRIPTION
Remove 5800, 0340 and 0342 as valid product codes for change address.

Ref this PR: https://github.com/bring/mybring-modify-delivery/pull/1904