### PR TITLE
Fix missing required annotation

### DIFF
--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -212,6 +212,9 @@
           {{- if $schemaObj.xml.attribute -}}
             <span>{{- print " attribute" -}}</span>
           {{- end -}}
+          {{- with $schemaObj.minLength -}}
+            <span>Min length: {{ . }}</span>
+          {{- end -}}
           {{- with $schemaObj.maxLength -}}
             <span>Max length: {{ . }}</span>
           {{- end -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -280,7 +280,7 @@
                 {{- $schema := index $components.schemas $schemaPath.File -}}
                 {{- $items := $schema.properties -}}
                 {{- range $key, $_ := $items -}}
-                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $key "required" (in $schema.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
                 {{- end -}}
               {{- end -}}
             {{- end -}}

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -332,6 +332,9 @@
           {{- with $schemaObj.format -}}
             <span>{{- printf " <%s>" . -}}</span>
           {{- end -}}
+          {{- with $schemaObj.minLength -}}
+            <span>Min length: {{ . }}</span>
+          {{- end -}}
           {{- with $schemaObj.maxLength -}}
             <span>Max length: {{ . }}</span>
           {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -155,6 +155,9 @@
           {{- if $schemaObj.xml.attribute -}}
             <span>{{- print " attribute" -}}</span>
           {{- end -}}
+          {{- with $schemaObj.minLength -}}
+            <span>Min length: {{ . }}</span>
+          {{- end -}}
           {{- with $schemaObj.maxLength -}}
             <span>Max length: {{ . }}</span>
           {{- end -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -227,7 +227,7 @@
                 {{- $schema := index $components.schemas $schemaPath.File -}}
                 {{- $items := $schema.properties -}}
                 {{- range $key, $_ := $items -}}
-                  {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
+                  {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $key "required" (in $schema.required $key) "components" $components "endpointId" $endpointId "recLevel" $recLevel) -}}
                 {{- end -}}
               {{- end -}}
             {{- end -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -159,16 +159,18 @@
   <div class="mb-border bb mbs">
     <div class="flex flex-wrap align-ifs pbs">
       <dt>
+        {{- $padding := "" -}}
         {{- if $hasChildren -}}
+          {{- $padding = "plm" -}}
           {{- partial "api/oas/param-toggle-btn.html" (dict "levelId" $levelId "name" $name "recLevel" $recLevel "threshold" 2) -}}
         {{- else -}}
           <code class="mls">{{ $name }}</code>
         {{- end -}}
         {{- if $required -}}
-          <div class="plm mls lh-solid param-state text-note">Required</div>
+          <div class="{{ $padding }} mls lh-solid param-state text-note">Required</div>
         {{- end -}}
         {{- if $deprecated -}}
-          <div class="plm mls lh-solid param-state text-note">Deprecated</div>
+          <div class="{{ $padding }} mls lh-solid param-state text-note">Deprecated</div>
         {{- end -}}
       </dt>
       <dd class="ptxs pls">

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -262,6 +262,9 @@
           {{- with $schemaObj.format -}}
             <span>{{- printf " <%s>" . -}}</span>
           {{- end -}}
+          {{- with $schemaObj.minLength -}}
+            <span>Min length: {{ . }}</span>
+          {{- end -}}
           {{- with $schemaObj.maxLength -}}
             <span>Max length: {{ . }}</span>
           {{- end -}}


### PR DESCRIPTION
Fixes a bug where the "required" prop was missing from arrays in the json format in request and responses. XML templates did not have the bug.

Shows min length prop. Can probably figure out a better way to show max and min though.

<img width="755" alt="Screenshot 2025-03-06 at 10 42 12" src="https://github.com/user-attachments/assets/811e00ec-04db-424c-b4df-36b18447888c" />

