### PR TITLE
Clean up templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,6 @@ running, do the following:
 - Duplicate the file and name it `new.md`
 - Remove `disqus`, `menu` and `weight` objects. This will prevent conflicts with
   the currently published page.
-- Add `hidden: true` instead. This will hide the new page in the menu and from
-  search engines.
 - Commit and make PR – the new page will be available at `{current-url}/new`
 
 If you don’t need duplication, just add `oas: {url to json}` to the current

--- a/js/api.js
+++ b/js/api.js
@@ -3,9 +3,9 @@ const paramToggleBtn = document.querySelectorAll(".param-toggle-btn")
 
 paramToggleBtn.forEach((btn) => {
   btn.addEventListener("click", function () {
-    const paramToggleBtnId = this.getAttribute('aria-controls')
-    const paramSubLevel = document.getElementById(paramToggleBtnId)
-    const paramToggleIcon = this.querySelector(".param-toggle-icon")
+    const paramToggleBtnId = this.getAttribute('aria-controls'),
+      paramSubLevel = document.getElementById(paramToggleBtnId),
+      paramToggleIcon = this.querySelector(".param-toggle-icon")
     let paramToggleBtnState = this.getAttribute('aria-expanded')
     paramToggleBtnState = paramToggleBtnState === 'true' ? false : true
 
@@ -23,17 +23,11 @@ toggleAllArr.forEach((toggleAllBtn) => {
     const toggleType = toggleAllBtn.dataset.toggleAll,
       closestDiv = toggleAllBtn.closest('div'),
       closestSchema = closestDiv.nextElementSibling,
-      toggleBtnArr = closestSchema.querySelectorAll('.param-toggle-btn')
-
-    let expand = 'false'
-    if (toggleType === 'collapse') {
-      expand = 'true'
-    }
+      toggleBtnArr = closestSchema.querySelectorAll('.param-toggle-btn'),
+      expand = toggleType === 'collapse' ? 'true' : 'false'
 
     toggleBtnArr.forEach((toggleBtn) => {
-      if (toggleBtn.getAttribute('aria-expanded') === expand) {
-        toggleBtn.click()
-      }
+    toggleBtn.getAttribute('aria-expanded') === expand && toggleBtn.click()
     })
   })
 })
@@ -44,39 +38,31 @@ function showSelectedSchema(ofElement) {
     closest = ofElement.closest("dd"),
     ofArr = Array.from(closest.children)
 
-  ofElement.setAttribute("checked", "")
   ofArr.forEach((ofChild) => {
     if (ofChild.tagName === "DL") {
-      ofChild.classList.add("dn")
-      if (ofChild.dataset.ofOne === elementVal) {
-        ofChild.classList.remove("dn")
-      }
+      ofChild.dataset.ofOne !== elementVal
+        ? ofChild.classList.add("dn")
+        : ofChild.classList.remove("dn")
     }
   })
 }
 
-const oneOfRadioArr = document.querySelectorAll("input[data-one-of]")
-oneOfRadioArr.forEach((radio) => {
-  radio.addEventListener("change", function () {
-    showSelectedSchema(radio)
+const oneOfElements = document.querySelectorAll("[data-one-of]")
+oneOfElements.forEach((ofElement) => {
+  ofElement.addEventListener("change", function () {
+    showSelectedSchema(ofElement)
   })
-})
-
-const allOfSelectArr = document.querySelectorAll("select[data-one-of]")
-allOfSelectArr.forEach((select) => {
-  select.addEventListener("change", function () {
-    showSelectedSchema(select)
-  })
+  // set oneOf/allOf selections on reload/backward/forward navigation
+  ofElement.type === 'radio' && ofElement.checked && showSelectedSchema(ofElement)
+  ofElement.type === 'select-one' && showSelectedSchema(select)
 })
 
 // Examples
 function switchExample(containerArr, dataAtt, id) {
   containerArr.forEach((container) => {
-    if (container.dataset[dataAtt] === id) {
-      container.hidden = false
-    } else {
-      container.hidden = true
-    }
+    container.dataset[dataAtt] === id
+      ? container.hidden = false
+      : container.hidden = true
   })
 }
 
@@ -90,12 +76,15 @@ responseExBtns.forEach((btn) => {
       return
     }
 
-    const resIdBtn = element.dataset.example
-    const endpointId = element.name
-    const responseSection = document.getElementById(endpointId)
-    const exampleContainers = responseSection.querySelectorAll("div[data-example]")
-    const activeBtn = document.querySelector('button[name="' + endpointId + '"][aria-selected="true"]')
-    activeBtn.setAttribute("aria-selected", false)
+    for (let i = 0; i < responseExBtns.length; i++) {
+      responseExBtns[i].setAttribute("aria-selected", false)
+    }
+
+    const resIdBtn = element.dataset.example,
+      endpointId = element.name,
+      responseSection = document.getElementById(endpointId),
+      exampleContainers = responseSection.querySelectorAll("div[data-example]")
+
     element.setAttribute("aria-selected", true)
 
     switchExample(exampleContainers, "example", resIdBtn)
@@ -108,7 +97,7 @@ const dataTypes = document.querySelectorAll('[data-type]')
 
 const setSelectFormat = (e) => {
   const storedFormat = localStorage.getItem("dataFormat")
-  let format = e.value;
+  let format = e.value
 
   formatSelects.forEach((f) => {
     for(let i = 0; i < f.options.length; i++) {
@@ -176,10 +165,10 @@ const exampleSelects = document.querySelectorAll(
 )
 exampleSelects.forEach((select) => {
   select.addEventListener("change", function (e) {
-    const element = e.target
-    const exId = element.value
-    const responseSection = element.closest("div[data-example]")
-    const exampleSubContainers = responseSection.querySelectorAll("div[data-example-sub]")
+    const element = e.target,
+      exId = element.value,
+      responseSection = element.closest("div[data-example]"),
+      exampleSubContainers = responseSection.querySelectorAll("div[data-example-sub]")
 
     switchExample(exampleSubContainers, "exampleSub", exId)
   })
@@ -195,35 +184,18 @@ if('clipboard' in navigator) {
     })
 
     function copyCode() {
-      const copyBtn = this
-      const exampleParent = copyBtn.parentNode
-      const example = exampleParent.querySelector('code').innerText
+      const copyBtn = this,
+        exampleParent = copyBtn.parentNode,
+        example = exampleParent.querySelector('code').innerText
 
       navigator.clipboard.writeText(example)
       .then(setCopiedBtnText)
 
       function setCopiedBtnText() {
-        copyBtn.querySelector('.copy-btn-label').innerText = "Copied"
-        setTimeout(resetCopyBtnText,3000)
-      }
-
-      function resetCopyBtnText() {
-        copyBtn.querySelector('.copy-btn-label').innerText = "Copy"
+        const copyBtnLabel = copyBtn.querySelector('.copy-btn-label')
+        copyBtnLabel.innerText = "Copied"
+        setTimeout(() => copyBtnLabel.innerText = "Copy",3000)
       }
     }
   }
 }
-
-document.addEventListener("DOMContentLoaded", function () {
-  // set oneOf/allOf selections on reload/backward/forward navigation
-  oneOfRadioArr.forEach((radio) => {
-    if (radio.checked) {
-      showSelectedSchema(radio)
-    } else {
-      radio.removeAttribute("checked")
-    }
-  })
-  allOfSelectArr.forEach((select) => {
-    showSelectedSchema(select)
-  })
-})

--- a/js/api.js
+++ b/js/api.js
@@ -27,7 +27,7 @@ toggleAllArr.forEach((toggleAllBtn) => {
       expand = toggleType === 'collapse' ? 'true' : 'false'
 
     toggleBtnArr.forEach((toggleBtn) => {
-    toggleBtn.getAttribute('aria-expanded') === expand && toggleBtn.click()
+      toggleBtn.getAttribute('aria-expanded') === expand && toggleBtn.click()
     })
   })
 })

--- a/js/api.js
+++ b/js/api.js
@@ -76,15 +76,13 @@ responseExBtns.forEach((btn) => {
       return
     }
 
-    for (let i = 0; i < responseExBtns.length; i++) {
-      responseExBtns[i].setAttribute("aria-selected", false)
-    }
-
     const resIdBtn = element.dataset.example,
       endpointId = element.name,
       responseSection = document.getElementById(endpointId),
-      exampleContainers = responseSection.querySelectorAll("div[data-example]")
+      exampleContainers = responseSection.querySelectorAll("div[data-example]"),
+      activeBtn = document.querySelector('button[name="' + endpointId + '"][aria-selected="true"]')
 
+    activeBtn.setAttribute("aria-selected", false)
     element.setAttribute("aria-selected", true)
 
     switchExample(exampleContainers, "example", resIdBtn)

--- a/js/api.js
+++ b/js/api.js
@@ -54,7 +54,7 @@ oneOfElements.forEach((ofElement) => {
   })
   // set oneOf/allOf selections on reload/backward/forward navigation
   ofElement.type === 'radio' && ofElement.checked && showSelectedSchema(ofElement)
-  ofElement.type === 'select-one' && showSelectedSchema(select)
+  ofElement.type === 'select-one' && showSelectedSchema(ofElement)
 })
 
 // Examples

--- a/layouts/_default/list.algolia.json
+++ b/layouts/_default/list.algolia.json
@@ -3,7 +3,6 @@
   {{- if (and
            (not .Draft)
            (not .IsHome)
-           (not .Params.hidden)
            (not .Params.private)
            (not (in .RelPermalink "/revision-history/"))
            (not (in .RelPermalink "/blog/"))

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,9 +1,6 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1" />
-  {{- with .Params.hidden -}}
-    <meta name="robots" content="noindex, nofollow">
-  {{- end -}}
   <meta http-equiv="expires" content="{{ now.Unix }}" />
   {{- $description := "" -}}
   {{- with .Summary -}}

--- a/layouts/partials/sidemenu.html
+++ b/layouts/partials/sidemenu.html
@@ -20,13 +20,11 @@
             {{- $lastElement = "mbm" -}}
           {{- end -}}
 
-          {{- $hidePage := false -}}
           {{- $url := .URL -}}
           {{- with .Page -}}
             {{/*  Semi-hacky way to prevent category from linking to untranslated category page  */}}
             {{- $categoryCheckUrl := strings.TrimLeft "/no" .RelPermalink -}}
             {{- $categoryCheckUrl = strings.TrimRight "/" $categoryCheckUrl -}}
-            {{- $hidePage = .Params.hidden -}}
             {{- if and (gt (len .Translations) 0) (ne $categoryCheckUrl $.Section) -}}
               {{- range .Translations -}}
                 {{- if eq (string .Language) (string $currentLanguage) -}}
@@ -35,7 +33,6 @@
               {{- end -}}
             {{- end -}}
           {{- end -}}
-          {{- if (ne $hidePage true) -}}
             <li
               class="{{ if (or ($currentPage.IsMenuCurrent .Menu .) ( and ($currentPage.HasMenuCurrent .Menu .) ( .HasChildren ))) }}active{{ end }} {{ $lastElement }}"
             >
@@ -110,7 +107,6 @@
                 {{- partial "toc.html" (dict "context" $currentPage "numberOfHeadings" "3" ) -}}
               {{- end -}}
             </li>
-          {{- end -}}
         {{- end -}}
       </ul>
     </nav>
@@ -123,18 +119,12 @@
               <span class="dev-sidemenu__title">{{ .Title }}</span>
               <ul>
                 {{ range .Children }}
-                  {{- $hidePage := false -}}
-                  {{- with .Page -}}
-                    {{- $hidePage = .Params.hidden -}}
-                  {{- end -}}
-                  {{- if or (eq $currentPage.Params.hidden true) (ne $hidePage true) -}}
-                    {{- if or (eq .Title "Order Management API") (eq .Title "Booking API") (eq .Title "Shipping Guide API") -}}
-                      {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "oasData" $.Params.oas "apiData" $apiData "prefix" "soap") -}}
-                    {{- else if isset $.Params "oas" -}}
-                      {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "oasData" $.Params.oas) -}}
-                    {{- else -}}
-                      {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "apiData" $apiData) -}}
-                    {{- end -}}
+                  {{- if or (eq .Title "Order Management API") (eq .Title "Booking API") (eq .Title "Shipping Guide API") -}}
+                    {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "oasData" $.Params.oas "apiData" $apiData "prefix" "soap") -}}
+                  {{- else if isset $.Params "oas" -}}
+                    {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "oasData" $.Params.oas) -}}
+                  {{- else -}}
+                    {{- partial "sidemenulist.html" (dict "ctx" . "currentPage" $currentPage "menu" .Menu "identifier" .Identifier "pageTitle" .Title "url" .URL "apiData" $apiData) -}}
                   {{- end -}}
                 {{- end -}}
               </ul>


### PR DESCRIPTION
Since we don‘t have any pages that are hidden (by the usage of `hidden` param) and there’s no need for it, we are removing the support for `hidden` param.
In addition to that, the JS code for the docs had potential to be improved. I couldn‘t quite see how to improve the examples part further, but there were other parts that could be refactored and reduced, so took the liberty of going through and making some tweaks here and there. 😃 