### PR TITLE
Correcting Finnish pickup point type descriptions

### DIFF
--- a/content/api/pickup-point/_index.md
+++ b/content/api/pickup-point/_index.md
@@ -80,10 +80,9 @@ params:
           - Type 43: Locker
 
         #### Finland
-          - Type SmartPOST: Finland Smart Post Pickup
-          - Type Posti: Finland Posti Pickup Point
-          - Type Noutopiste: Finland Pickup Point
-          - Type LOCKER: Finland Locker Pickup Point **_(These lockers are placed inside buildings only accessible to the residents and workers in the building)_**
+          - Type Posti: Posti pickup point
+          - Type Noutopiste: pickup point
+          - Type LOCKER: Posti parcel locker
 
   subpages:
     title: Special topics


### PR DESCRIPTION
SmartPost type is no longer used after we migrated to the new Posti Pickup point API. Lockers are accessible for everyone (within opening hours)