### PR TITLE
Handle missing ref objects

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -48,7 +48,7 @@
               {{- range first 3 $pages -}}
                 <div class="bg-gray1 bshadow pal rad-a2px">
                   <time class="mrs text-note"
-                    datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                    datetime="{{ .PublishDate.Format "2006-01-02" | safeHTML }}"
                     >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
                   >
                   {{- if (.Params.isImportant) -}}

--- a/layouts/partials/api/changelog.html
+++ b/layouts/partials/api/changelog.html
@@ -58,7 +58,7 @@
             <div> 
               <time
                 class="mrm text-note fw600"
-                datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                datetime="{{ .PublishDate.Format "2006-01-02" | safeHTML }}"
                 >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time>
               {{- if (.Params.isImportant) -}}
                   <span class="mb-badge mb-badge--yellow">Important</span>
@@ -90,7 +90,7 @@
                 <div class="flex">
                   <time
                   class="mrm text-note fw600"
-                  datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+                  datetime="{{ .PublishDate.Format "2006-01-02" | safeHTML }}"
                   >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time>
                   {{- if (.Params.isImportant) -}}
                   <span class="mb-badge mb-badge--yellow">Important</span>

--- a/layouts/partials/api/docs.html
+++ b/layouts/partials/api/docs.html
@@ -108,9 +108,11 @@
             </div>
             <table>
               <thead>
-                <th>Usage</th>
-                <th>Method</th>
-                <th>Endpoint</th>
+                <tr>
+                  <th>Usage</th>
+                  <th>Method</th>
+                  <th>Endpoint</th>
+                </tr>
               </thead>
               {{- range . -}}
                 {{ $displayName := .displayName }}

--- a/layouts/partials/api/importantupdates.html
+++ b/layouts/partials/api/importantupdates.html
@@ -33,7 +33,7 @@
       <div class="message--warn pal">
         <h3 class="text-basic">
           <time
-            datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+            datetime="{{ .PublishDate.Format "2006-01-02" | safeHTML }}"
             >{{ .PublishDate.Format "2 January 2006" | safeHTML }}</time
           >: {{ .Title }}
         </h3>

--- a/layouts/partials/api/oas/endpoints-table.html
+++ b/layouts/partials/api/oas/endpoints-table.html
@@ -23,12 +23,14 @@
 
     <table class="maxw96r">
       <thead>
-        {{- with $soapArr -}}
-          <th>Type</th>
-        {{- end -}}
-        <th>Usage</th>
-        <th>Method</th>
-        <th>Endpoint</th>
+        <tr>
+          {{- with $soapArr -}}
+            <th>Type</th>
+          {{- end -}}
+          <th>Usage</th>
+          <th>Method</th>
+          <th>Endpoint</th>
+        </tr>
       </thead>
       {{- $restInd := 0 -}}
       {{- $pathsLen := len .paths -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -27,7 +27,11 @@
   {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- with $schema -}}
+      {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- else -}}
+      <script>console.error("{{$schemaPath.File}} object missing from schema. XML response template render exited.")</script>
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/blog-meta.html
+++ b/layouts/partials/blog-meta.html
@@ -20,7 +20,7 @@
         data-mybicon-class="dev-blog__meta-icon"
       ></span>
       <time
-        datetime="{{ .PublishDate.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML }}"
+        datetime="{{ .PublishDate.Format "2006-01-02" | safeHTML }}"
         >&nbsp;{{ .PublishDate.Format "Jan 2, 2006" }}</time
       >
     </div>


### PR DESCRIPTION
Missing ref objects breaks the XML template and the entire page, the issue must be fixed in the source, but the template shouldn’t break, so that’s prevented now along with a console.error with the name of the missing objects.

And this sent me down a validation rabbit hole, which turns out there could be some improvements. So I fixed a couple that was too difficult to save for later.

![Screenshot 2025-03-28 at 14 39 37](https://github.com/user-attachments/assets/05ee2ae7-e4d3-4c73-b3da-ef8c784d8a68)
