### PR TITLE
Run workflow without deploy and errors for dependabot

### DIFF
--- a/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
+++ b/.github/workflows/azure-static-web-apps-mango-cliff-0e97d9203.yml
@@ -39,7 +39,7 @@ jobs:
         run: npm run algolia
 
       - name: update algolia search index for qa
-        if: github.ref != 'refs/heads/master' || github.event.pull_request.user.login != 'dependabot[bot]'
+        if: github.ref != 'refs/heads/master' && github.actor != 'dependabot[bot]'
         run: npm run qalgolia
 
       - name: notify slack failure


### PR DESCRIPTION
Because it’s unnecessary that it reports as failed