### PR TITLE
Limit truncation to raw content length

### DIFF
--- a/layouts/index.html
+++ b/layouts/index.html
@@ -62,7 +62,7 @@
                     <div class="screen-reader-text full-content" >
                       {{ .Content }}
                     </div>
-                    {{- if gt (len .Content) 300 -}}
+                    {{- if gt (len .RawContent) 300 -}}
                       <button class="read-more btn-link--dark" aria-hidden="true">Show more</button>
                     {{- end -}}
                   </div>


### PR DESCRIPTION
Checking .Content counts the rendered code, with HTML and all. Which lead to edge cases where the show more button is visible even though there isn’t more to show.

The documents API message has 292 characters, but when rendered as HTML it has 312, so it shows the button even though the text isn’t long enough.

This solution isn’t foolproof, if there is a link, the raw is potentially longer than the rendered visible text. We’ll see.