### PR TITLE
Update documentation for supported services

### DIFF
--- a/content/api/modify-delivery/index.md
+++ b/content/api/modify-delivery/index.md
@@ -133,7 +133,14 @@ documentation:
              <td>5800</td>
              <td>Yes</td>
              <td>Yes</td>
+             <td>Yes</td>
+          </tr>
+          <tr>
+             <td>Parcel Locker</td>
+             <td>5801</td>
+             <td>Yes</td>
              <td>No</td>
+             <td>Yes</td>
           </tr>
           <tr>
              <td>Business parcel</td>
@@ -161,14 +168,14 @@ documentation:
              <td>0340</td>
              <td>Yes</td>
              <td>No</td>
-             <td>No</td>
+             <td>Yes</td>
           </tr>
           <tr>
              <td>Pickup parcel bulk</td>
              <td>0342</td>
              <td>Yes</td>
              <td>No</td>
-             <td>No</td>
+             <td>Yes</td>
           </tr>
           <tr>
              <td>Home delivery parcel</td>


### PR DESCRIPTION
Add back support for 5800, 0340 and 0342 for change address. 

Also, 5801 was missing from the documentation, which was currently only for stop delivery. This is being supported by change address as well now.