### PR TITLE
Update dev site for 2082 vas coverage expansion in 3639

### DIFF
--- a/content/api/booking/examples/vas/2082.html
+++ b/content/api/booking/examples/vas/2082.html
@@ -1,0 +1,3 @@
+<div>
+  <p>Enable tracking. Applies to both recipient and sender.</p>
+</div>

--- a/content/api/booking/examples/vas/2082.json
+++ b/content/api/booking/examples/vas/2082.json
@@ -1,0 +1,5 @@
+"additionalServices": [
+  {
+    "id": "2082"
+  }
+]

--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -3139,7 +3139,7 @@
     "productionCode" : "3639",
     "domesticAllowedIn" : "-",
     "senderCountries" : "NO",
-    "destinations" : "SE, DK, FI, AT, BE, CH, CZ, DE, EE, FR, GB, HR, HU, IE, IS, IT, LT, LU, LV, NL, PL, SI, SK"
+    "destinations" : "SE, DK, FI, AT, AU, BE, CA, CH, CN, CZ, DE, EE, ES, FR, GB, GR, HR, HU, IE, IS, IT, JP, LT, LU, LV, NL, NZ, PL, PT, SI, SK, US"
   } ],
   "serviceAndCountryFootNotes" : [ ],
   "vasFootNotes" : [ ],


### PR DESCRIPTION
- Adding below countries to `2082` VAS coverage for `3639` services
          1. GREECE
          2. SPAIN
          3. PORTUGAL
          4. AUSTRALIA
          5. CANADA
          6. JAPAN
          7. CHINA
          8. NEW ZEALAND
          9. UNITED STATES
- Ref: https://github.com/bring/mybring-service-country-vas-common/pull/459