### PR TITLE
adjust publish date on api update

### DIFF
--- a/content/api/revision-history/analytics/2024-11-27.md
+++ b/content/api/revision-history/analytics/2024-11-27.md
@@ -1,6 +1,6 @@
 ---
 title: Analytics - new documents API
-publishDate: 2024-11-25
+publishDate: 2024-12-03
 layout: api
 isImportant: true
 ---


### PR DESCRIPTION
Seems like CleverReach failed to see that an update was added on the dev site. The publish date was set to a monday, and the publish time of each update is set to `06:04:05 +0100` in the feed. Since we have configured CleverReach to check for updates 7 days back in time each monday at 09:00 am, it seems like the time before 09:00 am on mondays is not considered then.

In my mind, when it says 7 days back in time, the whole day counts from 00:00 am, but seems like that is not the case.
Would be nice to confirm it by just adjusting the publish date on this API update. If this is the case, we should adjust the config in CleverReach from 09:00 am to something like 06:00 am.