### PR TITLE
replace buypass with letsencrhypt api.bring.com

### DIFF
--- a/content/api/revision-history/2025-09-26.md
+++ b/content/api/revision-history/2025-09-26.md
@@ -11,8 +11,8 @@ Migration from Buypass to Let’s Encrypt TLS Certificates
 As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025. To ensure continuity, we are migrating all TLS certificates from Buypass to Let´s Encrypt.
 
 As part of this activity:
-Old Buypass certificates will be removed
-New Let´s Encrypt certificates will be created
+* Old Buypass certificates will be removed
+* New Let´s Encrypt certificates will be created
 
 Impact to Customers:
 * If your application does not pin the certificate, no action is required and there will be zero impact.

--- a/content/api/revision-history/2025-09-26.md
+++ b/content/api/revision-history/2025-09-26.md
@@ -7,7 +7,7 @@ params:
   isImportant: true
 ---
 
-Important Update: Migration from Buypass to Let’s Encrypt TLS Certificates
+Migration from Buypass to Let’s Encrypt TLS Certificates
 As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025. To ensure continuity, we are migrating all TLS certificates from Buypass to Let´s Encrypt.
 
 As part of this activity:

--- a/content/api/revision-history/2025-09-26.md
+++ b/content/api/revision-history/2025-09-26.md
@@ -1,0 +1,22 @@
+---
+title: Note! New TLS certificates on api.bring.com 27th of October 2025
+publishDate: 2025-09-26
+layout: api
+notanapi: true
+params:
+  isImportant: true
+---
+
+Important Update: Migration from Buypass to Let’s Encrypt TLS Certificates
+As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025. To ensure continuity, we are migrating all TLS certificates from Buypass to LetsEncrypt.
+As part of this activity:
+Old Buypass certificates will be removed from the terraform state (Buypass)
+New LetsEncrypt certificates will be created
+
+Impact to Customers:
+If your application does not pin the certificate, no action is required and there will be zero impact.
+If your application does pin the certificate, you will need to download the new LetsEncrypt certificate and update your application configuration accordingly.
+This migration will be carried out in batches (due to LetsEncrypt rate limits) and will also cover certificates using the cert-share module.
+We recommend reviewing your applications to check whether certificate pinning is in place and preparing for updates if needed.
+
+For more queries, contact integrasjon.norge@bring.com (Norway) or edi@bring.com (outside Norway).

--- a/content/api/revision-history/2025-09-26.md
+++ b/content/api/revision-history/2025-09-26.md
@@ -1,5 +1,5 @@
 ---
-title: Note! New TLS certificates on api.bring.com 27th of October 2025
+title: Important Update! New TLS certificates on api.bring.com 27th of October 2025
 publishDate: 2025-09-26
 layout: api
 notanapi: true
@@ -8,15 +8,16 @@ params:
 ---
 
 Important Update: Migration from Buypass to Let’s Encrypt TLS Certificates
-As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025. To ensure continuity, we are migrating all TLS certificates from Buypass to LetsEncrypt.
+As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025. To ensure continuity, we are migrating all TLS certificates from Buypass to Let´s Encrypt.
+
 As part of this activity:
-Old Buypass certificates will be removed from the terraform state (Buypass)
-New LetsEncrypt certificates will be created
+Old Buypass certificates will be removed
+New Let´s Encrypt certificates will be created
 
 Impact to Customers:
-If your application does not pin the certificate, no action is required and there will be zero impact.
-If your application does pin the certificate, you will need to download the new LetsEncrypt certificate and update your application configuration accordingly.
-This migration will be carried out in batches (due to LetsEncrypt rate limits) and will also cover certificates using the cert-share module.
+* If your application does not pin the certificate, no action is required and there will be zero impact.
+* If your application does pin the certificate, you will need to download the new Let´s Encrypt certificate and update your application configuration accordingly.
+
 We recommend reviewing your applications to check whether certificate pinning is in place and preparing for updates if needed.
 
 For more queries, contact integrasjon.norge@bring.com (Norway) or edi@bring.com (outside Norway).


### PR DESCRIPTION
As of 15 September 2025, Buypass has stopped allowing registration of new ACME Account and will stop generating/renewing TLS certificates from 15th October 2025

Therefore we replace Buypass with LetsEncrypt on 27th of October for api.bring.com that is due to renual on 2nd of November.