### PR TITLE
Rename 4850: Generated from latest Common-vas

### DIFF
--- a/data/services_bsg.json
+++ b/data/services_bsg.json
@@ -96,7 +96,7 @@
 }, {
   "ServiceFamily" : "Parcel Norway domestic",
   "CustomerNumberType" : "Main customer number",
-  "ServiceName" : "Express next day",
+  "ServiceName" : "Business parcel express",
   "ServiceIcon" : "serviceicon-clock-striped",
   "ServiceCode" : "4850",
   "RequestCode" : "4850",

--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -499,7 +499,7 @@
   "bookingCode" : "1062",
   "incompatibleVases" : [ ],
   "supportedServices" : [ {
-    "serviceName" : "Express next day",
+    "serviceName" : "Business parcel express",
     "serviceType" : "B2B",
     "serviceFamily" : "Parcel Norway domestic",
     "serviceFamilySortOrder" : 1,
@@ -1071,7 +1071,7 @@
     "senderCountries" : "ALL",
     "destinations" : "SE, DK"
   }, {
-    "serviceName" : "Express next day",
+    "serviceName" : "Business parcel express",
     "serviceType" : "B2B",
     "serviceFamily" : "Parcel Norway domestic",
     "serviceFamilySortOrder" : 1,
@@ -1425,7 +1425,7 @@
     "senderCountries" : "-",
     "destinations" : "-"
   }, {
-    "serviceName" : "Express next day",
+    "serviceName" : "Business parcel express",
     "serviceType" : "B2B",
     "serviceFamily" : "Parcel Norway domestic",
     "serviceFamilySortOrder" : 1,
@@ -2127,7 +2127,7 @@
   "bookingCode" : "1083",
   "incompatibleVases" : [ ],
   "supportedServices" : [ {
-    "serviceName" : "Express next day",
+    "serviceName" : "Business parcel express",
     "serviceType" : "B2B",
     "serviceFamily" : "Parcel Norway domestic",
     "serviceFamilySortOrder" : 1,


### PR DESCRIPTION
- Rename 4850 service to Business parcel express (previously known as 'Express Next day')
- Ref: https://trello.com/c/KhjnLTyp/5717-4850-ekspress-neste-dag-changing-name-to-pakke-til-bedrift-ekspress
- NO: Pakke til bedrift ekspress
- SE: Paket till företag express
- DK: Pakke til virksomhed ekspres
- EN: Business parcel express