### PR TITLE
Update allowed sender countries for optional pickup point vas

### DIFF
--- a/data/services_vas.json
+++ b/data/services_vas.json
@@ -2554,7 +2554,7 @@
     "serviceCode" : "PICKUP_PARCEL",
     "productionCode" : "0340",
     "domesticAllowedIn" : "SE, DK",
-    "senderCountries" : "ALL",
+    "senderCountries" : "ALL COUNTRIES EXCEPT NORWAY",
     "destinations" : "SE, DK"
   } ],
   "serviceAndCountryFootNotes" : [ ],


### PR DESCRIPTION
Updating allowed sender countries for Optional Pickup Point with PICKUP_PARCEL. Changes are generated directly from mybring-service-country-vas-common.