### PR TITLE
remove query param 'po_box_only' in Postal Code API; introduce 'posta…

### DIFF
--- a/content/api/revision-history/checkout/2025-08-04.md
+++ b/content/api/revision-history/checkout/2025-08-04.md
@@ -1,6 +1,6 @@
 ---
 title: Postal Code API - removal of po_box_only query param
-publishDate: 2025-08-06
+publishDate: 2025-08-04
 layout: api
 notanapi: true
 ---

--- a/content/api/revision-history/checkout/2025-08-06.md
+++ b/content/api/revision-history/checkout/2025-08-06.md
@@ -5,15 +5,11 @@ layout: api
 notanapi: true
 ---
 
-On 15th August, we will be updating the [Postal Code API](/api/postal-code/#get-postal-codes-matching-query-get) to improve how postal code filtering is handled.
+On 15 August, the po_box_only query parameter will be removed from the Postal Code API. 
 
-As part of this update, we are removing the po_box_only query parameter. Instead, we are introducing a new, more flexible query parameter - postal_code_type:
+It is replaced by a new, more flexible parameter: postal_code_type.
+This new parameter allows filtering by postal code type using the following values: PO_BOX, STREET_ADDRESSES, COMBINED, SPECIAL_SERVICE.
+The API response format remains unchanged.
 
-This new parameter allows filtering based on the type of postal code, using the following comma-separated values:
-PO_BOX, STREET_ADDRESSES, COMBINED, SPECIAL_SERVICE
-
-The response structure will remain unchanged — only the filtering mechanism is being improved.
-
-If you currently use the po_box_only parameter, please update your integration to use postal_code_type before 8th August to ensure uninterrupted functionality.
-
-Feel free to reach out if you have any questions or need support with the migration.
+If you currently use po_box_only, please update your integration to use postal_code_type by 15 August to ensure uninterrupted service.
+You can read more about the Postal Code API [here](/api/postal-code)

--- a/content/api/revision-history/checkout/2025-08-06.md
+++ b/content/api/revision-history/checkout/2025-08-06.md
@@ -1,0 +1,19 @@
+---
+title: Postal Code API - removal of po_box_only query param
+publishDate: 2025-08-06
+layout: api
+notanapi: true
+---
+
+On 15th August, we will be updating the [Postal Code API](/api/postal-code/#get-postal-codes-matching-query-get) to improve how postal code filtering is handled.
+
+As part of this update, we are removing the po_box_only query parameter. Instead, we are introducing a new, more flexible query parameter - postal_code_type:
+
+This new parameter allows filtering based on the type of postal code, using the following comma-separated values:
+PO_BOX, STREET_ADDRESSES, COMBINED, SPECIAL_SERVICE
+
+The response structure will remain unchanged — only the filtering mechanism is being improved.
+
+If you currently use the po_box_only parameter, please update your integration to use postal_code_type before 8th August to ensure uninterrupted functionality.
+
+Feel free to reach out if you have any questions or need support with the migration.


### PR DESCRIPTION
…l_code_type' for filtering by type