### PR TITLE
Output missing schema warning in both consoles

### DIFF
--- a/layouts/partials/api/oas/request-schema-xml.html
+++ b/layouts/partials/api/oas/request-schema-xml.html
@@ -33,7 +33,11 @@
     {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" $schema "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- with $schema -}}
+      {{- partial "api/oas/request-schema-xml.html" (dict "schemaObj" . "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- else -}}
+      {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "XML request") -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 

--- a/layouts/partials/api/oas/request-schema.html
+++ b/layouts/partials/api/oas/request-schema.html
@@ -33,7 +33,11 @@
     {{- $contactParent = $objName -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- with $schema -}}
+      {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "deprecated" $deprecated "endpointId" $endpointId "recLevel" $recLevel "isOf" $isOf "parent" $parent "ofInd" $ofInd "contactParent" $contactParent) -}}
+    {{- else -}}
+      {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON request") -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -128,7 +132,11 @@
                   {{- range . -}}
                     {{- $schemaPath := path.Split . -}}
                     {{- $schema := index $components.schemas $schemaPath.File -}}
-                    {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                    {{- with $schema -}}
+                      {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "radio" "parent" $name "ofInd" $ofInd) -}}
+                    {{- else -}}
+                      {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON request") -}}
+                    {{- end -}}
                   {{- end -}}
                   {{- $ofInd = add $ofInd 1 -}}
                 {{- end -}}
@@ -140,7 +148,11 @@
             {{- range . -}}
               {{- $schemaPath := path.Split . -}}
               {{- $schema := index $components.schemas $schemaPath.File -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+              {{- with $schema -}}
+                {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "oneData" "ofInd" $ofInd) -}}
+              {{- else -}}
+                {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON request") -}}
+              {{- end -}}
               {{- $ofInd = add $ofInd 1 -}}
             {{- end -}}
           {{- end -}}
@@ -157,7 +169,11 @@
                 {{- range . -}}
                   {{- $schemaPath := path.Split . -}}
                   {{- $schema := index $components.schemas $schemaPath.File -}}
-                  {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                  {{- with $schema -}}
+                    {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "select" "parent" $name "ofInd" $ofInd) -}}
+                  {{- else -}}
+                    {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON request") -}}
+                  {{- end -}}
                 {{- end -}}
                 {{- $ofInd = add $ofInd 1 -}}
               {{- end -}}
@@ -168,7 +184,11 @@
             {{- range . -}}
               {{- $schemaPath := path.Split . -}}
               {{- $schema := index $components.schemas $schemaPath.File -}}
-              {{- partial "api/oas/request-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+              {{- with $schema -}}
+                {{- partial "api/oas/request-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "endpointId" $endpointId "recLevel" $recLevel "isOf" "allData" "ofInd" $ofInd) -}}
+              {{- else -}}
+                {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON request") -}}
+              {{- end -}}
               {{- $ofInd = add $ofInd 1 -}}
             {{- end -}}
           {{- end -}}

--- a/layouts/partials/api/oas/response-schema-xml.html
+++ b/layouts/partials/api/oas/response-schema-xml.html
@@ -30,7 +30,7 @@
     {{- with $schema -}}
       {{- partial "api/oas/response-schema-xml.html" (dict "schemaObj" . "name" $schemaPath.File "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "isOneOf" $isOneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
     {{- else -}}
-      <script>console.error("{{$schemaPath.File}} object missing from schema. XML response template render exited.")</script>
+      {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "XML response") -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/api/oas/response-schema.html
+++ b/layouts/partials/api/oas/response-schema.html
@@ -27,7 +27,11 @@
     {{- $isRef = true -}}
     {{- $schemaPath := path.Split . -}}
     {{- $schema := index $components.schemas $schemaPath.File -}}
-    {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $name "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- with $schema -}}
+      {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $name "components" $components "required" $required "deprecated" $deprecated "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" $oneOf "parent" $parent "oneOfInd" $oneOfInd) -}}
+    {{- else -}}
+      {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON response") -}}
+    {{- end -}}
   {{- end -}}
 {{- end -}}
 
@@ -49,8 +53,12 @@
               {{- range . -}}
                 {{- $schemaPath := path.Split . -}}
                 {{- $schema := index $components.schemas $schemaPath.File -}}
-                {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
-              {{ end }}
+                {{- with $schema -}}
+                  {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "radio" "parent" $name "oneOfInd" $oneOfInd) -}}
+                {{- else -}}
+                  {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON response") -}}
+                {{- end -}}
+              {{- end -}}
               {{- $oneOfInd = add $oneOfInd 1 -}}
             {{- end -}}
           </div>
@@ -61,7 +69,11 @@
         {{- range . -}}
           {{- $schemaPath := path.Split . -}}
           {{- $schema := index $components.schemas $schemaPath.File -}}
-          {{- partial "api/oas/response-schema.html" (dict "schemaObj" $schema "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
+          {{- with $schema -}}
+            {{- partial "api/oas/response-schema.html" (dict "schemaObj" . "name" $schemaPath.File "required" $required "deprecated" $deprecated "components" $components "responseCode" $responseCode "endpointId" $endpointId "recLevel" $recLevel "oneOf" "data" "oneOfInd" $oneOfInd) -}}
+          {{- else -}}
+            {{- partial "api/oas/schema-ref-error.html" (dict "objectName" $schemaPath.File "type" "JSON response") -}}
+          {{- end -}}
           {{- $oneOfInd = add $oneOfInd 1 -}}
         {{- end -}}
       {{- end -}}

--- a/layouts/partials/api/oas/schema-ref-error.html
+++ b/layouts/partials/api/oas/schema-ref-error.html
@@ -1,0 +1,2 @@
+{{ warnf "%d: %s: %s object missing from schema. UI for %s not rendered." math.Counter page.Title .objectName .type }}
+<script>console.warn("{{.objectName}} object missing from schema. UI for {{ .type }} not rendered.")</script>


### PR DESCRIPTION
Follow up to https://github.com/bring/developer-site/pull/1858
This adds the check to request and response templates, both XML and JSON. And it sends a warning to the console when building or running along with the name of the API. And it changes the error sent to the browser console into a warning.

There might be a better way to check for this earlier than on each render, but at the same time it allows as much of the interface to render without breaking … might look into it when doing a cleanup of the syntax.

![Screenshot 2025-03-31 at 17 50 20](https://github.com/user-attachments/assets/e1ea5ca1-5c69-43a0-a1ff-dcda6c1c8662)
