### PR TITLE
Fix service portfolio tables

### DIFF
--- a/css/dark-theme.css
+++ b/css/dark-theme.css
@@ -104,9 +104,24 @@
   & optgroup,
   & select,
   & textarea {
-    background-color: var(--green-26);
+    background-color: var(--green-22);
     color: var(--green-86);
     border-color: var(--green-40);
+
+    &:hover {
+      border-color: var(--green-60);
+    }
+
+    &:disabled {
+      background-color: var(--green-10);
+      border-color: var(--green-22);
+    }
+  }
+
+  & .mb-form input:hover,
+  select:hover,
+  text-area:hover {
+    border-color: var(--green-60);
   }
 
   & .dev-docscontent__section,
@@ -222,10 +237,18 @@
 
   & .dev-sidemenu a,
   & .param-toggle-icon,
-  & .form__label,
+  & label,
   & .dev-docscontent__info summary,
   & .dev-docscontent__info details p {
     color: var(--green-86);
+  }
+
+  .mb-form {
+    label:has([type="radio"], [type="checkbox"]) {
+      &:has(input):hover {
+        color: white;
+      }
+    }
   }
 
   & .dev-sidemenu a,

--- a/layouts/_default/services.html
+++ b/layouts/_default/services.html
@@ -20,8 +20,8 @@
           {{- if in .title "Value" -}}
             {{- partial "services/vas" (dict "data" (index $.Site.Data .data) "examples" $.Site.Data.examples) -}}
           {{- end -}}
-          {{- if in .title "Reports" -}}
-            {{- partial "services/reports-invoice" (dict "data" (index $.Site.Data .data)) -}}
+          {{- if in .title "Analytics" -}}
+            {{- partial "services/analytics" (dict "data" (index $.Site.Data .data)) -}}
           {{- end -}}
         </section>
       {{- end -}}

--- a/layouts/partials/services/analytics.html
+++ b/layouts/partials/services/analytics.html
@@ -1,23 +1,21 @@
 {{- partial "services/spreadsheetinfo" (dict "filename" "services_reports_invoice.xlsx" "name" "Analytics") -}}
-<div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 radius-a">
-  <div class="mrl">
-    <div class="flex flex-wrap-reverse align-ifs">
-      <div class="mrl">
-        <p class="form__label">Filter by</p>
-        <div class="btngroup">
+<div class="flex flex-wrap align-ifs mbm mb-form gcl">
+  <div>
+    <div class="flex flex-wrap-reverse align-ifs gcl grm">
+      <div>
+        <p class="mbxs fwb text-0.875r">Filter by</p>
+        <div class="flex flex-wrap gaxs">
           {{- partial "services/filterbtn" (dict "dataAtt" "data-ri-filterset='rifamily'" "btnText" "Service family") -}}
           {{- partial "services/filterbtn" (dict "dataAtt" "data-ri-filterset='riapi'" "btnText" "API") -}}
           {{- partial "services/filterbtn" (dict "dataAtt" "data-ri-filterset='rireptype'" "btnText" "Report type") -}}
         </div>
       </div>
-      <div>
-        <label class="form__label" for="ri-textfilter">
-          Reports name
-        </label>
-        <input id="ri-textfilter" type="text" class="form__control mrxs w100p maxw32r"/>
-      </div>
+      <label for="ri-textfilter">
+        Reports name
+        <input id="ri-textfilter" type="text"/>
+      </label>
     </div>
-    <div id="ri-filtersets">
+    <div id="ri-filtersets" class="mtxs">
       {{- $filterScratch := newScratch -}}
       {{- $filterScratch.Add "rifamily" slice -}}
       {{- $filterScratch.Add "riapi" slice -}}

--- a/layouts/partials/services/booking-sg.html
+++ b/layouts/partials/services/booking-sg.html
@@ -1,23 +1,21 @@
 {{- partial "services/spreadsheetinfo" (dict "filename" "services_booking_shippingguide.xlsx" "name" "Booking and Shipping Guide") -}}
-<div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 radius-a">
-  <div class="mrl">
-    <div class="flex flex-wrap-reverse align-ifs">
-      <div class="mrl">
-        <p class="form__label">Filter by</p>
-        <div class="btngroup">
+<div class="flex flex-wrap align-ifs mbm mb-form gcl">
+  <div>
+    <div class="flex flex-wrap-reverse align-ifs gcl grm">
+      <div>
+        <p class="mbxs fwb text-0.875r">Filter by</p>
+        <div class="flex flex-wrap gaxs">
           {{- partial "services/filterbtn" (dict "dataAtt" "data-bsg-filterset='type'" "btnText" "Service type") -}}
           {{- partial "services/filterbtn" (dict "dataAtt" "data-bsg-filterset='family'" "btnText" "Service family") -}}
           {{- partial "services/filterbtn" (dict "dataAtt" "data-bsg-filterset='cntype'" "btnText" "Customer number type") -}}
         </div>
       </div>
-      <div>
-        <label class="form__label" for="bsg-textfilter">
-          Service name, service code or API request code
-        </label>
-        <input id="bsg-textfilter" type="text" class="form__control mrxs w100p maxw32r"/>
-      </div>
+      <label for="bsg-textfilter">
+        Service name, service code or API request code
+        <input id="bsg-textfilter" type="text"/>
+      </label>
     </div>
-    <div id="bsg-filtersets">
+    <div id="bsg-filtersets" class="mtxs">
       {{- $filterScratch := newScratch -}}
       {{- $filterScratch.Add "type" slice -}}
       {{- $filterScratch.Add "family" slice -}}

--- a/layouts/partials/services/servicefilter.html
+++ b/layouts/partials/services/servicefilter.html
@@ -1,9 +1,9 @@
 {{- $filter := .filter -}}
-<fieldset class="flex-dir-col align-ifs bg-white bshadow mbm pam" id="{{ $filter }}" hidden>
+<fieldset class="flex-dir-col align-ifs bg-gray2 radius-a mbm pam" id="{{ $filter }}" hidden>
   <legend class="screen-reader-text">{{- .legendText -}}</legend>
   {{- range uniq .filterScratch -}}
     {{- if and (ne . "-") (ne . "") -}}
-      <label class="mrm">
+      <label>
       <input type="checkbox" value="{{ . }}" class="checkitem" data-filter="{{ $filter }}"/> {{ . }}</label>
     {{- end -}}
   {{- end -}}

--- a/layouts/partials/services/vas.html
+++ b/layouts/partials/services/vas.html
@@ -4,25 +4,23 @@
   Information applies to revised services only. Services without any supported value added services are not part of the table.
 </p>
 <div class="mbs">
-  <div class="flex flex-wrap align-ifs mbs bg-gray1 pal pr0 radius-a">
-    <div class="mrl">
-      <div class="flex flex-wrap-reverse align-ifs justify-csb">
-        <div class="mrl">
-          <p class="form__label">Filter by</p>
-          <div class="btngroup">
+  <div class="flex flex-wrap align-ifs mbm mb-form gcl">
+    <div>
+      <div class="flex flex-wrap-reverse align-ifs justify-csb gcl grm">
+        <div>
+          <p class="mbxs fwb text-0.875r">Filter by</p>
+          <div class="flex flex-wrap gaxs">
             {{- partial "services/filterbtn" (dict "dataAtt" "data-vas-filterset='vas-service'" "btnText" "Service") -}}
             {{- partial "services/filterbtn" (dict "dataAtt" "data-vas-filterset='vas-type'" "btnText" "Service type") -}}
             {{- partial "services/filterbtn" (dict "dataAtt" "data-vas-filterset='vas-family'" "btnText" "Service family") -}}
           </div>
         </div>
-        <div>
-          <label class="form__label mrxl" for="vasfilter">
-            VAS name, booking or shipping guide API request code
-          </label>
-          <input id="vasfilter" type="text" class="form__control mrxs w100p maxw32r"/>
-        </div>
+        <label for="vasfilter">
+          VAS name, booking or shipping guide API request code
+          <input id="vasfilter" type="text"/>
+        </label>
       </div>
-      <div id="filtersets">
+      <div id="filtersets" class="mtxs">
         {{- $filterScratch := newScratch -}}
         {{- $filterScratch.Add "servicetype" slice -}}
         {{- $filterScratch.Add "servicefamily" slice -}}

--- a/layouts/partials/services/vasfilter.html
+++ b/layouts/partials/services/vasfilter.html
@@ -1,5 +1,5 @@
 {{- $filter := .filter -}}
-<fieldset class="flex-dir-col mbm bg-white pam bshadow" id="{{ $filter }}" hidden>
+<fieldset class="flex-dir-col bg-gray2 radius-a mbm pam" id="{{ $filter }}" hidden>
   <legend class="screen-reader-text">{{- .legendText -}}</legend>
   <div {{ if gt (len (uniq .filterScratch)) 10 }} class="filtercols" {{ end }}>
     {{- range .filterScratch -}}


### PR DESCRIPTION
The analytics table was completely missing after the renaming a few months ago. 🧐
The filters were also misaligned, probably caused by some updated design system CSS – the margins were to blame, of course. So I used the mb-form class instead.