### PR TITLE
bring-parcels-services-from-dk-fi-no-se-and-europe-updates

### DIFF
--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -7,26 +7,6 @@
   "bookingCode" : "1000",
   "incompatibleVases" : [ "Flex delivery" ],
   "supportedServices" : [ {
-    "serviceName" : "Business Parcel",
-    "serviceType" : "B2B",
-    "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
-    "serviceFamilySortOrder" : 2,
-    "serviceCode" : "BUSINESS_PARCEL",
-    "productionCode" : "0330",
-    "domesticAllowedIn" : "-",
-    "senderCountries" : "NO, SE, DK, FI",
-    "destinations" : "FO, GL"
-  }, {
-    "serviceName" : "Business Parcel Bulk",
-    "serviceType" : "B2B",
-    "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
-    "serviceFamilySortOrder" : 2,
-    "serviceCode" : "BUSINESS_PARCEL_BULK",
-    "productionCode" : "0332",
-    "domesticAllowedIn" : "FI",
-    "senderCountries" : "ALL",
-    "destinations" : "FI, FO, IS"
-  }, {
     "serviceName" : "Pickup parcel",
     "serviceType" : "B2C",
     "serviceFamily" : "Parcel Norway domestic",
@@ -37,16 +17,6 @@
     "senderCountries" : "-",
     "destinations" : "-"
   }, {
-    "serviceName" : "PickUp Parcel",
-    "serviceType" : "B2C",
-    "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
-    "serviceFamilySortOrder" : 2,
-    "serviceCode" : "PICKUP_PARCEL",
-    "productionCode" : "0340",
-    "domesticAllowedIn" : "-",
-    "senderCountries" : "SE, DK, FI",
-    "destinations" : "FO, GL"
-  }, {
     "serviceName" : "PickUp Parcel Bulk",
     "serviceType" : "B2C",
     "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
@@ -55,37 +25,7 @@
     "productionCode" : "0342",
     "domesticAllowedIn" : "-",
     "senderCountries" : "ALL",
-    "destinations" : "NO, FI, FO, IS"
-  }, {
-    "serviceName" : "Home Delivery Parcel",
-    "serviceType" : "B2C",
-    "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
-    "serviceFamilySortOrder" : 2,
-    "serviceCode" : "HOME_DELIVERY_PARCEL",
-    "productionCode" : "0349",
-    "domesticAllowedIn" : "-",
-    "senderCountries" : "ALL",
-    "destinations" : "FI"
-  }, {
-    "serviceName" : "Express Nordic 09:00 Bulk",
-    "serviceType" : "B2B",
-    "serviceFamily" : "Parcel Sweden, Denmark, Finland & Parcel Norway cross-border",
-    "serviceFamilySortOrder" : 2,
-    "serviceCode" : "EXPRESS_NORDIC_0900_BULK",
-    "productionCode" : "0334",
-    "domesticAllowedIn" : "-",
-    "senderCountries" : "ALL",
     "destinations" : "NO"
-  }, {
-    "serviceName" : "Mail",
-    "serviceType" : "B2X",
-    "serviceFamily" : "Mail",
-    "serviceFamilySortOrder" : 8,
-    "serviceCode" : "MAIL",
-    "productionCode" : "3266",
-    "domesticAllowedIn" : "NO",
-    "senderCountries" : "-",
-    "destinations" : "-"
   } ],
   "serviceAndCountryFootNotes" : [ ],
   "vasFootNotes" : [ ],
@@ -2641,7 +2581,7 @@
     "productionCode" : "0340",
     "domesticAllowedIn" : "SE, DK",
     "senderCountries" : "NO, SE, DK, FI",
-    "destinations" : "NO, SE, DK, FI, AX, FO, GL, IS"
+    "destinations" : "NO, SE, DK, FI"
   }, {
     "serviceName" : "PickUp Parcel Bulk",
     "serviceType" : "B2C",
@@ -2651,7 +2591,7 @@
     "productionCode" : "0342",
     "domesticAllowedIn" : "SE, DK",
     "senderCountries" : "ALL",
-    "destinations" : "NO, SE, DK, FI, FO, IS"
+    "destinations" : "NO, SE, DK, FI"
   }, {
     "serviceName" : "Home Delivery Parcel",
     "serviceType" : "B2C",


### PR DESCRIPTION
- Remove **Limited quantities (0003)** VAS from below destination countries for `0340 (PICKUP_PARCEL)` and` 0342 (PICKUP_PARCEL_BULK)`
       1. FO - FAROE_ISLANDS
       2. GL - GREENLAND
       3. IS - ICELAND
       4. AX - ALAND_ISLANDS
- Remove support for **POSTOPPKRAV (1000/0051) VAS** from all the countries except for `0342 (Pickup Parcel Bulk)` for NO and `Pickup parcel (5800)` (NO domestic)
