### PR TITLE
Skip complete workflow for dependabot

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
+++ b/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
@@ -18,6 +18,7 @@ jobs:
     env:
       ALGOLIA_ADMIN_KEY: ${{ secrets.ALGOLIA_ADMIN_KEY }}
       ALGOLIA_INDEX: ${{ github.ref == 'refs/heads/master' && 'devsite_prod' || 'devsite_qa' }}
+      SKIP_DEPLOY_ON_MISSING_SECRETS: true
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Dependabot builds, but it doesn’t need to deploy, but it should still be considered a success so it can be merged.