### PR TITLE
Show deprecated params in api docs

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -236,7 +236,7 @@
     }
   }
 
-  & .param-required {
+  & .param-state {
     color: var(--red-72);
   }
 

--- a/css/documentation.css
+++ b/css/documentation.css
@@ -286,7 +286,7 @@ div.response {
   transform: rotate(90deg);
 }
 
-.param-required {
+.param-state {
   color: var(--red-dark);
 }
 

--- a/layouts/partials/api/oas/request-params.html
+++ b/layouts/partials/api/oas/request-params.html
@@ -65,7 +65,7 @@
         <dt class="pls">
           <code>{{- replace .name "MyBring" "Mybring" -}}</code>
           {{- if eq .required true -}}
-            <div class="param-required text-note">Required</div>
+            <div class="param-state text-note">Required</div>
           {{- end -}}
         </dt>
         <dd class="pls">

--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -3,6 +3,7 @@
 {{- $objName := .objName -}}
 {{- $contactParent := .contactParent -}}
 {{- $required := .required -}}
+{{- $deprecated := .deprecated -}}
 {{- $components := .components -}}
 {{- $endpointId := .endpointId -}}
 {{- $uniqueId := "" -}}
@@ -32,7 +33,7 @@
     {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
   {{- end -}}
 {{- end -}}
 
@@ -62,7 +63,7 @@
     {{- with $schemaObj.properties -}}
       <dl id="xml-{{ $name | anchorize }}" class="pls {{ if ne $ofInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" {{ if in $isOf "one" }}aria-label="{{ $name }}"{{ end }}>
         {{- range $key, $_ := . -}}
-          {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
@@ -86,7 +87,10 @@
             <code class="mls">{{ $name }}</code>
           {{- end -}}
           {{- if $required -}}
-            <div class="plm mls lh-solid param-required text-note">Required</div>
+            <div class="plm mls lh-solid param-state text-note">Required</div>
+          {{- end -}}
+          {{- if $deprecated -}}
+            <div class="plm mls lh-solid param-state text-note">Deprecated</div>
           {{- end -}}
         </dt>
         <dd class="ptxs pls">
@@ -106,7 +110,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
+              {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -119,7 +123,7 @@
               <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
               <div class="flex flex-wrap gcm">
                 {{- range $key, $_ := . -}}
-                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
                   {{- $ofInd = add $ofInd 1 -}}
                 {{- end -}}
               </div>
@@ -127,7 +131,7 @@
           </form>
           {{- $ofInd = 0 -}}
           {{- range $key, $_ := . -}}
-            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
             {{- $ofInd = add $ofInd 1 -}}
           {{- end -}}
         </dd>
@@ -139,14 +143,14 @@
               <label class="form__label" for="{{ $levelName }}">Schema (allOf)</label>
               <select class="form__control wauto maxw100p" id="{{ $levelName }}" data-one-of>
                 {{- range $key, $_ := . -}}
-                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                  {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
                   {{- $ofInd = add $ofInd 1 -}}
                 {{- end -}}
               </select>
             </div>
           {{- $ofInd = 0 -}}
           {{- range $key, $_ := . -}}
-            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+            {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
             {{- $ofInd = add $ofInd 1 -}}
           {{- end -}}
         </dd>
@@ -185,7 +189,10 @@
       <dt>
         <code>{{ $name }}</code>
         {{- if $required -}}
-          <div class="lh-tight param-required text-note">Required</div>
+          <div class="lh-tight param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="lh-tight param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="pls">

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -4,6 +4,7 @@
 {{- $contactParent := .contactParent -}}
 {{- $components := .components -}}
 {{- $required := .required -}}
+{{- $deprecated := .deprecated -}}
 {{- $endpointId := .endpointId -}}
 {{- $uniqueId := "" -}}
 {{- $recLevel := add .recLevel 1 -}}
@@ -32,7 +33,7 @@
     {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
   {{- end -}}
 {{- end -}}
 
@@ -40,7 +41,7 @@
 {{- if and (eq $schemaObj.type "object") (lt $recLevel 3) (not (or $schemaObj.allOf $schemaObj.oneOf)) (not $isOf) -}}
   {{- with $schemaObj.properties -}}
     {{- range $key, $_ := . -}}
-      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
+      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd) -}}
     {{- end -}}
   {{- end -}}
 
@@ -67,7 +68,7 @@
     {{- with $schemaObj.properties -}}
       <dl id="json-{{ $name | anchorize }}" class="pls {{ if ne $ofInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" {{ if in $isOf "one" }}aria-label="{{ $name }}"{{ end }}>
         {{- range $key, $_ := . -}}
-          {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
@@ -91,7 +92,10 @@
             <code class="mls">{{ $name }}</code>
           {{- end -}}
           {{- if $required -}}
-            <div class="plm mls lh-solid param-required text-note">Required</div>
+            <div class="plm mls lh-solid param-state text-note">Required</div>
+          {{- end -}}
+          {{- if $deprecated -}}
+            <div class="plm mls lh-solid param-state text-note">Deprecated</div>
           {{- end -}}
         </dt>
         <dd class="ptxs pls">
@@ -108,7 +112,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "objName" $objName "contactParent" $contactParent) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -124,7 +128,7 @@
                   {{- range . -}}
                     {{- $schemaPath := path.Split . -}}
                     {{- $schema := index $components.schemas $schemaPath.File -}}
-                    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
                   {{- end -}}
                   {{- $ofInd = add $ofInd 1 -}}
                 {{- end -}}
@@ -136,7 +140,7 @@
             {{- range . -}}
               {{- $schemaPath := path.Split . -}}
               {{- $schema := index $components.schemas $schemaPath.File -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
               {{- $ofInd = add $ofInd 1 -}}
             {{- end -}}
           {{- end -}}
@@ -153,7 +157,7 @@
                 {{- range . -}}
                   {{- $schemaPath := path.Split . -}}
                   {{- $schema := index $components.schemas $schemaPath.File -}}
-                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
                 {{- end -}}
                 {{- $ofInd = add $ofInd 1 -}}
               {{- end -}}
@@ -164,7 +168,7 @@
             {{- range . -}}
               {{- $schemaPath := path.Split . -}}
               {{- $schema := index $components.schemas $schemaPath.File -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
               {{- $ofInd = add $ofInd 1 -}}
             {{- end -}}
           {{- end -}}
@@ -214,7 +218,10 @@
           <code class="mls">{{ $name }}</code>
         {{- end -}}
         {{- if $required -}}
-          <div class="mls lh-solid param-required text-note">Required</div>
+          <div class="mls lh-solid param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="mls lh-solid param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="ptxs pls">
@@ -305,7 +312,10 @@
       <dt>
         <code>{{ $name }}</code>
         {{- if $required -}}
-          <div class="lh-tight param-required text-note">Required</div>
+          <div class="lh-tight param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="lh-tight param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="pls">

--- a/layouts/partials/api/oas/required.html
+++ b/layouts/partials/api/oas/required.html
@@ -1,1 +1,1 @@
-<div class="lh-solid param-required text-note">Required</div>
+<div class="lh-solid param-state text-note">Required</div>

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -1,6 +1,7 @@
 {{- $schemaObj := .schemaObj -}}
 {{- $name := .name -}}
 {{- $required := .required -}}
+{{- $deprecated := .deprecated -}}
 {{- $components := .components -}}
 {{- $responseCode := .responseCode -}}
 {{- $endpointId := .endpointId -}}
@@ -26,7 +27,7 @@
   {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
   {{- end -}}
 {{- end -}}
 
@@ -52,7 +53,7 @@
     {{- with $schemaObj.properties -}}
       <dl id="{{ $responseCode }}-xml-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" aria-label="{{ $name }}">
         {{- range $key, $_ := . -}}
-          {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
@@ -66,7 +67,10 @@
             <code class="mls">{{ $name }}</code>
           {{- end -}}
           {{- if $required -}}
-            <div class="plm mls lh-solid param-required text-note">Required</div>
+            <div class="plm mls lh-solid param-state text-note">Required</div>
+          {{- end -}}
+          {{- if $deprecated -}}
+            <div class="plm mls lh-solid param-state text-note">Deprecated</div>
           {{- end -}}
         </dt>
         <dd class="ptxs pls">
@@ -86,7 +90,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 2 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
+              {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -99,7 +103,7 @@
               <legend class="fw600 pts mbxs">Schema (oneOf)</legend>
               <div class="flex flex-wrap gcm">
                 {{- range $key, $_ := . -}}
-                  {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
+                  {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
                   {{- $oneOfInd = add $oneOfInd 1 -}}
                 {{- end -}}
               </div>
@@ -107,7 +111,7 @@
           </form>
           {{- $oneOfInd = 0 -}}
           {{- range $key, $_ := . -}}
-            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "data" "oneOfInd" $oneOfInd) -}}
+            {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" "data" "oneOfInd" $oneOfInd) -}}
             {{- $oneOfInd = add $oneOfInd 1 -}}
           {{- end -}}
         </dd>
@@ -133,7 +137,10 @@
       <dt>
         <code>{{ $name }}</code>
         {{- if $required -}}
-          <div class="lh-tight param-required text-note">Required</div>
+          <div class="lh-tight param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="lh-tight param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="pls">

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -3,6 +3,7 @@
 {{- $components := .components -}}
 {{- $responseCode := .responseCode -}}
 {{- $required := .required -}}
+{{- $deprecated := .deprecated -}}
 {{- $endpointId := .endpointId -}}
 {{- $uniqueId := "" -}}
 {{- $recLevel := add .recLevel 1 -}}
@@ -26,7 +27,7 @@
     {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
   {{- end -}}
 {{- end -}}
 
@@ -34,7 +35,7 @@
 {{- if and (eq $schemaObj.type "object") (lt $recLevel 3) -}}
   {{- with $schemaObj.properties -}}
     {{- range $key, $_ := . -}}
-      {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+      {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
     {{- end -}}
   {{- end -}}
 
@@ -48,7 +49,7 @@
               {{- range . -}}
                 {{- $schemaPath := path.Split . -}}
                 {{- $schema := index $components.schemas $schemaPath.File -}}
-                {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
+                {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
               {{ end }}
               {{- $oneOfInd = add $oneOfInd 1 -}}
             {{- end -}}
@@ -60,7 +61,7 @@
         {{- range . -}}
           {{- $schemaPath := path.Split . -}}
           {{- $schema := index $components.schemas $schemaPath.File -}}
-          {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
+          {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
           {{- $oneOfInd = add $oneOfInd 1 -}}
         {{- end -}}
       {{- end -}}
@@ -85,7 +86,7 @@
     {{- with $schemaObj.properties -}}
       <dl id="{{ $responseCode }}-json-{{ $name | anchorize }}" class="pls {{ if ne $oneOfInd 0 }}dn{{ end }}" data-of-one="{{ $levelName }}" aria-label="{{ $name }}">
         {{- range $key, $_ := . -}}
-          {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
+          {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
         {{- end -}}
       </dl>
     {{- end -}}
@@ -99,7 +100,10 @@
             <code class="mls">{{ $name }}</code>
           {{- end -}}
           {{- if $required -}}
-            <div class="plm mls lh-solid param-required text-note">Required</div>
+            <div class="plm mls lh-solid param-state text-note">Required</div>
+          {{- end -}}
+          {{- if $deprecated -}}
+            <div class="plm mls lh-solid param-state text-note">Deprecated</div>
           {{- end -}}
         </dt>
         <dd class="ptxs pls">
@@ -116,7 +120,7 @@
         <dd class="schema__sublist {{ if gt $recLevel 1 }}dn{{ end }}" id="{{ $levelId }}">
           <dl class="pls">
             {{- range $key, $_ := . -}}
-              {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
+              {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schemaObj.required $key) "deprecated" .deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel) -}}
             {{- end -}}
           </dl>
         </dd>
@@ -161,7 +165,10 @@
           <code class="mls">{{ $name }}</code>
         {{- end -}}
         {{- if $required -}}
-          <div class="plm mls lh-solid param-required text-note">Required</div>
+          <div class="plm mls lh-solid param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="plm mls lh-solid param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="ptxs pls">
@@ -240,7 +247,10 @@
       <dt>
         <code>{{ $name }}</code>
         {{- if $required -}}
-          <div class="lh-tight param-required text-note">Required</div>
+          <div class="lh-tight param-state text-note">Required</div>
+        {{- end -}}
+        {{- if $deprecated -}}
+          <div class="lh-tight param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="pls">


### PR DESCRIPTION
Adding support for showing the param state `deprecated: true` (like we have for `required: true`).
The class name in css was quite specific to the `required` state, so making that also a bit more universal.