### PR TITLE
Adding support for enum descriptions via `x-enum-descriptions` extension

### DIFF
--- a/layouts/_partials/api/oas/response-schema-xml.html
+++ b/layouts/_partials/api/oas/response-schema-xml.html
@@ -167,10 +167,18 @@
           {{- end -}}
         </div>
         {{- with $schemaObj.enum -}}
+          {{ $descriptions := index $schemaObj "x-enum-descriptions" -}}
           <dl>
             <dt><span class="text-note fw600">Enum</span></dt>
-            {{- range . -}}
-              <dd><code class="wrap-text">{{ . }}</code></dd>
+            {{- range $i, $enum := . -}}
+              <dd>
+                <code class="wrap-text">{{ $enum }}</code>
+                {{ if ne $descriptions nil }}
+                  {{ if lt $i (len $descriptions) }}
+                    <span class="text-0.875r plm db">{{ index $descriptions $i }}</span>
+                  {{ end }}
+                {{ end}}
+              </dd>
             {{- end -}}
           </dl>
         {{- end -}}

--- a/layouts/_partials/api/oas/response-schema.html
+++ b/layouts/_partials/api/oas/response-schema.html
@@ -284,10 +284,18 @@
           {{- end -}}
         </div>
         {{- with $schemaObj.enum -}}
+          {{ $descriptions := index $schemaObj "x-enum-descriptions" -}}
           <dl>
             <dt><span class="text-note fw600">Enum</span></dt>
-            {{- range . -}}
-              <dd><code class="wrap-text">{{ . }}</code></dd>
+            {{- range $i, $enum := . -}}
+              <dd>
+                <code class="wrap-text">{{ $enum }}</code>
+                {{ if ne $descriptions nil }}
+                  {{ if lt $i (len $descriptions) }}
+                    <span class="text-0.875r plm db">{{ index $descriptions $i }}</span>
+                  {{ end }}
+                {{ end}}
+              </dd>
             {{- end -}}
           </dl>
         {{- end -}}


### PR DESCRIPTION
To provide clients with more details about the purpose of an enum constant, support for descriptions is required. Acoording to Google a  "standard" seems to have been established utilizing the `x-enum-descriptions` schema extension:

```
    "capabilities":
    {
        "type": "string",
        "description": "Capabilities at pickup point",
        "enum":
        [
            "LOCATED_INDOORS",
            "LOCATED_OUTDOORS",
            "LQ"
        ],
        "xml":
        {
            "wrapped": true
        },
        "x-enum-descriptions":
        [
            "Located inside a building",
            "Located outside in the open",
            "Accepts limited quantities. Only available for pickup points in Finland"
        ]
    }
```

This will produce the following if descriptions are found. If no descriptions exist, presentation will be as is.

<img width="677" height="271" alt="Screenshot 2025-08-27 at 10 44 20" src="https://github.com/user-attachments/assets/a5b62d4e-2f1d-4ed9-a3fd-0cb850ac33c5" />
